### PR TITLE
Disable all upgrade buttons after level up

### DIFF
--- a/content/panorama/layout/custom_game/custom_loading_screen.xml
+++ b/content/panorama/layout/custom_game/custom_loading_screen.xml
@@ -142,7 +142,7 @@
 							<Label text="#fixed_ability_ability_trigger_on_move_name" id="ability_trigger_on_move" />
 							<Label text="#DOTA_Tooltip_ability_spectre_dispersion2" id="spectre_dispersion2" />
 							<Label text="#fixed_ability_ability_charge_damage_name" id="ability_charge_damage" />
-							<Label text="#DOTA_Tooltip_ability_riki_permanent_invisibility" id="riki_permanent_invisibility" />
+							<Label text="#DOTA_Tooltip_ability_riki_backstab" id="riki_backstab" />
 							<Label text="#DOTA_Tooltip_ability_medusa_split_shot" id="medusa_split_shot" />
 							<Label text="#DOTA_Tooltip_ability_black_drake_magic_amplification_aura" id="black_drake_magic_amplification_aura" />
 							<Label text="#DOTA_Tooltip_ability_kobold_taskmaster_speed_aura" id="kobold_taskmaster_speed_aura" />

--- a/content/panorama/scripts/custom_game/battlepass.js
+++ b/content/panorama/scripts/custom_game/battlepass.js
@@ -297,6 +297,28 @@ function AddPlayerProperty(player, property) {
   }
 }
 
+function DisableAllUpgradeButtons() {
+  const container = $('#PropertyListContainer');
+  const children = container.Children();
+  for (let i = 0; i < children.length; i++) {
+    const panel = children[i];
+    const levelupButton = panel.FindChildTraverse('Levelup');
+    const maxLevelupButton = panel.FindChildTraverse('MaxLevelup');
+
+    if (levelupButton) {
+      levelupButton.SetHasClass('deactivated', true);
+      levelupButton.SetHasClass('activated', false);
+      levelupButton.SetPanelEvent('onactivate', () => {});
+    }
+
+    if (maxLevelupButton && !maxLevelupButton.BHasClass('hidden')) {
+      maxLevelupButton.SetHasClass('deactivated', true);
+      maxLevelupButton.SetHasClass('activated', false);
+      maxLevelupButton.SetPanelEvent('onactivate', () => {});
+    }
+  }
+}
+
 function OnLevelupActive(panel) {
   $.Msg('Levelup');
   $.Msg(panel.FindChildTraverse('Levelup').name);
@@ -305,6 +327,10 @@ function OnLevelupActive(panel) {
   panel.FindChildTraverse('Levelup').SetHasClass('deactivated', true);
   panel.FindChildTraverse('Levelup').SetHasClass('activated', false);
   panel.FindChildTraverse('Levelup').SetPanelEvent('onactivate', () => {});
+
+  // 禁用所有其他升级按钮
+  DisableAllUpgradeButtons();
+
   // send request to server
   GameEvents.SendCustomGameEventToServer('player_property_levelup', {
     name: panel.FindChildTraverse('Levelup').name,
@@ -321,6 +347,10 @@ function OnLevelupToMaxActive(panel) {
   maxLevelupButton.SetHasClass('deactivated', true);
   maxLevelupButton.SetHasClass('activated', false);
   maxLevelupButton.SetPanelEvent('onactivate', () => {});
+
+  // 禁用所有其他升级按钮
+  DisableAllUpgradeButtons();
+
   // send request to server to upgrade to max level
   GameEvents.SendCustomGameEventToServer('player_property_levelup', {
     name: maxLevelupButton.name,


### PR DESCRIPTION
Added DisableAllUpgradeButtons function to deactivate all upgrade buttons when a player levels up or upgrades to max. Also updated XML to use Riki's backstab tooltip instead of permanent invisibility.

## Release Note

```
[b]游戏性更新 v5.00a[/b]

- 修正一些bug和平衡性改动。
```

```
[b]Gameplay update v5.00a[/b]

- Fixed some bugs and balance.
```
