### PR TITLE
10/26

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1585,6 +1585,14 @@
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_bonus_spell_amp"           "%+$spell_amp"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note0"					"You're silly, my cursed rapier is permanent."
 
+		// item_rapier_ultra_bot_1 解放的诅咒圣剑
+		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1"                        "<font color='#e03e2e'>Liberated Rapier</font>"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Description"            "<h1>Passive: <font color='#a74abd'>Eternal</font></h1>Protected by Mars. Grants <font color='#f15b47'>%bonus_damage_percent%%%</font> bonus base attack damage. Cannot be sold or destroyed.\n<h1>Passive: True Strike</h1>Attacks will not miss due to evasion or other effects.\n<h1>Passive: <font color='#e03e2e'>Price of Power (Liberated)</font></h1>Great power always comes with a price. <br><font color='#e03e2e'>But there is no price after liberation.</font>"
+		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1_Lore"					"The liberated cursed rapier can never be destroyed."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_damage"			"+$damage"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_spell_amp"           "%+$spell_amp"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note0"					"You're silly, my cursed rapier is permanent."
+
 		// item_bfury_ultra 救世狂战
 		"DOTA_Tooltip_ability_item_bfury_ultra"                         "<font color='#e03e2e'>Worldbreaker</font>"
 		"DOTA_Tooltip_Ability_item_bfury_ultra_Description"             "<h1>Passive: Quell</h1>Increases attack damage against non-hero units by %quelling_bonus% for melee heroes, and %quelling_bonus_ranged% for ranged.\n<h1>Passive: Worldsplitter</h1>Deals %cleave_damage_percent%%% of attack damage as physical damage in a cone up to %cleave_distance% range. Deals %cleave_damage_percent_creep%%% physical damage against non-hero units. (Melee Only)"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1634,6 +1634,41 @@
 		"DOTA_Tooltip_modifier_devastator_2_debuff"						"Magic Corruption"
 		"DOTA_Tooltip_modifier_devastator_2_debuff_Description"  			"Magic resistance reduced by %dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%."
 
+		// 三种双刀
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1"							"<font color='#e03e2e'>Sange and Yasha Ultra</font>"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_Note0"						"Yasha-based movement speed bonuses from multiple items do not stack."
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_Lore"						"Sange and Yasha, when attuned by the moonlight and used together, become a very powerful combination."
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_bonus_strength"				"+$str"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_bonus_agility"				"+$agi"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_bonus_attack_speed"			"+$attack"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_movement_speed_percent_bonus"	"%+$move_speed"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_status_resistance"					"%+Status Resistance"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_hp_regen_amp"							"%+Health Regen and Lifesteal Amp"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_slow_resistance"							"%+Slow Resistance"
+
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1"							"<font color='#e03e2e'>Kaya and Sange Ultra</font>"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_Lore"							"Two of three known items of unimaginable power that many believe were crafted at the same enchanter's forge."
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_bonus_damage"							"+$damage"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_bonus_strength"						"+$str"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_bonus_intellect"					"+$int"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_spell_amp"					"%+Spell Amplification"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_mana_regen_multiplier"				"%+Mana Regen Amplification"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_slow_resistance"					"%+Slow Resistance"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_hp_regen_amp"							"%+Health Regen and Lifesteal Amp"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_spell_lifesteal_amp"				"%+Spell Lifesteal Amplification"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_manacost_reduction"				"%+Mana Cost/Mana Loss Reduction"
+
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1"							"<font color='#e03e2e'>Yasha and Kaya Ultra</font>"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_Lore"					"Yasha and Kaya when paired together share a natural resonance."
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_bonus_intellect"					"+$int"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_spell_amp"					"%+Spell Amplification"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_mana_regen_multiplier"				"%+Mana Regen Amplification"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_bonus_agility"							"+$agi"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_bonus_attack_speed"					"+$attack"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_movement_speed_percent_bonus"			"%+$move_speed"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_spell_lifesteal_amp"				"%+Spell Lifesteal Amplification"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_cast_speed_pct"				"%+Cast Speed Bonus"
+
 		// 力量跳2
 		"DOTA_Tooltip_ability_item_overwhelming_blink_2"                            "Tyson's Flash"
 		"DOTA_Tooltip_ability_item_overwhelming_blink_2_Description"			    "<h1>Active: Tyson's Flash</h1>Teleports to the farthest location within %blink_range% range.<br><br>Upon arrival, deals %damage_base% + %damage_pct_instant%%% of your strength as instant damage to all enemies within %radius% range, and applies a total of %damage_pct_over_time%%% of your strength as damage over time. Slows enemies by %movement_slow%%% movement speed and reduces their attack speed by %attack_slow% for %duration% seconds.<br><br>Cannot be used for %blink_damage_cooldown% seconds after being attacked by enemy heroes or Roshan."
