### PR TITLE
Moonshard rework. Stackable moonshards

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -4,110 +4,51 @@
 "DOTAAbilities"
 {
 	//=================================================================================================================
-	// Recipe: Moon Shard
-	//=================================================================================================================
-	"item_recipe_moon_shard_datadriven"
-	{
-		// General
-		//-------------------------------------------------------------------------------------------------------------
-		"ID"						"9001"
-		"BaseClass"					"item_datadriven"
-		"Model"						"models/props_gameplay/recipe.mdl"
-		"AbilityTextureName"		"item_recipe_moon_shard_datadriven"
-
-		// Item Info
-		//-------------------------------------------------------------------------------------------------------------
-		"ItemCost"					"4000"
-		"ItemShopTags"				""
-
-		// Recipe
-		//-------------------------------------------------------------------------------------------------------------
-		"ItemRecipe"				"1"
-		"ItemResult"				"item_moon_shard_datadriven"
-		"ItemRequirements"
-		{
-			"01"					"item_hyperstone;item_hyperstone"
-		}
-	}
-	//=================================================================================================================
-	// Moon Shard 银月
+	// Moon Shard (Custom Stackable)
 	//=================================================================================================================
 	"item_moon_shard_datadriven"
 	{
 		// General
 		//-------------------------------------------------------------------------------------------------------------
-		"ID"						"9002"
-		"BaseClass"					"item_datadriven"
-		"AbilityTextureName" 		"item_moon_shard_datadriven"
-		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
-		"AbilityUnitTargetTeam"		"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
-		"AbilityUnitTargetType"		"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CUSTOM"
+		"ID"                            "9002"
+		"BaseClass"                     "item_lua"
+		"ScriptFile"                    "items/item_moon_shard"
+		"AbilityTextureName"            "item_moon_shard_datadriven"
 
-		"AbilityCastRange"			"0" // anywhere on the map
-		"IsTempestDoubleClonable"	"0"
+		// Behavior matches the Lua script logic
+		"AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CUSTOM"
+		"AbilityCastRange"              "0"
 
-		// Item Info
+		// Item Info (Stacking logic copied from Tome)
 		//-------------------------------------------------------------------------------------------------------------
-		"ItemCost"					"8000"
-		"ItemShopTags"				"attack_speed"
-		"ItemQuality"				"common"
-		"ItemAliases"				"moon shard"
-		"ItemDeclarations"			"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
+		"ItemCost"                      "8000"
+		"ItemShopTags"                  "attack_speed;consumable"
+		"ItemQuality"                   "common"
+		"ItemAliases"                   "moon shard"
 
-		// Special
+		"ItemStackable"                 "1"
+		"ItemPermanent"                 "0"
+		"ItemInitialCharges"            "1"
+		"IsTempestDoubleClonable"       "0"
+		"ItemSellable"                  "1"
+		"ItemShareability"              "ITEM_FULLY_SHAREABLE"
+
+		"ItemDeclarations"              "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
+
+		// Special Values (Used for tooltips primarily now, logic is in Lua)
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-				"bonus_attack_speed"			"200"
-				"bonus_night_vision"			"400"
-				"consumed_bonus_attack_speed"	"100"	// tooltip only
-				"consumed_bonus_night_vision"	"200"	// tooltip only
-				"consumed_bonus_day_vision"		"200"	// tooltip only
-		}
+			// Passive stats (while holding)
+			"bonus_attack_speed"            "200"
+			"bonus_night_vision"            "400"
 
-		// Data driven
-		// -------------------------------------------------------------------------------------------------------------
-		"OnSpellStart"
-		{
-			"RunScript"
-			{
-				"ScriptFile"		"items/item_moon_shard"
-				"Function"			"MoonShardOnSpell"
-
-				"modifier"			"modifier_item_moon_shard_datadriven_consumed"
-			}
-		}
-		"Modifiers"
-		{
-			"modifier_item_moon_shard_datadriven"
-			{
-				"Passive"			"1"
-				"IsHidden"			"1"
-
-				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_MULTIPLE | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
-
-				"Properties"
-				{
-					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT"		"%bonus_attack_speed"
-					"MODIFIER_PROPERTY_BONUS_NIGHT_VISION"				"%bonus_night_vision"
-				}
-			}
-			"modifier_item_moon_shard_datadriven_consumed"
-			{
-				"IsBuff"			"1"
-				"IsPurgable"		"0"
-
-				"Attributes" 		"MODIFIER_ATTRIBUTE_PERMANENT"
-
-				"TextureName"		"item_moon_shard_datadriven"
-
-				"Properties"
-				{
-					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT"		"100"
-					"MODIFIER_PROPERTY_BONUS_NIGHT_VISION"				"200"
-					"MODIFIER_PROPERTY_BONUS_DAY_VISION"				"200"
-				}
-			}
+			// Consumed stats (per stack of the buff)
+			"consumed_bonus_attack_speed"   "100"
+			"consumed_bonus_night_vision"   "200"
+			"consumed_bonus_day_vision"     "200"
 		}
 	}
 	//=================================================================================================================

--- a/game/scripts/vscripts/items/item_moon_shard.lua
+++ b/game/scripts/vscripts/items/item_moon_shard.lua
@@ -1,13 +1,111 @@
-function MoonShardOnSpell(keys)
-	local caster = keys.caster
-	local target = keys.target
-	local ability = keys.ability
-	local modifier = keys.modifier
+item_moon_shard_datadriven = class({})
 
