### PR TITLE
v2.30 fix dota2 update bug

### DIFF
--- a/game/scripts/vscripts/api/game.lua
+++ b/game/scripts/vscripts/api/game.lua
@@ -68,5 +68,5 @@ function Game.prototype.SendEndGameInfo(self, endData)
     }
     ApiClient:sendWithRetry(apiParameter)
 end
-Game.VERSION = "v2.29"
+Game.VERSION = "v2.30"
 return ____exports

--- a/src/vscripts/api/game.ts
+++ b/src/vscripts/api/game.ts
@@ -23,7 +23,7 @@ class GameInfo {
 
 export class Game {
 
-	private static VERSION = "v2.29";
+	private static VERSION = "v2.30";
 	constructor() {
 	}
 


### PR DESCRIPTION
## 修改的Issues
- [ ] fix #9999

## Releas Note

[b]游戏性更新 v2.30[/b]

尝试修复BUG。
允许本地主机获取玩家数据。（不能获得赛季积分。根据个人网络情况不一定能加载成功，失败时请尝试加速器节点等）

[b]Gameplay update v2.30[/b]

Try to fix bug.
Allow local host fetch player data. (Cannot get season points)