@@ -2599,6 +2634,14 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_bonus_mres"				"%+$spell_resist"
 
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1"				"<font color='#FFFF00'>Light</font> Guardian Greaves(Neutral)"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_Description"			"<h1>Active: Mend</h1>Restores %replenish_health% health and %replenish_mana% mana to nearby allies, and removes most negative effects from the caster.<br><br>Radius: %replenish_radius%<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>\n\n<h1>Passive: Guardian Aura</h1> Grants %aura_health_regen% health regeneration, %aura_mana_regen% mana regeneration and %aura_armor% armor to allied units. If an allied hero's health falls below %aura_bonus_threshold%%%, this is increased to %aura_health_regen_bonus% health regeneration, %aura_mana_regen_bonus% mana regeneration and %aura_armor_bonus% armor. <br><br>Radius: %aura_radius% \nMovement speed bonuses from multiple pairs of boots do not stack."
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_movement"			"+$move_speed"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_mana"				"+$mana"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_mana_regen"				"+$mana_regen"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_armor"			"+$armor"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_mres"				"%+$spell_resist"
+
 		// item_guardian_greaves_dark 暗影·卫士胫甲
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark"				"<font color='#8A2BE2'>Dark</font> Guardian Greaves"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_Description"			"<h1>Active: Mend</h1>Restores %replenish_health% health and %replenish_mana% mana to nearby allies, and removes most negative effects from the caster.<br><br>Radius: %replenish_radius%<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>\n\n<h1>Passive: Guardian Aura</h1> Grants %aura_health_regen% health regeneration, %aura_mana_regen% mana regeneration and %aura_armor% armor to allied units. If an allied hero's health falls below %aura_bonus_threshold%%%, this is increased to %aura_health_regen_bonus% health regeneration, %aura_mana_regen_bonus% mana regeneration and %aura_armor_bonus% armor. <br><br>Radius: %aura_radius% \nMovement speed bonuses from multiple pairs of boots do not stack."
@@ -2607,6 +2650,14 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_mana_regen"				"+$mana_regen"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_bonus_mres"				"%+$spell_resist"
+
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark"				"<font color='#8A2BE2'>Dark</font> Guardian Greaves(Neutral)"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_Description"			"<h1>Active: Mend</h1>Restores %replenish_health% health and %replenish_mana% mana to nearby allies, and removes most negative effects from the caster.<br><br>Radius: %replenish_radius%<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>\n\n<h1>Passive: Guardian Aura</h1> Grants %aura_health_regen% health regeneration, %aura_mana_regen% mana regeneration and %aura_armor% armor to allied units. If an allied hero's health falls below %aura_bonus_threshold%%%, this is increased to %aura_health_regen_bonus% health regeneration, %aura_mana_regen_bonus% mana regeneration and %aura_armor_bonus% armor. <br><br>Radius: %aura_radius% \nMovement speed bonuses from multiple pairs of boots do not stack."
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_movement"			"+$move_speed"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_mana"				"+$mana"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_mana_regen"				"+$mana_regen"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_armor"			"+$armor"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_mres"				"%+$spell_resist"
 
 		// item_guardian_greaves_ai 光暗·卫士胫甲
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai"				"<font color='#00FF00'>Light</font> <font color='#8A2BE2'>Dark</font> Guardian Greaves"
@@ -2617,12 +2668,26 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_bonus_mres"				"%+$spell_resist"
 
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1"				"<font color='#00FF00'>Light</font> <font color='#8A2BE2'>Dark</font> Guardian Greaves(Neutral)"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_Description"			"<h1>Active: Mend</h1>Restores %replenish_health% health and %replenish_mana% mana to nearby allies, and removes most negative effects from the caster.<br><br>Radius: %replenish_radius%<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>\n\n<h1>Passive: Guardian Aura</h1> Grants %aura_health_regen% health regeneration, %aura_mana_regen% mana regeneration and %aura_armor% armor to allied units. If an allied hero's health falls below %aura_bonus_threshold%%%, this is increased to %aura_health_regen_bonus% health regeneration, %aura_mana_regen_bonus% mana regeneration and %aura_armor_bonus% armor. <br><br>Radius: %aura_radius% \nMovement speed bonuses from multiple pairs of boots do not stack."
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_movement"			"+$move_speed"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_mana"				"+$mana"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_mana_regen"				"+$mana_regen"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_armor"			"+$armor"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_mres"				"%+$spell_resist"
+
 		// item_disperser_chaos 混沌·散魂剑
 		"DOTA_Tooltip_ability_item_disperser_chaos"				"<font color='#FF4500'>Chaotic Disperser</font>"
 		"DOTA_Tooltip_ability_item_disperser_chaos_Description"				"<h1>Active: Suppress</h1> Affects all units in a %radius% AoE around the target. All enemies around the target are slowed for %enemy_effect_duration% seconds.<br><br> All allies around the target receive a basic dispel, increase their movement speed, and are unslowable for %ally_effect_duration% seconds.<br><br>Both movement speed reduction and increase start at %phase_movement_speed%%% and gradually decrease to 0% over the course of the buff duration.<br><br>Range: %abilitycastrange%<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>\n\n<h1>Passive: Manabreak</h1>Each attack burns %feedback_mana_burn% mana from the target, and deals %damage_per_burn% physical damage per burned mana. <br><br>Burns %feedback_mana_burn_illusion_melee% mana per attack from melee illusions and %feedback_mana_burn_illusion_ranged% mana per attack from ranged illusions."
 		"DOTA_Tooltip_ability_item_disperser_chaos_bonus_agility"				"+$agi"
 		"DOTA_Tooltip_ability_item_disperser_chaos_bonus_intellect"			"+$int"
 		"DOTA_Tooltip_ability_item_disperser_chaos_bonus_damage"				"+$damage"
+
+		"DOTA_Tooltip_ability_item_disperser_chaos_1"				"<font color='#FF4500'>Chaotic Disperser（Neutral）</font>"
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_Description"				"<h1>Active: Suppress</h1> Affects all units in a %radius% AoE around the target. All enemies around the target are slowed for %enemy_effect_duration% seconds.<br><br> All allies around the target receive a basic dispel, increase their movement speed, and are unslowable for %ally_effect_duration% seconds.<br><br>Both movement speed reduction and increase start at %phase_movement_speed%%% and gradually decrease to 0% over the course of the buff duration.<br><br>Range: %abilitycastrange%<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>\n\n<h1>Passive: Manabreak</h1>Each attack burns %feedback_mana_burn% mana from the target, and deals %damage_per_burn% physical damage per burned mana. <br><br>Burns %feedback_mana_burn_illusion_melee% mana per attack from melee illusions and %feedback_mana_burn_illusion_ranged% mana per attack from ranged illusions."
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_bonus_agility"				"+$agi"
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_bonus_intellect"			"+$int"
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_bonus_damage"				"+$damage"
 
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1771,6 +1771,43 @@
 		"DOTA_Tooltip_modifier_devastator_2_debuff"						"法力腐蚀"
 		"DOTA_Tooltip_modifier_devastator_2_debuff_Description"  			"魔法抗性降低%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%"
 
+		// item_sange_and_yasha_1 神散夜
+		"DOTA_Tooltip_Ability_item_sange_and_yasha_1"			"<font color='#e03e2e'>神器·散夜对剑</font>"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_Note0"						"不会与其他夜叉、散夜对剑以及幻影斧提供的移动速度加成叠加。"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_Lore"						"在神力的恩泽之下，这把双剑的力量有了质的飞跃"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_bonus_strength"				"+$str"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_bonus_agility"				"+$agi"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_bonus_attack_speed"			"+$attack"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_movement_speed_percent_bonus"	"%+$move_speed"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_status_resistance"					"%+状态抗性"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_hp_regen_amp"							"%+生命恢复和吸血增强"
+		"DOTA_Tooltip_ability_item_sange_and_yasha_1_slow_resistance"							"%+减速抗性"
+
+		// item_kaya_and_sange_1 神散慧
+		"DOTA_Tooltip_Ability_item_kaya_and_sange_1"				"<font color='#e03e2e'>神器·散慧对剑</font>"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_Lore"							"在神力的恩泽之下，这把双剑的力量有了质的飞跃。"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_bonus_damage"							"+$damage"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_bonus_strength"						"+$str"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_bonus_intellect"					"+$int"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_spell_amp"					"%+技能增强"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_mana_regen_multiplier"				"%+魔法恢复增强"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_slow_resistance"					"%+减速抗性"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_hp_regen_amp"							"%+生命恢复和吸血增强"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_spell_lifesteal_amp"				"%+技能吸血增强"
+		"DOTA_Tooltip_ability_item_kaya_and_sange_1_manacost_reduction"				"%+魔法消耗/魔法损失降低"
+
+		// item_yasha_and_kaya_1 神慧夜
+		"DOTA_Tooltip_Ability_item_yasha_and_kaya_1"				"<font color='#e03e2e'>神器·慧夜对剑</font>"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_Lore"					"在神力的恩泽之下，这把双剑的力量有了质的飞跃"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_bonus_intellect"					"+$int"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_spell_amp"					"%+技能增强"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_mana_regen_multiplier"				"%+魔法恢复增强"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_bonus_agility"							"+$agi"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_bonus_attack_speed"					"+$attack"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_movement_speed_percent_bonus"			"%+$move_speed"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_spell_lifesteal_amp"				"%+技能吸血增强"
+		"DOTA_Tooltip_ability_item_yasha_and_kaya_1_cast_speed_pct"				"%+施法速度加成"
+
 		// 力量跳2
 		"DOTA_Tooltip_ability_item_overwhelming_blink_2"                            "泰森闪光"
 		"DOTA_Tooltip_ability_item_overwhelming_blink_2_Description"			    "<h1>主动：泰森闪光</h1>传送到最远%blink_range%距离的位置。<br><br>传送后，%radius%范围内所有敌人受到%damage_base% + %damage_pct_instant%%%力量值的瞬时伤害，并且额外持续受到总计为%damage_pct_over_time%%%力量值的伤害，被减缓%movement_slow%%%移动速度，降低%attack_slow%攻击速度，持续%duration%秒。<br><br>受到来自敌方英雄或肉山的攻击时，盛势闪光将在%blink_damage_cooldown%秒内无法使用。"
