### PR TITLE
修正抽选技能bug

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -831,8 +831,8 @@
 		// 死亡先知
 		"DOTA_Tooltip_Ability_death_prophet_witchcraft2"									"Witchcraft"
 		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_Description"						"Death Prophet's occult knowledge deepens with experience, gaining movement speed and spell cooldown reduction."
-		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_movement_speed_pct_per_level"	"%MOVEMENT SPEED:"
-		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_cooldown_reduction_pct_per_level" "%COOLDOWN REDUCTION:"
+		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_movement_speed_pct"				"%MOVEMENT SPEED:"
+		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_cooldown_reduction_pct"			"%COOLDOWN REDUCTION:"
 
 		// 魔法盾
 		"DOTA_Tooltip_ability_medusa_mana_shield2"								"Mana Shield"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -562,11 +562,9 @@
 		"DOTA_Tooltip_ability_brewmaster_drunken_boxing_duration" 		"duration："
 		//精准光环
 		"DOTA_Tooltip_ability_drow_ranger_trueshot2"										"Precision Aura"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Description"							"Grants bonus agility based on your current agility and the ability's level. Nearby ranged heroes receive %trueshot_agi_bonus_allies_pct%%% of the bonus."
+		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Description"							"Grants Drow bonus agility based on Drow's current agility and level. Nearby ranged heroes received %trueshot_agi_bonus_allies_pct%%% of the bonus agility."
 		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Lore"								"Traxex' time spent alone in the forests of her Drow home has allowed her to teach other archers how to improve their bow skills."
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus_base"				"%AGILITY BASE BONUS:"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus_per_level"		"%AGILITY BONUS PER LEVEL:"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_agi_bonus_pct_tooltip"				"%TOTAL AGILITY BONUS:"
+		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus"					"%AGILITY BONUS:"
 		"DOTA_Tooltip_ability_drow_ranger_trueshot2_radius"								"RADIUS:"
 
 		//长角抛物

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -280,14 +280,6 @@
 		"DOTA_Tooltip_ability_brewmaster_drunken_boxing_Description" 	"%miss% %% шанс уклонения и нанести критический урон. После активации эффекта скорость передвижения увеличивается на 30%, а шанс уклонения и критической атаки утраивается"
 		"DOTA_Tooltip_ability_brewmaster_drunken_boxing_damage" 		"%Критический урон: "
 		"DOTA_Tooltip_ability_brewmaster_drunken_boxing_duration" 		"Длительность： "
-		//精准光环
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2"										"Precision Aura"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Description"							"Даёт владельцу дополнительную ловкость, зависящую от его уровня и от текущего показателя ловкости. Герои дальнего боя неподалёку получают %trueshot_agi_bonus_allies_pct%%% от бонуса."
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Lore"								"Коротая своё одиночество в бесконечных тренировках, Траксекс научилась передавать толику своего мастерства любому лучнику."
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus_base"				"%БАЗОВЫЙ БОНУС К ЛОВКОСТИ:"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus_per_level"		"%БОНУС К ЛОВКОСТИ ЗА УРОВЕНЬ:"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_agi_bonus_pct_tooltip"				"%СУММАРНЫЙ БОНУС К ЛОВКОСТИ:"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_radius"								"РАДИУС:"
 
 		//长角抛物
 		"DOTA_Tooltip_ability_magnataur_horn_toss2"						        "Horn Toss"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1207,6 +1207,9 @@
 		"DOTA_Tooltip_ability_life_stealer_rage_status_resist"							"%状态抗性："
 		"DOTA_Tooltip_ability_life_stealer_rage_bonus_armor"							"护甲："
 
+		// 虚空假面 逆转时空
+		"DOTA_Tooltip_ability_faceless_void_time_zone_Description"					"在时空中创造一个遮罩，改变其中所有单位的移动、攻击、施法、弹道和转身速度。友军的速度提升，冷却加快。敌人的速度降低，技能和物品的冷却全部冻结。时间膨胀的负面状态持续时间在逆转时空内不会变少。"
+
 
 "DOTA_Tooltip_ability_ability_mind_control"                     "夺舍"
 "DOTA_Tooltip_ability_ability_mind_control_Description"         "夺舍一个敌方AI英雄%duration%秒。你可以暂时操控该英雄的移动，攻击和施法。在控制期间,该英雄队伍转变，且击杀和被击杀都算到你头上。但AI残余的意识还可能与你争抢，拼手速的时候到了"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -824,8 +824,8 @@
 		// 死亡先知
 		"DOTA_Tooltip_Ability_death_prophet_witchcraft2"									"巫术精研"
 		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_Description"						"死亡先知的神秘学识随着经验积累而加深，获得移动速度和技能冷却时间减少。"
