### PR TITLE
Fix item_shadow_judgment duration logic

### DIFF
--- a/game/scripts/vscripts/items/item_shadow_judgment.lua
+++ b/game/scripts/vscripts/items/item_shadow_judgment.lua
@@ -110,10 +110,11 @@ function item_shadow_judgment:ApplyBlueFantasyEffect(target)
     if not IsServer() then return end
 
     local caster = self:GetCaster()
-    local duration = self:GetSpecialValueFor("mute_duration") * (1 - target:GetStatusResistance())
 
     -- 驱散
     target:Purge(true, false, false, false, false)
+    
+    local duration = self:GetSpecialValueFor("mute_duration") * (1 - target:GetStatusResistance())
 
     -- 添加自定义苍蓝幻想debuff
     target:AddNewModifier(caster, self, "modifier_shadow_judgment_mute", { duration = duration })


### PR DESCRIPTION
Fixed an issue where Shadow Judgment's duration was calculated BEFORE applying the purge.

Bug:
When attacking a target with Aeon Disk (which provides high Status Resistance), the code previously:
1. Applies damage, which triggers the target's Aeon Disk buff.
2. Calculated duration based on current Status Res (resulting in <1 sec duration due to Aeon buff).
3. Applied Purge (removing Aeon and Status Res).
4. Applied the modifier with the short duration.

If the target uses Refresher and triggers Aeon again immediately, the Shadow Judgment modifier expires before the next dispel tick occurs, failing to dispel the second Aeon.

Fix:
Moved the duration calculation line to AFTER the Purge call. This ensures the duration is calculated against the target's base Status Resistance.