### PR TITLE
Minor hero changes

### DIFF
--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -1614,7 +1614,7 @@
 		"MaxLevel" "4"
 		"AbilityCooldown"				"90.0 80.0 70.0 60.0"
 		"AbilityManaCost"				"150 200 250 300"
-		"SpellImmunityType"             "SPELL_IMMUNITY_ENEMIES_YES"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 		"AbilityValues"
 		{
 				"echo_slam_echo_damage"
@@ -2170,8 +2170,7 @@
 			}
 			"AbilityCooldown"
 			{
-				"value"						"20 18 16 14 12"
-				"special_bonus_unique_kunkka_torrent_cooldown"			"-3"
+				"value"						"16 15 14 13 12"
 			}
 			"stun_duration"
 			{
@@ -4626,7 +4625,7 @@
 		"AbilityManaCost"				"110 125 140 155 170"
 		"AbilityValues"
 		{
-			"duration"              "0.8"	// 1.25
+			"duration"				"0.8"	// 1.25
 			"toss_damage"
 			{
 				"value"				"180 270 360 450 540"	// 90 180 270 360 +90
@@ -6749,14 +6748,14 @@
 				"value"			"150 250 350 400 450"
 				"special_bonus_unique_mirana_7"	"+350"	// +250
 			}
-			"starfall_radius"   
-            {
-                "value"         "825"	// 675
-            }
-            "starfall_secondary_radius"
-            {
-                "value"         "825"	// 675
-            }
+			"starfall_radius"
+			{
+				"value"			"825"	// 675
+			}
+			"starfall_secondary_radius"
+			{
+				"value"			"825"	// 675
+			}
 		}
 	}
 	//=================================================================================================================
@@ -8860,21 +8859,8 @@
 					"value"			"35 65 95 125 155"
 					"special_bonus_unique_viper_3"	"+45"
 				}
-				"radius"        
-                {
-                    "value"     "400 500 600 700 800"
-                    "affected_by_aoe_increase"  "1"
-                }
 				"attack_slow"		"30 40 50 60 70"
 				"duration"			"6.5 7 7.5 8 8.5"
-				"radius_increase"           
-                {
-                    "special_bonus_unique_viper_nethertoxin_radius"                     "+0"
-                }       
-                "expand_interval"           
-                {
-                    "special_bonus_unique_viper_nethertoxin_radius"                     "+0"
-                }
 		}
 	}
 	// 腐蚀皮肤

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -2461,7 +2461,6 @@
 	// 冥界亚龙 毒龙
 	"npc_dota_hero_viper"
 	{
-		"Ability16"		"special_bonus_movement_speed_75"
 		"Bot"
 		{
 			"Build"


### PR DESCRIPTION
There were a few changes that a couple of people wanted to make to a few heroes that I thought were very minor and easy to do, so I went ahead and did them here. Your discretion on whether or not they should be done, of course.

Viper:
-Nethertoxin's radius now increases per level, from 400 at all levels to 400/500/600/700/800.
--I have observed and been told by others that Viper has been causing some performance issues due to him casting Nethertoxin multiple times in teamfights, as the game is constantly calculating Nethertoxin radius increases. As a result, I have elected to replace this talent, and increase Nethertoxin's radius by default.
--The offending talent has been replaced with a +75 movement speed talent.

Mirana:
-Starstorm radius increased from 675 to 825.
--Mirana may come next on the heroes I will look more deeply into since like Marci originally, her innate is rather worthless and redundant.

Earthshaker:
-Echo Slam now ignores debuff immunity.
--Echo Slam is only a damage-dealing spell, so this does not allow him to stun enemies through BKBs, as his other spells such as Aftershock and Fissure still do not ignore debuff immunity, allowing enemies to continue to counter and escape his ultimate.

Kunkka:
-Torrent base stun duration reduced from 1.25 to 1.
-Torrent cooldown increased from 16/14/12/10/8 to 20/18/16/14/12.
-Torrent cooldown reduction talent reduced from -4 to -3.
--This was done because Kunkka bots had a tendency to spam Torrents on a player multiple times, keeping players in place, and since Torrent's stun ignores status resistance, this often times became a huge nuisance with little counterplay.

Tiny:
-Toss air time reduced from 1.25 to 0.8.
--This was done to help negate the possibility of being stunlocked due to a Tiny bot's double Toss combo since, much like Kunkka's Torrent, Toss ignores status resistance if you are the one Tiny is Tossing.