-		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_movement_speed_pct_per_level"	"%移动速度加成："
-		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_cooldown_reduction_pct_per_level" "%冷却时间减少："
+		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_movement_speed_pct"				"%移动速度加成："
+		"DOTA_Tooltip_Ability_death_prophet_witchcraft2_cooldown_reduction_pct"			"%冷却时间减少："
 
 		// 魔法盾
 		"DOTA_Tooltip_ability_medusa_mana_shield2"								"魔法盾"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -563,11 +563,9 @@
 		"DOTA_Tooltip_ability_brewmaster_drunken_boxing_duration" 		"持续时间："
 		//精准光环
 		"DOTA_Tooltip_ability_drow_ranger_trueshot2"										"精准光环"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Description"							"根据当前敏捷和英雄等级获得敏捷加成。附近远程英雄获得%trueshot_agi_bonus_allies_pct%%%敏捷加成。"
+		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Description"							"卓尔游侠根据她自身的当前敏捷和英雄等级获得敏捷加成。附近远程英雄获得%trueshot_agi_bonus_allies_pct%%%敏捷加成。"
 		"DOTA_Tooltip_ability_drow_ranger_trueshot2_Lore"								"崔希丝在卓尔族森林中独处的时光让她有时间教导其他弓箭手如何提高弓技。"
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus_base"				"%基础敏捷加成："
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus_per_level"		"%每级敏捷加成："
-		"DOTA_Tooltip_ability_drow_ranger_trueshot2_agi_bonus_pct_tooltip"				"%总敏捷加成："
+		"DOTA_Tooltip_ability_drow_ranger_trueshot2_trueshot_agi_bonus"					"%敏捷加成："
 		"DOTA_Tooltip_ability_drow_ranger_trueshot2_radius"								"作用范围："
 
 		//长角抛物

--- a/game/scripts/npc/neutral_items.txt
+++ b/game/scripts/npc/neutral_items.txt
@@ -236,7 +236,6 @@
 				"item_flayers_bota"					"1"		// 剥皮血囊
 				"item_metamorphic_mandible"			"1"		// 变态上颚
 				"item_dandelion_amulet"				"1"		// 蒲公英护符
-				"item_enchanters_bauble"			"1"		// 附魔师之椟
 				"item_prophets_pendulum"			"1"		// 先知灵摆
 				"item_conjurers_catalyst"			"1"		// 咒术师触媒
 
@@ -251,6 +250,7 @@
 				"item_seer_stone"					"1"		// 先哲之石
 				"item_repair_kit"					"1"		// 维修器具
 				"item_mirror_shield"				"1"		// 神镜盾
+				"item_magnifying_monocle"			"1"		// 放大单片镜
 
 			}
 
@@ -324,10 +324,12 @@
 				"item_harmonizer"					"1"		// 协和
 				"item_heavy_blade"					"1"		// 行巫之祸
 
+				// 级别移动
+				"item_enchanters_bauble"			"1"		// 附魔师之椟
+
 				// 额外添加
 				"item_nemesis_curse"				"1"		// 天诛之咒
 				"item_ceremonial_robe"				"1"		// 祭礼长袍