@@ -2721,6 +2758,14 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_bonus_mres"				"%+$spell_resist"
 
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1"				"<font color='#FFFF00'>圣光·卫士胫甲(中立)</font>"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_Description"			"<h1>主动：修复</h1>使周围友军回复%replenish_health%点生命和%replenish_mana%点魔法，并移除施法者身上大部分的负面效果。<br><br>作用范围：%replenish_radius%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：卫士光环</h1> 为周围友军提供%aura_health_regen%点/秒生命恢复，%aura_mana_regen%点/秒魔法恢复和%aura_armor%点护甲。如果友方英雄的生命值低于%aura_bonus_threshold%%%，光环效果将提升至%aura_health_regen_bonus%点/秒生命恢复，%aura_mana_regen_bonus%点/秒魔法恢复和%aura_armor_bonus%点护甲。<br><br>作用范围：%aura_radius%\n多个鞋类物品提供的移动速度加成不叠加。"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_movement"			"+$move_speed"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_mana"				"+$mana"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_mana_regen"				"+$mana_regen"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_armor"			"+$armor"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_mres"				"%+$spell_resist"
+
 		// item_guardian_greaves_dark 暗影·卫士胫甲
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark"				"<font color='#8A2BE2'>暗影·卫士胫甲</font>"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_Description"			"<h1>主动：修复</h1>使周围友军回复%replenish_health%点生命和%replenish_mana%点魔法，并移除施法者身上大部分的负面效果。<br><br>作用范围：%replenish_radius%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：卫士光环</h1> 为周围友军提供%aura_health_regen%点/秒生命恢复，%aura_mana_regen%点/秒魔法恢复和%aura_armor%点护甲。如果友方英雄的生命值低于%aura_bonus_threshold%%%，光环效果将提升至%aura_health_regen_bonus%点/秒生命恢复，%aura_mana_regen_bonus%点/秒魔法恢复和%aura_armor_bonus%点护甲。<br><br>作用范围：%aura_radius%\n多个鞋类物品提供的移动速度加成不叠加。"
@@ -2729,6 +2774,14 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_mana_regen"				"+$mana_regen"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_bonus_mres"				"%+$spell_resist"
+
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1"				"<font color='#8A2BE2'>暗影·卫士胫甲(中立)</font>"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_Description"			"<h1>主动：修复</h1>使周围友军回复%replenish_health%点生命和%replenish_mana%点魔法，并移除施法者身上大部分的负面效果。<br><br>作用范围：%replenish_radius%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：卫士光环</h1> 为周围友军提供%aura_health_regen%点/秒生命恢复，%aura_mana_regen%点/秒魔法恢复和%aura_armor%点护甲。如果友方英雄的生命值低于%aura_bonus_threshold%%%，光环效果将提升至%aura_health_regen_bonus%点/秒生命恢复，%aura_mana_regen_bonus%点/秒魔法恢复和%aura_armor_bonus%点护甲。<br><br>作用范围：%aura_radius%\n多个鞋类物品提供的移动速度加成不叠加。"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_movement"			"+$move_speed"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_mana"				"+$mana"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_mana_regen"				"+$mana_regen"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_armor"			"+$armor"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_mres"				"%+$spell_resist"
 
 		// item_guardian_greaves_ai 光暗·卫士胫甲
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai"				"<font color='#00FF00'>光</font><font color='#8A2BE2'>暗</font>·<font color='#00FF00'>卫</font><font color='#8A2BE2'>士</font><font color='#00FF00'>胫</font><font color='#8A2BE2'>甲</font>"
@@ -2739,12 +2792,26 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_bonus_mres"				"%+$spell_resist"
 
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1"				"<font color='#00FF00'>光</font><font color='#8A2BE2'>暗</font>·<font color='#00FF00'>卫</font><font color='#8A2BE2'>士</font><font color='#00FF00'>胫</font><font color='#8A2BE2'>甲(中立)</font>"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_Description"			"<h1>主动：修复</h1>使周围友军回复%replenish_health%点生命和%replenish_mana%点魔法，并移除施法者身上大部分的负面效果。<br><br>作用范围：%replenish_radius%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：卫士光环</h1> 为周围友军提供%aura_health_regen%点/秒生命恢复，%aura_mana_regen%点/秒魔法恢复和%aura_armor%点护甲。如果友方英雄的生命值低于%aura_bonus_threshold%%%，光环效果将提升至%aura_health_regen_bonus%点/秒生命恢复，%aura_mana_regen_bonus%点/秒魔法恢复和%aura_armor_bonus%点护甲。<br><br>作用范围：%aura_radius%\n多个鞋类物品提供的移动速度加成不叠加。"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_movement"			"+$move_speed"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_mana"				"+$mana"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_mana_regen"				"+$mana_regen"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_armor"			"+$armor"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_mres"				"%+$spell_resist"
+
 		// item_disperser_chaos 混沌·散魂剑
 		"DOTA_Tooltip_ability_item_disperser_chaos"				"<font color='#FF4500'>混沌·散魂剑</font>"
 		"DOTA_Tooltip_ability_item_disperser_chaos_Description"				"<h1>主动：抑制</h1>若目标是敌军，会被减速%enemy_effect_duration%秒，若目标是友军则会提升移动速度，施加弱驱散效果并且无法被减速，持续%ally_effect_duration%秒。施法者总是会获得友军的加成效果。<br><br>移动速度减缓和提升效果在状态持续时间内初始均为%phase_movement_speed%%%，并且逐渐减少至0。<br><br>施法距离：%abilitycastrange%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：破法</h1>每次攻击将燃烧目标%feedback_mana_burn%点魔法，而且每燃烧一点魔法都会造成%damage_per_burn%点物理伤害。<br><br>近战英雄的幻象每次攻击将燃烧%feedback_mana_burn_illusion_melee%点魔法。远程英雄的幻象每次攻击将燃烧%feedback_mana_burn_illusion_ranged%点魔法。"
 		"DOTA_Tooltip_ability_item_disperser_chaos_bonus_agility"				"+$agi"
 		"DOTA_Tooltip_ability_item_disperser_chaos_bonus_intellect"			"+$int"
 		"DOTA_Tooltip_ability_item_disperser_chaos_bonus_damage"				"+$damage"
+
+		"DOTA_Tooltip_ability_item_disperser_chaos_1"				"<font color='#FF4500'>混沌·散魂剑（中立）</font>"
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_Description"				"<h1>主动：抑制</h1>若目标是敌军，会被减速%enemy_effect_duration%秒，若目标是友军则会提升移动速度，施加弱驱散效果并且无法被减速，持续%ally_effect_duration%秒。施法者总是会获得友军的加成效果。<br><br>移动速度减缓和提升效果在状态持续时间内初始均为%phase_movement_speed%%%，并且逐渐减少至0。<br><br>施法距离：%abilitycastrange%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：破法</h1>每次攻击将燃烧目标%feedback_mana_burn%点魔法，而且每燃烧一点魔法都会造成%damage_per_burn%点物理伤害。<br><br>近战英雄的幻象每次攻击将燃烧%feedback_mana_burn_illusion_melee%点魔法。远程英雄的幻象每次攻击将燃烧%feedback_mana_burn_illusion_ranged%点魔法。"
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_bonus_agility"				"+$agi"
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_bonus_intellect"			"+$int"
+		"DOTA_Tooltip_ability_item_disperser_chaos_1_bonus_damage"				"+$damage"
 
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -2758,7 +2758,7 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_bonus_mres"				"%+$spell_resist"
 
