### PR TITLE
Fix Roshan respawn and reduce early bot gold/XP

### DIFF
--- a/content/panorama/layout/custom_game/custom_loading_screen.xml
+++ b/content/panorama/layout/custom_game/custom_loading_screen.xml
@@ -83,8 +83,8 @@
 							<Label text="350%" id="350"/>
 							<Label text="400%" id="400"/>
 							<Label text="500%" id="500"/>
-							<Label text="600%" id="600"/>
-							<Label text="700%" id="700"/>
+							<!-- <Label text="600%" id="600"/>
+							<Label text="700%" id="700"/> -->
 						</DropDown>
 					</Panel>
 

--- a/content/panorama/scripts/custom_game/game_mode.js
+++ b/content/panorama/scripts/custom_game/game_mode.js
@@ -76,7 +76,7 @@ function InitCustomSetting() {
 
   $('#respawn_time_percentage_dropdown').SetSelected('50');
   $('#max_level_dropdown').SetSelected('200');
-  $('#tower_power_dropdown').SetSelected('400');
+  $('#tower_power_dropdown').SetSelected('300');
 
   $('#starting_gold_player_dropdown').SetSelected('5000');
   $('#starting_gold_bot_dropdown').SetSelected('3000');
@@ -190,7 +190,7 @@ function InitN6Setting() {
   $('#player_gold_xp_multiplier_dropdown').SetSelected('1.5');
   $('#bot_gold_xp_multiplier_dropdown').SetSelected('9');
 
-  $('#tower_power_dropdown').SetSelected('400');
+  $('#tower_power_dropdown').SetSelected('350');
 
   $('#starting_gold_player_dropdown').SetSelected('3000');
   $('#starting_gold_bot_dropdown').SetSelected('5000');
@@ -199,7 +199,7 @@ function InitN7Setting() {
   $('#player_gold_xp_multiplier_dropdown').SetSelected('1.5');
   $('#bot_gold_xp_multiplier_dropdown').SetSelected('11');
 
-  $('#tower_power_dropdown').SetSelected('500');
+  $('#tower_power_dropdown').SetSelected('400');
 
   $('#starting_gold_player_dropdown').SetSelected('3000');
   $('#starting_gold_bot_dropdown').SetSelected('5000');

--- a/src/vscripts/modules/event/event-entity-killed.ts
+++ b/src/vscripts/modules/event/event-entity-killed.ts
@@ -232,7 +232,6 @@ export class EventEntityKilled {
   private dropItemChanceRoshan = 100;
   private dropItemChanceAncient = 1.0;
   private dropItemChanceNeutral = 0.2;
-  public static roshanKillCount = 0;
   //符文
   private dropItemListFusionMaterial: string[] = [
     'item_fusion_hawkeye',
@@ -287,11 +286,17 @@ export class EventEntityKilled {
     const creepName = creep.GetName();
 
     if (creepName === 'npc_dota_roshan') {
-      EventEntityKilled.roshanKillCount++;
-      // 第一次击杀不掉落物品，return
-      if (EventEntityKilled.roshanKillCount < 2) {
-        return;
-      }
+      // 延迟移除无人捡取的金币袋
+      Timers.CreateTimer(this.removeGoldBagDelay, () => {
+        const goldBags = Entities.FindAllByClassname('dota_item_drop') as CDOTA_Item_Physical[];
+        for (const goldBag of goldBags) {
+          const itemName = goldBag.GetContainedItem().GetName();
+          if (itemName === 'item_bag_of_gold') {
+            goldBag.RemoveSelf();
+          }
+        }
+      });
+
       // 击杀肉山奖励
       if (PlayerHelper.IsGoodTeamUnit(attacker)) {
         // 龙珠掉落，不重复掉落
@@ -312,17 +317,6 @@ export class EventEntityKilled {
           this.dropItem(creep, this.dropItemListFusionMaterial, this.dropItemChanceRoshan);
         }
       }
-
-      // 延迟移除无人捡取的金币袋
-      Timers.CreateTimer(this.removeGoldBagDelay, () => {
-        const goldBags = Entities.FindAllByClassname('dota_item_drop') as CDOTA_Item_Physical[];
-        for (const goldBag of goldBags) {
-          const itemName = goldBag.GetContainedItem().GetName();
-          if (itemName === 'item_bag_of_gold') {
-            goldBag.RemoveSelf();
-          }
-        }
-      });
     } else if (creep.IsAncient()) {
       // 击杀远古
       if (PlayerHelper.IsHumanPlayer(attacker)) {

--- a/src/vscripts/modules/event/event-npc-spawned.ts
+++ b/src/vscripts/modules/event/event-npc-spawned.ts
@@ -5,9 +5,9 @@ import { GameConfig } from '../GameConfig';
 import { BotAbility } from '../helper/bot-ability';
 import { ModifierHelper } from '../helper/modifier-helper';
 import { PlayerHelper } from '../helper/player-helper';
-import { EventEntityKilled } from './event-entity-killed';
 export class EventNpcSpawned {
   private roshanLevelBase = 1;
+  private isFirstRoshan = true;
   private heroSpawnRetryCount = 0;
   private readonly MAX_SPAWN_RETRY = 100;
   // abiliti name list of roshan
@@ -162,9 +162,9 @@ export class EventNpcSpawned {
 
     if (creepName === 'npc_dota_roshan') {
       // kill
-      const killCount = EventEntityKilled.roshanKillCount;
-      if (killCount === 0) {
-        creep.Kill(undefined, undefined);
+      if (this.isFirstRoshan) {
+        creep.Kill(undefined, creep);
+        this.isFirstRoshan = false;
         return;
       }
       for (const abilityName of this.roshanLevelupBaseAbilities) {

--- a/src/vscripts/modules/filter/gold-xp-filter.ts
+++ b/src/vscripts/modules/filter/gold-xp-filter.ts
@@ -3,8 +3,8 @@ import { PlayerHelper } from '../helper/player-helper';
 
 @reloadable
 export class GoldXPFilter {
-  private readonly REDUCE_RATE_3_MIN = 0.8;
-  private readonly REDUCE_RATE_6_MIN = 0.9;
+  private readonly REDUCE_RATE_3_MIN = 0.6;
+  private readonly REDUCE_RATE_6_MIN = 0.8;
   private readonly REDUCE_RATE_HERO_KILL = 0.3;
 
   constructor() {


### PR DESCRIPTION
## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.18b[/b]

- 修正肉山无法正常刷新的问题。
- 略微降低电脑前期倍率。
- 略微降低N6 N7防御塔强度。
```

```
[b]Gameplay update v5.18b[/b]

- Fixed Roshan not respawning correctly after the first-kill spawn flow.
- Slightly reduced early-game bot gold and XP multipliers.
- Slightly reduced N6 N7 tower power.
```