-				"item_magnifying_monocle"			"1"		// 放大单片镜
 				"item_ballista"						"1"		// 弩炮
 				"item_giants_ring"					"1"		// 巨人之戒
 				"item_ex_machina"					"1"		// 机械之心

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -223,8 +223,8 @@
 			}
 			"trueshot_agi_bonus"
 			{
-				"value"				"10"
-				"hero_levelup"		"+0.5"
+				"value"				"25"		// 10
+				// "hero_levelup"		"+0.5"
 			}
 			"trueshot_agi_bonus_allies_pct"		"50"
 		}

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -155,12 +155,12 @@
 		{
 			"movement_speed_pct"
 			{
-				"value"				"10"		// 0.5
+				"value"				"20"		// 0.5
 				// "hero_levelup"		"+0.5"		// +0.75
 			}
 			"cooldown_reduction_pct"
 			{
-				"value"				"10"
+				"value"				"20"
 				// "hero_levelup"		"+0.5"		// +0.75
 			}
 		}

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -153,15 +153,15 @@
 
 		"AbilityValues"
 		{
-			"movement_speed_pct_per_level"
+			"movement_speed_pct"
 			{
-				"value"				"10"		// 0.75
-				"hero_levelup"		"+0.5"		// 0.75
+				"value"				"10"		// 0.5
+				"hero_levelup"		"+0.5"		// +0.75
 			}
-			"cooldown_reduction_pct_per_level"
+			"cooldown_reduction_pct"
 			{
-				"value"				"10"		// 0.75
-				"hero_levelup"		"+0.5"		// 0.75
+				"value"				"10"
+				"hero_levelup"		"+0.5"		// +0.75
 			}
 		}
 	}

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -156,12 +156,12 @@
 			"movement_speed_pct"
 			{
 				"value"				"10"		// 0.5
-				"hero_levelup"		"+0.5"		// +0.75
+				// "hero_levelup"		"+0.5"		// +0.75
 			}
 			"cooldown_reduction_pct"
 			{
 				"value"				"10"
-				"hero_levelup"		"+0.5"		// +0.75
+				// "hero_levelup"		"+0.5"		// +0.75
 			}
 		}
 	}

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -221,13 +221,12 @@
 				"value"			"1200"
 				"affected_by_aoe_increase"	"1"
 			}
-			"trueshot_agi_bonus_base"			"4 8 12 16 18"
-			"trueshot_agi_bonus_per_level"		"1"
-			"trueshot_agi_bonus_allies_pct"		"50"
-			"agi_bonus_pct_tooltip"
+			"trueshot_agi_bonus"
 			{
-				"dynamic_value"						"true"
+				"value"				"10"
+				"hero_levelup"		"+0.5"
 			}
+			"trueshot_agi_bonus_allies_pct"		"50"
 		}
 
 	}

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -5881,6 +5881,7 @@
 	"faceless_void_time_zone"
 	{
 		"MaxLevel"						"4"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_POINT"
 		"AbilityCastRange"				"900"		// 500
 		"AbilityCooldown"				"120"	// 155/145/135 固定 120
 		"AbilityManaCost"				"125 200 275 350"

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -5671,7 +5671,11 @@
 		"MaxLevel"						"5"
 		"AbilityValues"
 		{
-				"trueshot_agi_bonus_base"			"4 8 12 16 20"
+				"trueshot_agi_bonus"
+				{
+					"value"				"10"
+					"hero_levelup"		"+0.5"
+				}
 		}
 	}
 	//=================================================================================================================