-		"DOTA_Tooltip_ability_item_guardian_greaves_light_1"				"<font color='#FFFF00'>圣光·卫士胫甲(中立)</font>"
+		"DOTA_Tooltip_ability_item_guardian_greaves_light_1"				"<font color='#FFFF00'>圣光·卫士胫甲（中立）</font>"
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_Description"			"<h1>主动：修复</h1>使周围友军回复%replenish_health%点生命和%replenish_mana%点魔法，并移除施法者身上大部分的负面效果。<br><br>作用范围：%replenish_radius%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：卫士光环</h1> 为周围友军提供%aura_health_regen%点/秒生命恢复，%aura_mana_regen%点/秒魔法恢复和%aura_armor%点护甲。如果友方英雄的生命值低于%aura_bonus_threshold%%%，光环效果将提升至%aura_health_regen_bonus%点/秒生命恢复，%aura_mana_regen_bonus%点/秒魔法恢复和%aura_armor_bonus%点护甲。<br><br>作用范围：%aura_radius%\n多个鞋类物品提供的移动速度加成不叠加。"
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_movement"			"+$move_speed"
 		"DOTA_Tooltip_ability_item_guardian_greaves_light_1_bonus_mana"				"+$mana"
@@ -2775,7 +2775,7 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_bonus_mres"				"%+$spell_resist"
 
-		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1"				"<font color='#8A2BE2'>暗影·卫士胫甲(中立)</font>"
+		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1"				"<font color='#8A2BE2'>暗影·卫士胫甲（中立）</font>"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_Description"			"<h1>主动：修复</h1>使周围友军回复%replenish_health%点生命和%replenish_mana%点魔法，并移除施法者身上大部分的负面效果。<br><br>作用范围：%replenish_radius%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：卫士光环</h1> 为周围友军提供%aura_health_regen%点/秒生命恢复，%aura_mana_regen%点/秒魔法恢复和%aura_armor%点护甲。如果友方英雄的生命值低于%aura_bonus_threshold%%%，光环效果将提升至%aura_health_regen_bonus%点/秒生命恢复，%aura_mana_regen_bonus%点/秒魔法恢复和%aura_armor_bonus%点护甲。<br><br>作用范围：%aura_radius%\n多个鞋类物品提供的移动速度加成不叠加。"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_movement"			"+$move_speed"
 		"DOTA_Tooltip_ability_item_guardian_greaves_dark_1_bonus_mana"				"+$mana"
@@ -2792,7 +2792,7 @@
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_bonus_armor"			"+$armor"
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_bonus_mres"				"%+$spell_resist"
 
-		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1"				"<font color='#00FF00'>光</font><font color='#8A2BE2'>暗</font>·<font color='#00FF00'>卫</font><font color='#8A2BE2'>士</font><font color='#00FF00'>胫</font><font color='#8A2BE2'>甲(中立)</font>"
+		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1"				"<font color='#00FF00'>光</font><font color='#8A2BE2'>暗</font>·<font color='#00FF00'>卫</font><font color='#8A2BE2'>士</font><font color='#00FF00'>胫</font><font color='#8A2BE2'>甲（中立）</font>"
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_Description"			"<h1>主动：修复</h1>使周围友军回复%replenish_health%点生命和%replenish_mana%点魔法，并移除施法者身上大部分的负面效果。<br><br>作用范围：%replenish_radius%<br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n\n<h1>被动：卫士光环</h1> 为周围友军提供%aura_health_regen%点/秒生命恢复，%aura_mana_regen%点/秒魔法恢复和%aura_armor%点护甲。如果友方英雄的生命值低于%aura_bonus_threshold%%%，光环效果将提升至%aura_health_regen_bonus%点/秒生命恢复，%aura_mana_regen_bonus%点/秒魔法恢复和%aura_armor_bonus%点护甲。<br><br>作用范围：%aura_radius%\n多个鞋类物品提供的移动速度加成不叠加。"
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_movement"			"+$move_speed"
 		"DOTA_Tooltip_ability_item_guardian_greaves_ai_1_bonus_mana"				"+$mana"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1723,6 +1723,14 @@
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_bonus_spell_amp"           "%+$spell_amp"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note0"					"融合了光暗之力获得解放的诅咒圣剑。"
 
+		// item_rapier_ultra_bot_1 解放的诅咒圣剑
+		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1"                        "<font color='#e03e2e'>解放的诅咒圣剑</font>"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Description"            "<h1>被动：<font color='#a74abd'>永恒之力</font></h1>受到来自战争之神的神秘力量庇护，获得<font color='#f15b47'>%bonus_damage_percent%%%</font>基础攻击力加成。\n<h1>被动：克敌机先</h1>攻击不会因闪避或其他效果而落空。\n<h1>被动：<font color='#e03e2e'>力量的代价（解放）</font></h1>过于强大力量总会有它的代价。<br><font color='#e03e2e'>但是解放之后就没有代价了</font>"
+		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1_Lore"					"解放后的诅咒圣剑不会摧毁"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_damage"			"+$damage"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_spell_amp"           "%+$spell_amp"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note0"					"融合了光暗之力获得解放的诅咒圣剑。"
+
 		// item_bfury_ultra 救世狂战
 		"DOTA_Tooltip_ability_item_bfury_ultra"                         "<font color='#e03e2e'>救世狂战</font>"
 		"DOTA_Tooltip_Ability_item_bfury_ultra_Description"             "<h1>被动：斩断世界线</h1>知道Sccc斩断世界线的那一刀吗？普通攻击时对目标周围最远%cleave_distance%距离的锥形区域内敌人造成%cleave_damage_percent%%%物理伤害。对非英雄单位造成%cleave_damage_percent_creep%%%物理伤害。（仅近战有效）"

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -5546,6 +5546,31 @@
 			}
 		}
 	}
+	// 极度饥渴（暂时替代召熊）
+	"broodmother_insatiable_hunger"
+	{
+		"MaxLevel" "5"
+		"AbilityCastPoint"				"0.0"
+		"AbilityCooldown"				"45 40 35 30 20"
+		"AbilityValues"
+		{
+			"bonus_damage"
+			{
+				"value"					"40 50 60 70 80"
+				"CalculateSpellDamageTooltip"	"0"
+			}
+			"lifesteal_pct"
+			{
+				"value"				"40 60 80 100 120"
+			}
+			"creep_lifesteal_reduction_pct"		"40"
+			"duration"
+			{
+				"value"		"8 10 12 14 16"
+				"special_bonus_shard"	"+2"
+			}
+		}
+	}
 	// 灵魂链接
 	"lone_druid_spirit_link"
 	{
@@ -5569,6 +5594,7 @@
 	// 吼
 	"lone_druid_savage_roar"
 	{
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 		"MaxLevel" "5"
 		"AbilityValues"
 		{
@@ -5577,6 +5603,12 @@
 				{
 					"value"				"36 32 28 24 20"
 					"special_bonus_unique_lone_druid_4"			"-7"
+				}
+				"shard_radius"
+				{
+					"value"					"1050"
+					"RequiresShard"				"1"
+					"affected_by_aoe_increase"	"1"
 				}
 		}
 	}
@@ -5588,15 +5620,15 @@
 		{
 			"bonus_armor"
 			{
-				"value"				"8 12 16 20"	// 8 10 12
+				"value"				"16 24 32 40"	// 8 10 12
 			}
 			"bonus_hp"
 			{
-				"value"					"1000 2000 3000 4000" // 500 1000 1500
+				"value"					"2000 3000 4000 5000" // 500 1000 1500
 			}
 		}
 	}
