### PR TITLE
修正紫妈A杖技能智力系数调整至与技能描述相同，现在附带2秒眩晕，且不再需要一个额外技能点数。

### DIFF
--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -393,7 +393,7 @@
 		"DOTA_Tooltip_ability_ability_yukari_01_range"	"施法距离:"
 		"DOTA_Tooltip_ability_ability_yukari_01_speed"	"弹幕飞行速度:"
 		"DOTA_Tooltip_ability_ability_thdots_yukari04"	"「深弹幕结界 -梦幻泡影-」"
-		"DOTA_Tooltip_ability_ability_thdots_yukari04_Description"	"以任意位置为目标展开大型的传送结界，结界范围内的己方队友和其他队友玩家的单位会一起被传送至目标单位旁。引导时间越长，传送结界的范围就越大。最大引导时间2秒，结界的最大范围为750。无论引导多久，只要引导一结束（即使是被打断的），传送就会进行。\n引导期间，目标地点会散射出大量的弹幕，对周围的敌方单位造成伤害,传送完成后产生空间震，对%wanbaochui_radius%范围内的敌方单位造成%int_bonus%倍智力的魔法伤害\n"
+		"DOTA_Tooltip_ability_ability_thdots_yukari04_Description"	"以任意位置为目标展开大型的传送结界，结界范围内的己方队友和其他队友玩家的单位会一起被传送至目标单位旁。引导时间越长，传送结界的范围就越大。最大引导时间2秒，结界的最大范围为750。无论引导多久，只要引导一结束（即使是被打断的），传送就会进行。\n引导期间，目标地点会散射出大量的弹幕，对周围的敌方单位造成伤害,传送完成后产生空间震，对%wanbaochui_radius%范围内的敌方单位造成%int_bonus%倍智力的魔法伤害与2秒眩晕\n"
 		"DOTA_Tooltip_ability_ability_thdots_yukari04_min_radius"	"传送最小范围："
 		"DOTA_Tooltip_ability_ability_thdots_yukari04_max_radius"	"传送最大范围："
 		"DOTA_Tooltip_ability_ability_thdots_yukari04_ex_damage"	"弹幕持续伤害："

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -1814,7 +1814,7 @@
 				"value"						"0"
 				"special_bonus_unique_yukari_01_stun" "+0.8"
 			}
-			"speed"			"1100"
+			"speed"			"1200"
 			"radius"		"70"
 			"range"			"1500"
 			"num"			"6"

--- a/game/scripts/vscripts/heroes/hero_yukari/yukari04.lua
+++ b/game/scripts/vscripts/heroes/hero_yukari/yukari04.lua
@@ -30,28 +30,7 @@ function Yukari04_OnSpellStart(keys)
 	local lvl=ability:GetLevel()
 	local wanbaochui_radius = ability:GetSpecialValueFor("wanbaochui_radius")
 	local int_bonus = ability:GetSpecialValueFor("int_bonus")
-
-	if lvl==1 then
-		vecPos=target
-	elseif lvl==2 then
-		local allies = FindUnitsInRadius(
-			caster:GetTeamNumber(),
-			target,
-			nil,
-			keys.TargetRange,
-			DOTA_UNIT_TARGET_TEAM_FRIENDLY,
-			DOTA_UNIT_TARGET_BUILDING + DOTA_UNIT_TARGET_BASIC + DOTA_UNIT_TARGET_HERO,
-			DOTA_UNIT_TARGET_FLAG_INVULNERABLE,
-			FIND_CLOSEST,
-			false)
-		if #allies>0 then 
-			vecPos=allies[1]:GetOrigin()
-		end
-	elseif lvl==3 then
-		vecPos=target
-	end
-	
-
+	vecPos=target
 	if vecPos then
 		local tick=0
 		local tick_interval=keys.BarrageFireInterval
@@ -185,7 +164,7 @@ function Yukari04_OnSpellStart(keys)
 					ParticleManager:DestroyParticle(e1,true)
 					ParticleManager:DestroyParticle(e2,true)
 				
-						local intdamage=caster:GetIntellect()*4
+						local intdamage=caster:GetIntellect()*1.5
 						local enemies=FindUnitsInRadius(
 										caster:GetTeamNumber(),
 										caster:GetOrigin(),
@@ -204,6 +183,7 @@ function Yukari04_OnSpellStart(keys)
 								damage_type=DAMAGE_TYPE_MAGICAL,
 							}
 							UnitDamageTarget(damage_table)	
+							v:AddNewModifier( caster, self, "modifier_stunned", {Duration = 2} )
 						end
 						local pfx = ParticleManager:CreateParticle("particles/econ/items/death_prophet/death_prophet_ti9/death_prophet_silence_ti9.vpcf", PATTACH_CUSTOMORIGIN, nil)
 						ParticleManager:SetParticleControl(pfx, 0, caster:GetAbsOrigin())

--- a/game/scripts/vscripts/heroes/hero_yukari/yukari_moon_portal.lua
+++ b/game/scripts/vscripts/heroes/hero_yukari/yukari_moon_portal.lua
@@ -149,7 +149,7 @@ function modifier_yukari_moon_portal_caster:OnDestroy()
 
     self.ability = self:GetAbility()
     self.parent = self:GetParent()
-    self.ability:StartCooldown(self.ability:GetCooldown(-1) * self.parent:GetCooldownReduction())
+    self.ability:StartCooldown(self.ability:GetCooldown(-duration) )
 
     local HiddenAbilities = {
         "yukari_moon_portal",

--- a/game/scripts/vscripts/heroes/hero_yukari/yukari_tentacles.lua
+++ b/game/scripts/vscripts/heroes/hero_yukari/yukari_tentacles.lua
@@ -7,12 +7,12 @@ LinkLuaModifier( "modifier_yukari_umb", "heroes/hero_yukari/yukari_tp", LUA_MODI
 function yukari_tentacles:GetAOERadius()
 	return self:GetSpecialValueFor( "radius" )
 end
---function yukari_tentacles:OnUpgrade()
-  --  local ability = self:GetCaster():FindAbilityByName("ability_thdots_yukari04")
-   -- if ability and ability:GetLevel() < self:GetLevel() then
-    --    ability:SetLevel(self:GetLevel())
-   -- end
---end
+function yukari_tentacles:OnUpgrade()
+   local ability = self:GetCaster():FindAbilityByName("ability_thdots_yukari04")
+   if ability and ability:GetLevel() < self:GetLevel() then
+      ability:SetLevel(self:GetLevel())
+   end
+end
 function yukari_tentacles:GetIntrinsicModifierName()
     return "modifier_yukari_umb"
 end


### PR DESCRIPTION
## 简要的概括修改内容
Yukari
A杖技能智力系数调整至与技能描述相同，现在附带2秒眩晕，且不再需要一个额外技能点数。
略微加快了空饵「狂躁高速飞行物体」弹幕飞行速度