@@ -9833,14 +9837,13 @@
 	{
 		"AbilityValues"
 		{
-			"movement_speed_pct_per_level"
+			"movement_speed_pct"
 			{
-				"value"				"1"		// 0.75
+				"value"				"1"		// 0.5
 				"hero_levelup"		"+0.5"	// +0.75
 			}
-			"cooldown_reduction_pct_per_level"
+			"cooldown_reduction_pct"
 			{
-				"value"				"1"		// 0.75
 				"hero_levelup"		"+0.5"	// +0.75
 			}
 		}

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -3084,14 +3084,7 @@
 		{
 			"duration"
 			{
-				"value"				"5 6 7 8"
-				"special_bonus_unique_omniknight_guardian_angel_duration"			"+2"
-			}
-			"radius"
-			{
-				"value"						"250"
-				"affected_by_aoe_increase"	"1"
-				"special_bonus_scepter"		"+150"
+				"value"				"4.5 5 5.5 6"
 			}
 			"AbilityCooldown"
 			{

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -78,7 +78,7 @@ export class GameConfig {
     if (IsInToolsMode()) {
       print('[GameConfig] 开发者模式快速开始游戏');
       GameRules.SetCustomGameSetupAutoLaunchDelay(5);
-      GameRules.SetHeroSelectionTime(5);
+      // GameRules.SetHeroSelectionTime(5);
       GameRules.SetHeroSelectPenaltyTime(1); // 选择英雄超时惩罚时间
       GameRules.SetStrategyTime(3);
       GameRules.SetPreGameTime(5); // 进入游戏后号角吹响前的准备时间

--- a/src/vscripts/modules/lottery/lottery-abilities-bot.ts
+++ b/src/vscripts/modules/lottery/lottery-abilities-bot.ts
@@ -254,7 +254,7 @@ export const abilityTiersPassiveBot: Tier[] = [
       'huskar_berserkers_blood', // 狂战士之血
       'legion_commander_moment_of_courage', // 勇气之霎
       'abyssal_underlord_atrophy_aura', // 衰退光环
-      'obsidian_destroyer_equilibrium', // 精华变迁
+      // 'obsidian_destroyer_equilibrium', // 精华变迁
       'abaddon_frostmourne', // 魔霭诅咒
       'lycan_feral_impulse', // 野性驱使
 

--- a/src/vscripts/modules/lottery/lottery-abilities-bot.ts
+++ b/src/vscripts/modules/lottery/lottery-abilities-bot.ts
@@ -198,7 +198,6 @@ export const abilityTiersPassiveBot: Tier[] = [
       'leshrac_defilement2', // 大肆污染 拉席克
       'tinker_eureka2', // 修补匠 尤里卡！
       'rubick_might_and_magus2', // 拉比克 力量与魔法
-      'death_prophet_witchcraft2', // 死亡先知 巫术精研
       'clinkz_infernal_shred2', // 克林克兹先天 地狱之裂
 
       // 'ability_trigger_learned_skills', //蓝蝴蝶
@@ -239,6 +238,7 @@ export const abilityTiersPassiveBot: Tier[] = [
       'centaur_sturdy', // 人马 不屈
       'ancient_apparition_frost_orb', // 冰霜法球
       'medusa_mana_shield2', // 魔法盾
+      'death_prophet_witchcraft2', // 死亡先知 巫术精研
     ],
   },
   {

--- a/src/vscripts/modules/lottery/lottery-abilities.ts
+++ b/src/vscripts/modules/lottery/lottery-abilities.ts
@@ -204,7 +204,6 @@ export const abilityTiersPassive: Tier[] = [
       'leshrac_defilement2', // 大肆污染 拉席克
       'tinker_eureka2', // 修补匠 尤里卡！
       'rubick_might_and_magus2', // 拉比克 力量与魔法
-      'death_prophet_witchcraft2', // 死亡先知 巫术精研
 
       'ability_trigger_learned_skills', //蓝蝴蝶
       'ability_trigger_on_spell_reflect', //绿蝴蝶
@@ -245,6 +244,7 @@ export const abilityTiersPassive: Tier[] = [
       'centaur_sturdy', // 人马 不屈
       'ancient_apparition_frost_orb', // 冰霜法球
       'medusa_mana_shield2', // 魔法盾
+      'death_prophet_witchcraft2', // 死亡先知 巫术精研
     ],
   },
   {

--- a/src/vscripts/modules/lottery/lottery-abilities.ts
+++ b/src/vscripts/modules/lottery/lottery-abilities.ts
@@ -260,7 +260,7 @@ export const abilityTiersPassive: Tier[] = [
       'huskar_berserkers_blood', // 狂战士之血
       'legion_commander_moment_of_courage', // 勇气之霎
       'abyssal_underlord_atrophy_aura', // 衰退光环
-      'obsidian_destroyer_equilibrium', // 精华变迁
+      // 'obsidian_destroyer_equilibrium', // 精华变迁
       'abaddon_frostmourne', // 魔霭诅咒
       'lycan_feral_impulse', // 野性驱使
 


### PR DESCRIPTION
## Issue

- [x] fix #1969

## Checklist

- [x] 巫术精研抽选与说明、数值显示正常
- [x] 逆转时空不再被错误隐藏，可选可施放，说明正确
- [x] 精准光环抽选后效果与说明正常
- [x] 黑鸟相关技能效果与显示正常
- [x] 全能骑士终极大招已削弱（强度/驱散等符合预期）

## Release Note

```
[b]游戏性更新 v5.18d[/b]

- 将附魔师之椟调整至五级中立物品池。
- 修正技能抽选中的巫术精研、逆转时空与精准光环。
- 削弱全能骑士的终极大招。
```

```
[b]Gameplay update v5.18d[/b]

- Moved Enchanter's Bauble to tier 5 neutral items.
- Fixed Witchcraft, Time Zone, and Precision Aura in the ability draft pool.
- Nerfed Omniknight's Guardian Angel.
```