-	// 小熊被动
+	// 粉碎击
 	"lone_druid_spirit_bear_demolish"
 	{
 		"AbilityValues"
@@ -5620,9 +5652,14 @@
 	{
 		"AbilityValues"
 		{
-			"item_slots"				"4"
-			"bonus_stat_percent"		"50 60 70 80 90"
+			"item_slots"				"6"
+			"bonus_stat_percent"		"60 70 80 90 100"
 		}
+	}
+	// 缠绕之爪
+	"lone_druid_entangling_claws"
+	{
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 	}
 	//=================================================================================================================
 	// Ability: Luna 露娜/月骑

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -7432,9 +7432,9 @@
 			{
 				"value"				"35 40 45 50 55"
 			}
-			"bonus_range"			"300 350 400 450 500"
-			"tooltip_attack_range"			"450 500 550 600 650"
-			"bonus_damage"			"30 50 70 90 110"
+			"bonus_range"			"300 400 500 550 600"
+			"tooltip_attack_range"			"450 550 650 700 750"
+			"bonus_damage"			"60 90 120 150 180"
 			"AbilityCooldown"
 			{
 				"value"				"120 115 110 105 100"
@@ -7448,7 +7448,7 @@
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 		"AbilityCooldown"				"60.0 50.0 40.0 30.0"
 		"AbilityManaCost"				"100 75 50 25"
-		"AbilityCastRange"				"600 800 1000 1200"	// 475
+		"AbilityCastRange"				"900 1200 1500 1800"	// 475
 		"AbilityValues"
 		{
 				"hit_point_minimum_pct"		"30 25 20 15"
@@ -7461,7 +7461,7 @@
 		{
 			"value"
 			{
-				"value" "20"
+				"value" "25"
 				"ad_linked_abilities" "terrorblade_sunder"
 			}
 		}

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -609,11 +609,11 @@
 		"Ability2"		"brewmaster_drunken_brawler"
 		"Ability8"		"brewmaster_primal_split_lua"
 		"Ability14"		"special_bonus_unique_terrorblade_metamorphosis_cooldown"
-		"Ability16"		"special_bonus_all_stats_10"
 		"Ability12"		"special_bonus_unique_terrorblade"
-		"AttributeStrengthGain"		"4.0" // 2
-		"AttributeIntelligenceGain"	"3.20000" // 1.6
-		"AttributeAgilityGain"		"10.000000" // 4
+		"Ability16"		"special_bonus_all_stats_20"
+		"AttributeStrengthGain"		"3.0" // 2
+		"AttributeIntelligenceGain"	"2.40000" // 1.6
+		"AttributeAgilityGain"		"7.000000" // 4
 	}
 	"npc_dota_hero_axe"
 	{

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -1465,6 +1465,13 @@
 			}
 		}
 	}
+	"npc_dota_hero_lone_druid"
+	{
+		"Ability1"		"broodmother_insatiable_hunger"
+		"Ability5"		"lone_druid_entangling_claws"
+		"Ability16"		"special_bonus_hp_200"
+		"Ability10"		"special_bonus_unique_lone_druid_8"
+	}
 	"npc_dota_hero_luna"
 	{
 		"Bot"

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -603,6 +603,18 @@
 		// "Ability4"		"brewmaster_cinder_brew"
 		// "Ability5"		"brewmaster_drunken_brawler"
 	}