-	if caster:IsRealHero() and target:IsRealHero() and not caster:HasModifier("modifier_arc_warden_tempest_double") and not target:HasModifier("modifier_arc_warden_tempest_double") then
-		AddStacks(ability, caster, target, modifier, 1, true)
-		EmitSoundOnClient("Item.MoonShard.Consume", target)
-		-- caster:RemoveItem(ability)
-		UTIL_RemoveImmediate(ability)
-	end
+-- Define constants here so we don't rely on the item handle (which might be destroyed)
+local CONSUMED_BONUS_AS = 100
+local CONSUMED_BONUS_NIGHT_VISION = 200
+local CONSUMED_BONUS_DAY_VISION = 200
+
+LinkLuaModifier("modifier_item_moon_shard_consumed_buff", "items/item_moon_shard", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_moon_shard_passive", "items/item_moon_shard", LUA_MODIFIER_MOTION_NONE)
+
+function item_moon_shard_datadriven:GetIntrinsicModifierName()
+    return "modifier_item_moon_shard_passive"
+end
+
+function item_moon_shard_datadriven:OnSpellStart()
+    local caster = self:GetCaster()
+    local target = self:GetCursorTarget()
+
+    EmitSoundOnClient("Item.MoonShard.Consume", target)
+
+    if target:IsRealHero() and not target:IsTempestDouble() then
+
+        local modifier_name = "modifier_item_moon_shard_consumed_buff"
+        local modifier = target:FindModifierByName(modifier_name)
+
+        if modifier then
+            modifier:IncrementStackCount()
+        else
+            target:AddNewModifier(caster, self, modifier_name, {})
+            local new_mod = target:FindModifierByName(modifier_name)
+            if new_mod then
+                new_mod:SetStackCount(1)
+            end
+        end
+
+        -- Spend 1 charge. If it reaches 0, the item entity is destroyed.
+        self:SpendCharge(1)
+    end
+end
+
+------------------------------------------------------------------------------------------------
+-- Modifier: Consumed Buff (Permanent stats after eating)
+------------------------------------------------------------------------------------------------
+modifier_item_moon_shard_consumed_buff = class({})
+
+function modifier_item_moon_shard_consumed_buff:IsHidden() return false end
+function modifier_item_moon_shard_consumed_buff:IsPurgable() return false end
+function modifier_item_moon_shard_consumed_buff:RemoveOnDeath() return false end
+function modifier_item_moon_shard_consumed_buff:IsPermanent() return true end
+function modifier_item_moon_shard_consumed_buff:GetTexture() return "item_moon_shard_datadriven" end
+
+function modifier_item_moon_shard_consumed_buff:DeclareFunctions()
+    local funcs = {
+        MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT,
+        MODIFIER_PROPERTY_BONUS_NIGHT_VISION,
+        MODIFIER_PROPERTY_BONUS_DAY_VISION,
+        MODIFIER_PROPERTY_TOOLTIP
+    }
+    return funcs
+end
+
+-- FIXED: Use local constants instead of self:GetAbility():GetSpecialValueFor()
+-- This ensures the stats remain even if the item is destroyed.
+function modifier_item_moon_shard_consumed_buff:GetModifierAttackSpeedBonus_Constant()
+    return CONSUMED_BONUS_AS * self:GetStackCount()
+end
+
+function modifier_item_moon_shard_consumed_buff:GetBonusNightVision()
+    return CONSUMED_BONUS_NIGHT_VISION * self:GetStackCount()
+end
+
+function modifier_item_moon_shard_consumed_buff:GetBonusDayVision()
+    return CONSUMED_BONUS_DAY_VISION * self:GetStackCount()
+end
+
+function modifier_item_moon_shard_consumed_buff:OnTooltip()
+    return CONSUMED_BONUS_AS * self:GetStackCount()
+end
+
+------------------------------------------------------------------------------------------------
+-- Modifier: Passive (Stats while holding the item in inventory)
+------------------------------------------------------------------------------------------------
+modifier_item_moon_shard_passive = class({})
+
+function modifier_item_moon_shard_passive:IsHidden() return true end
+function modifier_item_moon_shard_passive:IsPurgable() return false end
+function modifier_item_moon_shard_passive:GetAttributes() return MODIFIER_ATTRIBUTE_MULTIPLE end
+
+function modifier_item_moon_shard_passive:DeclareFunctions()
+    local funcs = {
+        MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT,
+        MODIFIER_PROPERTY_BONUS_NIGHT_VISION
+    }
+    return funcs
+end
+
+-- Note: It is safe to use GetAbility() here because this modifier ONLY exists
+-- while the item exists in the inventory.
+function modifier_item_moon_shard_passive:GetModifierAttackSpeedBonus_Constant()
+    if self:GetAbility() then
+        return self:GetAbility():GetSpecialValueFor("bonus_attack_speed")
+    end
+    return 0
+end
+
+function modifier_item_moon_shard_passive:GetBonusNightVision()
+    if self:GetAbility() then
+        return self:GetAbility():GetSpecialValueFor("bonus_night_vision")
+    end
+    return 0
 end


### PR DESCRIPTION
Moonshard type changed from item_datadriven to item_lua and recipe deleted. 
Now moonshard is one-click buy item that can be stacked as tomes of attributes. 
All stats unchanged

Example:
https://www.youtube.com/watch?v=gaQHGlu6khY