+	"npc_dota_hero_terrorblade"
+	{
+		"Ability1"		"brewmaster_cinder_brew"
+		"Ability2"		"brewmaster_drunken_brawler"
+		"Ability8"		"brewmaster_primal_split_lua"
+		"Ability14"		"special_bonus_unique_terrorblade_metamorphosis_cooldown"
+		"Ability16"		"special_bonus_all_stats_10"
+		"Ability12"		"special_bonus_unique_terrorblade"
+		"AttributeStrengthGain"		"4.0" // 2
+		"AttributeIntelligenceGain"	"3.20000" // 1.6
+		"AttributeAgilityGain"		"10.000000" // 4
+	}
 	"npc_dota_hero_axe"
 	{
 		"Bot"

--- a/game/scripts/npc/npc_items_artifact.txt
+++ b/game/scripts/npc/npc_items_artifact.txt
@@ -4949,11 +4949,11 @@
 		"AbilityTextureName"			"item_armlet_light"
 		"AbilityValues"
 		{
-			"bonus_damage"			"90"
-			"bonus_attack_speed"	"90"
-			"bonus_armor"			"36"
+			"bonus_damage"			"60"
+			"bonus_attack_speed"	"60"
+			"bonus_armor"			"24"
 			"bonus_health_regen"	"30"
-			"unholy_bonus_damage"	"110"
+			"unholy_bonus_damage"	"100"
 			"unholy_bonus_strength"	"150"
 			"unholy_bonus_armor"	"24"
 			"unholy_bonus_slow_resistance"	"45"
@@ -4985,15 +4985,15 @@
 		"AbilityTextureName"			"item_armlet_dark"
 		"AbilityValues"
 		{
-			"bonus_damage"			"45"
-			"bonus_attack_speed"	"45"
-			"bonus_armor"			"18"
-			"bonus_health_regen"	"60"
-			"unholy_bonus_damage"	"220"
-			"unholy_bonus_strength"	"300"
+			"bonus_damage"			"90"
+			"bonus_attack_speed"	"90"
+			"bonus_armor"			"36"
+			"bonus_health_regen"	"100"
+			"unholy_bonus_damage"	"250"
+			"unholy_bonus_strength"	"350"
 			"unholy_bonus_armor"	"48"
 			"unholy_bonus_slow_resistance"	"90"
-			"unholy_health_drain_per_second"	"900"
+			"unholy_health_drain_per_second"	"1000"
 			"toggle_cooldown"		"0.036"
 		}
 	}
@@ -5026,9 +5026,57 @@
 		"AbilityTextureName"			"item_guardian_greaves_light"
 		"AbilityValues"
 		{
-			"bonus_movement"		"100"
-			"bonus_armor"			"20"
-			"mana_regen"			"10"
+			"bonus_movement"		"200"
+			"bonus_armor"			"40"
+			"mana_regen"			"20"
+			"aura_health_regen"		"50"
+			"aura_armor"			"20"
+			"aura_mana_regen"		"30"
+			"aura_radius"			"1800"
+			"aura_health_regen_bonus"	"150"
+			"aura_mana_regen_bonus"	"60"
+			"aura_armor_bonus"		"40"
+			"aura_bonus_threshold"	"75"
+			"replenish_health"		"1000"
+			"replenish_mana"		"500"
+			"replenish_radius"
+			{
+				"value"		"1800"
+				"affected_by_aoe_increase"	"1"
+			}
+			"max_health_pct_heal_amount"		"8"
+		}
+	}
+	"item_recipe_guardian_greaves_light_1"
+	{
+		"BaseClass"						"item_datadriven"
+		"ID"						    "11049"
+		"ItemCost"                      "0"
+		"ItemShopTags"					""
+		"ItemRecipe"                    "1"
+		"ItemResult"                    "item_guardian_greaves_light_1"
+		"ItemRequirements"
+		{
+			"01"                        "item_guardian_greaves_light;item_exchange"
+		}
+	}
+	"item_guardian_greaves_light_1"
+	{
+		"BaseClass"                     "item_guardian_greaves"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"FightRecapLevel"				"1"
+		"AbilityCooldown"				"30"
+		"AbilityManaCost"				"0"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"ItemAlertable"					"1"
+		"ShouldBeSuggested"				"1"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"AbilityTextureName"			"item_guardian_greaves_light"
+		"AbilityValues"
+		{
+			"bonus_movement"		"200"
+			"bonus_armor"			"40"
+			"mana_regen"			"20"
 			"aura_health_regen"		"50"
 			"aura_armor"			"20"
 			"aura_mana_regen"		"30"
@@ -5074,9 +5122,57 @@
 		"AbilityTextureName"			"item_guardian_greaves_dark"
 		"AbilityValues"
 		{
-			"bonus_movement"		"200"
-			"bonus_armor"			"40"
-			"mana_regen"			"20"
+			"bonus_movement"		"100"
+			"bonus_armor"			"20"
+			"mana_regen"			"10"
+			"aura_health_regen"		"25"
+			"aura_armor"			"10"
+			"aura_mana_regen"		"15"
+			"aura_radius"			"900"
+			"aura_health_regen_bonus"	"50"
+			"aura_mana_regen_bonus"	"30"
+			"aura_armor_bonus"		"20"
+			"aura_bonus_threshold"	"25"
+			"replenish_health"		"2000"
+			"replenish_mana"		"1000"
+			"replenish_radius"
+			{
+				"value"		"900"
+				"affected_by_aoe_increase"	"1"
+			}
+			"max_health_pct_heal_amount"		"3"
+		}
+	}
+	"item_recipe_guardian_greaves_dark_1"
+	{
+		"BaseClass"						"item_datadriven"
+		"ID"						    "11050"
+		"ItemCost"                      "0"
+		"ItemShopTags"					""
+		"ItemRecipe"                    "1"
+		"ItemResult"                    "item_guardian_greaves_dark_1"
+		"ItemRequirements"
+		{
+			"01"                        "item_guardian_greaves_dark;item_exchange"
+		}
+	}
+	"item_guardian_greaves_dark_1"
+	{
+		"BaseClass"                     "item_guardian_greaves"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"FightRecapLevel"				"1"
+		"AbilityCooldown"				"10"
+		"AbilityManaCost"				"0"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"ItemAlertable"					"1"
+		"ShouldBeSuggested"				"1"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"AbilityTextureName"			"item_guardian_greaves_dark"
+		"AbilityValues"
+		{
+			"bonus_movement"		"100"
+			"bonus_armor"			"20"
+			"mana_regen"			"10"
 			"aura_health_regen"		"25"
 			"aura_armor"			"10"
 			"aura_mana_regen"		"15"
@@ -5107,9 +5203,62 @@
 		{
 			"01"                        "item_guardian_greaves_light;item_dark_part"
 			"02"						"item_guardian_greaves_dark;item_light_part"
+			"03"                        "item_guardian_greaves_light;item_light_part"
+			"04"                        "item_guardian_greaves_dark;item_dark_part"
 		}
 	}
 	"item_guardian_greaves_ai"
+	{
+		"BaseClass"                     "item_guardian_greaves"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"FightRecapLevel"				"1"
+		"AbilityCooldown"				"10"
+		"AbilityManaCost"				"0"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"ItemAlertable"					"1"
+		"ShouldBeSuggested"				"1"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"AbilityValues"
+		{
+			"bonus_movement"		"200"
+			"bonus_armor"			"40"
+			"mana_regen"			"20"
+			"aura_health_regen"		"50"
+			"aura_armor"			"20"
+			"aura_mana_regen"		"30"
+			"aura_radius"			"1800"
+			"aura_health_regen_bonus"	"200"
+			"aura_mana_regen_bonus"	"60"
+			"aura_armor_bonus"		"40"
+			"aura_bonus_threshold"	"100"
+			"replenish_health"		"3000"
+			"replenish_mana"		"1500"
+			"replenish_radius"
+			{
+				"value"		"1800"
+				"affected_by_aoe_increase"	"1"
+			}
+			"max_health_pct_heal_amount"		"8"
+		}
+	}
+	"item_recipe_guardian_greaves_ai_1"
+	{
+		"BaseClass"						"item_datadriven"
+		"ID"						    "13051"
+		"ItemCost"                      "0"
+		"ItemShopTags"					""
+		"ItemRecipe"                    "1"
+		"ItemResult"					"item_guardian_greaves_ai_1"
+		"ItemRequirements"
+		{
+			"01"                        "item_guardian_greaves_ai;item_exchange"
+			"02"						"item_guardian_greaves_light_1;item_dark_part"
+			"03"						"item_guardian_greaves_dark_1;item_light_part"
+			"04"						"item_guardian_greaves_light_1;item_light_part"
+			"05"						"item_guardian_greaves_dark_1;item_dark_part"
+		}
+	}
+	"item_guardian_greaves_ai_1"
 	{
 		"BaseClass"                     "item_guardian_greaves"
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET"
@@ -5156,8 +5305,7 @@
 		"ItemResult"					"item_disperser_chaos"
 		"ItemRequirements"
 		{
-			"01"						"item_disperser;item_light_part"
-			"02"						"item_disperser;item_dark_part"
+			"01"						"item_disperser;item_diffusal_blade"
 		}
 	}
 
@@ -5185,7 +5333,60 @@
 		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
 		"AbilityValues"
 		{
-			"bonus_agility"			"100"
+			"bonus_agility"			"80"
+			"bonus_intellect"		"25"
+			"feedback_mana_burn"	"150"
+			"feedback_mana_burn_illusion_melee"	"50"
+			"feedback_mana_burn_illusion_ranged"	"50"
+			"purge_rate"			"5"
+			"purge_root_duration"	"6.0"
+			"damage_per_burn"		"1.0"
+			"enemy_effect_duration"	"8.0"
+			"ally_effect_duration"	"5.0"
+			"movement_speed_buff_rate"	"6"
+			"phase_movement_speed"		"100"
+		}
+	}
+	"item_recipe_disperser_chaos_1"
+	{
+		"BaseClass"					"item_datadriven"
+		"ID"						"11047"
+		"ItemCost"					"0"
+		"Model"							"models/props_gameplay/recipe.vmdl"
+		"ItemShopTags"					""
+		"ItemRecipe"					"1"
+		"ItemResult"					"item_disperser_chaos_1"
+		"ItemRequirements"
+		{
+			"01"						"item_disperser_chaos;item_exchange"
+		}
+	}
+
+	"item_disperser_chaos_1"
+	{
+		"BaseClass"						"item_disperser"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_BOTH"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"FightRecapLevel"				"1"
+		"SpellDispellableType"			"SPELL_DISPELLABLE_YES"
+		"AbilityCastRange"				"800"
+		"AbilityCastPoint"				"0.0"
+		"AbilityCooldown"				"10.0"
+		"AbilityManaCost"				"75"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"ItemCost"						"6100"
+		"ItemShopTags"					"agi;int;unique;hard_to_tag"
+		"ItemQuality"					"artifact"
+		"ItemAliases"					"diffusal blade 1"
+		"ItemPermanent"					"1"
+		"UpgradesItems"					"item_diffusal_blade"
+		"UpgradeRecipe"					"item_recipe_diffusal_blade"
+		"ShouldBeSuggested"				"1"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"AbilityValues"
+		{
+			"bonus_agility"			"80"
 			"bonus_intellect"		"25"
 			"feedback_mana_burn"	"150"
 			"feedback_mana_burn_illusion_melee"	"50"

--- a/game/scripts/npc/npc_items_artifact.txt
+++ b/game/scripts/npc/npc_items_artifact.txt
@@ -4993,7 +4993,7 @@
 			"unholy_bonus_strength"	"350"
 			"unholy_bonus_armor"	"48"
 			"unholy_bonus_slow_resistance"	"90"
-			"unholy_health_drain_per_second"	"1000"
+			"unholy_health_drain_per_second"	"1200"
 			"toggle_cooldown"		"0.036"
 		}
 	}

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -5388,39 +5388,6 @@
 	}
 
 	//=================================================================================================================
-	// 神器散夜
-	//=================================================================================================================
-	"item_recipe_sange_and_yasha_1"
-	{
-		"BaseClass"						"item_recipe_sange_and_yasha"
-		"ItemRecipe"					"1"
-		"ItemResult"					"item_sange_and_yasha_1"
-		"ItemRequirements"
-		{
-			"01"						"item_sange_and_yasha;item_sange_and_yasha;item_ultimate_orb"
-		}
-	}
-
-	"item_sange_and_yasha_1"
-	{
-		"BaseClass"						"item_sange_and_yasha"
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
-		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
-		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-		"SuggestLategame"				"1"
-		"AbilityValues"
-		{
-				"bonus_strength"		"50"
-				"bonus_agility"			"50"
-				"status_resistance"				"62.5" // 特色 x2.5
-				"bonus_attack_speed"	"60" // 不值钱 x3
-				"movement_speed_percent_bonus"	"30" // 特色 x2.5
-				"hp_regen_amp"			"50" // x2
-				"slow_resistance"		"50" // x2
-		}
-	}
-
-	//=================================================================================================================
 	// 神器散慧
 	//=================================================================================================================
 	"item_recipe_kaya_and_sange_1"
@@ -5445,12 +5412,45 @@
 		{
 				"bonus_strength"		"50"
 				"bonus_intellect"			"50"
-				"slow_resistance"			"75" // 特色 x3
-				"mana_regen_multiplier"		"200" // 大特色 x4
-				"spell_amp"			"30" // x2.5
-				"hp_regen_amp"			"75" // 特色 x3
-				"spell_lifesteal_amp"	"75" // 特色 x3
-				"manacost_reduction"	"75" // 特色 x3
+				"slow_resistance"			"60"
+				"mana_regen_multiplier"		"150"
+				"spell_amp"				"30" // 12
+				"hp_regen_amp"			"60" // 25
+				"spell_lifesteal_amp"	"60" // 25
+				"manacost_reduction"	"60" // 25
+		}
+	}
+
+	//=================================================================================================================
+	// 神器散夜
+	//=================================================================================================================
+	"item_recipe_sange_and_yasha_1"
+	{
+		"BaseClass"						"item_recipe_sange_and_yasha"
+		"ItemRecipe"					"1"
+		"ItemResult"					"item_sange_and_yasha_1"
+		"ItemRequirements"
+		{
+			"01"						"item_sange_and_yasha;item_sange_and_yasha;item_ultimate_orb"
+		}
+	}
+
+	"item_sange_and_yasha_1"
+	{
+		"BaseClass"						"item_sange_and_yasha"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"SuggestLategame"				"1"
+		"AbilityValues"
+		{
+				"bonus_strength"		"50"
+				"bonus_agility"			"50"
+				"status_resistance"		"60" // 25
+				"bonus_attack_speed"	"60" // 20
+				"movement_speed_percent_bonus"	"30" // 12
+				"hp_regen_amp"			"60" // 25
+				"slow_resistance"		"60" // 25
 		}
 	}
 
@@ -5478,14 +5478,13 @@
 		"AbilityValues"
 		{
 				"bonus_agility"			"50"
-				"bonus_intellect"			"50"
-				"bonus_attack_speed"	"60" // 不值钱 x3
-				"mana_regen_multiplier"		"100" // x2
-				"movement_speed_percent_bonus"	"24" // x2
-				"spell_amp"			"24" // x2
-				"spell_lifesteal_amp"	"100" // 特色 x4
-				"cast_speed_pct"		"100" // 特色 x4
-
+				"bonus_intellect"		"50"
+				"bonus_attack_speed"	"60" // 20
+				"mana_regen_multiplier"	"100" // 50
+				"movement_speed_percent_bonus"	"30" // 12
+				"spell_amp"				"30" // 12
+				"spell_lifesteal_amp"	"60" // 25
+				"cast_speed_pct"		"60" // 25
 		}
 	}
 }

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -5386,4 +5386,106 @@
 			"01"						"item_overwhelming_blink;item_overwhelming_blink"
 		}
 	}
+
+	//=================================================================================================================
+	// 神器散夜
+	//=================================================================================================================
+	"item_recipe_sange_and_yasha_1"
+	{
+		"BaseClass"						"item_recipe_sange_and_yasha"
+		"ItemRecipe"					"1"
+		"ItemResult"					"item_sange_and_yasha_1"
+		"ItemRequirements"
+		{
+			"01"						"item_sange_and_yasha;item_sange_and_yasha;item_ultimate_orb"
+		}
+	}
+
+	"item_sange_and_yasha_1"
+	{
+		"BaseClass"						"item_sange_and_yasha"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"SuggestLategame"				"1"
+		"AbilityValues"
+		{
+				"bonus_strength"		"50"
+				"bonus_agility"			"50"
+				"status_resistance"				"62.5" // 特色 x2.5
+				"bonus_attack_speed"	"60" // 不值钱 x3
+				"movement_speed_percent_bonus"	"30" // 特色 x2.5
+				"hp_regen_amp"			"50" // x2
+				"slow_resistance"		"50" // x2
+		}
+	}
+
+	//=================================================================================================================
+	// 神器散慧
+	//=================================================================================================================
+	"item_recipe_kaya_and_sange_1"
+	{
+		"BaseClass"						"item_recipe_kaya_and_sange"
+		"ItemRecipe"					"1"
+		"ItemResult"					"item_kaya_and_sange_1"
+		"ItemRequirements"
+		{
+			"01"						"item_kaya_and_sange;item_kaya_and_sange;item_ultimate_orb"
+		}
+	}
+
+	"item_kaya_and_sange_1"
+	{
+		"BaseClass"						"item_kaya_and_sange"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"SuggestLategame"				"1"
+		"AbilityValues"
+		{
+				"bonus_strength"		"50"
+				"bonus_intellect"			"50"
+				"slow_resistance"			"75" // 特色 x3
+				"mana_regen_multiplier"		"200" // 大特色 x4
+				"spell_amp"			"30" // x2.5
+				"hp_regen_amp"			"75" // 特色 x3
+				"spell_lifesteal_amp"	"75" // 特色 x3
+				"manacost_reduction"	"75" // 特色 x3
+		}
+	}
+
+	//=================================================================================================================
+	// 神器慧夜
+	//=================================================================================================================
+	"item_recipe_yasha_and_kaya_1"
+	{
+		"BaseClass"						"item_recipe_yasha_and_kaya"
+		"ItemRecipe"					"1"
+		"ItemResult"					"item_yasha_and_kaya_1"
+		"ItemRequirements"
+		{
+			"01"						"item_yasha_and_kaya;item_yasha_and_kaya;item_ultimate_orb"
+		}
+	}
+
+	"item_yasha_and_kaya_1"
+	{
+		"BaseClass"						"item_yasha_and_kaya"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"SuggestLategame"				"1"
+		"AbilityValues"
+		{
+				"bonus_agility"			"50"
+				"bonus_intellect"			"50"
+				"bonus_attack_speed"	"60" // 不值钱 x3
+				"mana_regen_multiplier"		"100" // x2
+				"movement_speed_percent_bonus"	"24" // x2
+				"spell_amp"			"24" // x2
+				"spell_lifesteal_amp"	"100" // 特色 x4
+				"cast_speed_pct"		"100" // 特色 x4
+
+		}
+	}
 }

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -5046,6 +5046,53 @@
 		}
 	}
 
+	// ai独立解放剑
+	"item_rapier_ultra_bot_1"
+	{
+		"BaseClass"						"item_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"ID"							"19596"
+		"AbilityTextureName"			"item_rapier_ultra"
+		"ItemCost"						"8282"
+
+		"ItemPurchasable"				"0"
+		"ItemDroppable"					"1"
+		"ItemKillable"					"0"
+		"ItemSellable"					"0"
+		"AllowedInBackpack"				"1"
+
+		"AbilityValues"
+		{
+			"bonus_damage"			"1000"
+			"bonus_spell_amp"		"100"
+			"bonus_damage_percent"	"100"
+
+			"ruin_chance_tooltip"	"0"
+		}
+		"Modifiers"
+		{
+			"modifier_item_rapier_ultra_stats"
+			{
+				"Passive"				"1"
+				"IsHidden"				"1"
+				"RemoveOnDeath"			"0"
+
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_MULTIPLE | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE"		"%bonus_damage"
+					"MODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE"	"%bonus_spell_amp"
+					"MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE"		"%bonus_damage_percent"
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_CANNOT_MISS" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
 	//=================================================================================================================
     // 神器救世狂战 bfury ultra
     //=================================================================================================================

--- a/game/scripts/shops.txt
+++ b/game/scripts/shops.txt
@@ -312,9 +312,9 @@
 		"item"		"item_blue_fantasy"			// 苍蓝幻想
  		"item"		"item_satanic_2"
  		"item"		"item_skadi_2"
- 		"item"		"item_kaya_and_sange"
- 		"item"		"item_sange_and_yasha"
- 		"item"		"item_yasha_and_kaya"
+ 		"item"		"item_kaya_and_sange_1"
+ 		"item"		"item_sange_and_yasha_1"
+ 		"item"		"item_yasha_and_kaya_1"
 		"item"		"item_sacred_six_vein"
 		"item"		"item_overwhelming_blink_2"
 		"item"		"item_swift_blink_2"

--- a/game/scripts/vscripts/bot/bot_think_item_build.lua
+++ b/game/scripts/vscripts/bot/bot_think_item_build.lua
@@ -26,7 +26,7 @@ local function addTome(k, v)
     replaceItem(v, "item_blade_mail_2", "item_force_field_ai")
 
     -- 诅咒圣剑
-    replaceItem(v, "item_excalibur", "item_rapier_ultra_bot")
+    replaceItem(v, "item_excalibur", "item_rapier_ultra_bot_1")
   end
 
   -- 一组属性书

--- a/game/scripts/vscripts/items/item_adi_king.lua
+++ b/game/scripts/vscripts/items/item_adi_king.lua
@@ -152,7 +152,7 @@ function modifier_item_adi_king_buff:DeclareFunctions()
     {
         MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE,
         MODIFIER_PROPERTY_IGNORE_MOVESPEED_LIMIT,
-        MODIFIER_PROPERTY_MOVESPEED_LIMIT,
+        -- MODIFIER_PROPERTY_MOVESPEED_LIMIT,
         MODIFIER_PROPERTY_EVASION_CONSTANT,
     }
 end
@@ -169,9 +169,9 @@ function modifier_item_adi_king_buff:GetModifierMoveSpeedBonus_Percentage()
     return self.active_sp
 end
 
-function modifier_item_adi_king_buff:GetModifierMoveSpeed_Limit()
-    return 2000
-end
+-- function modifier_item_adi_king_buff:GetModifierMoveSpeed_Limit()
+--     return 2000
+-- end
 
 function modifier_item_adi_king_buff:GetModifierIgnoreMovespeedLimit()
     return 1

--- a/game/scripts/vscripts/items/item_adi_king_plus.lua
+++ b/game/scripts/vscripts/items/item_adi_king_plus.lua
@@ -152,7 +152,7 @@ function modifier_item_adi_king_plus_buff:DeclareFunctions()
     {
         MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE,
         MODIFIER_PROPERTY_IGNORE_MOVESPEED_LIMIT,
-        MODIFIER_PROPERTY_MOVESPEED_LIMIT,
+        -- MODIFIER_PROPERTY_MOVESPEED_LIMIT,
         MODIFIER_PROPERTY_EVASION_CONSTANT,
     }
 end
@@ -169,9 +169,9 @@ function modifier_item_adi_king_plus_buff:GetModifierMoveSpeedBonus_Percentage()
     return self.active_sp
 end
 
-function modifier_item_adi_king_plus_buff:GetModifierMoveSpeed_Limit()
-    return 2000
-end
+-- function modifier_item_adi_king_plus_buff:GetModifierMoveSpeed_Limit()
+--     return 2000
+-- end
 
 function modifier_item_adi_king_plus_buff:GetModifierIgnoreMovespeedLimit()
     return 1

--- a/src/vscripts/api/game.ts
+++ b/src/vscripts/api/game.ts
@@ -32,7 +32,7 @@ class EndGameInfo {
 }
 
 export class Game {
-  private static VERSION = "v3.37";
+  private static VERSION = "v3.38";
   constructor() {}
 
   public SendEndGameInfo(endData: EndGameInfo) {

--- a/src/vscripts/modifiers/property/property_declare.ts
+++ b/src/vscripts/modifiers/property/property_declare.ts
@@ -220,16 +220,16 @@ export class property_movespeed_bonus_constant extends PropertyBaseModifier {
 @registerModifier()
 export class property_ignore_movespeed_limit extends PropertyBaseModifier {
   DeclareFunctions(): ModifierFunction[] {
-    return [ModifierFunction.IGNORE_MOVESPEED_LIMIT, ModifierFunction.MOVESPEED_LIMIT];
+    return [ModifierFunction.IGNORE_MOVESPEED_LIMIT]; // , ModifierFunction.MOVESPEED_LIMIT
   }
 
   GetModifierIgnoreMovespeedLimit(): 0 | 1 {
     return 1;
   }
 
-  GetModifierMoveSpeed_Limit(): number {
-    return 2000;
-  }
+  // GetModifierMoveSpeed_Limit(): number {
+  //   return 2000;
+  // }
 }
 
 @registerModifier()


### PR DESCRIPTION
德鲁伊：移除小熊和粉碎击，获得极度饥渴作为替代，加强缠绕之爪并常驻，加强命石3、大招、吼。
恐怖利刃：移除倒影和惑幻，获得浸酒和醉拳以及特殊醉拳大招，加强成长和技能。
商店加入三种神器双刀，平衡光臂章与暗臂章
大鞋现在拥有中立版本，混沌散魂剑简化配方且拥有中立版本

移除突破移速属性的2000上限，移除阿迪王2000上限，ai独立解放诅咒圣剑（这段别发。然后看看有没有漏的2000没删）
