### PR TITLE
Align bot neutral items with 7.41 KV and primary-attribute enhancement pools

### DIFF
--- a/.cursor/skills/issue/SKILL.md
+++ b/.cursor/skills/issue/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: issue
+description: >-
+  Implements a GitHub issue end-to-end from an issue URL or /issue: fetch issue,
+  branch from develop as feature/<issue>-slug, implement (multi-file), then open
+  PR via create-pr. Stops to ask the user when the issue is ambiguous or work
+  is blocked. Use when the user pastes a github.com/.../issues/N link, says
+  /issue, or asks to fix or implement a numbered GitHub issue.
+---
+
+# /issue
+
+从 GitHub Issue 驱动开发：读 Issue → 从 `develop` 切分支 → 实现 → 复用 [create-pr](../create-pr/SKILL.md) 开 PR。
+
+## 约束
+
+- 不改 `git config`；不做破坏性 git 操作（与 create-pr 一致）。
+- 可改多文件；以 Issue 验收范围为准，避免无关重构。
+
+## 何时必须停下来问用户
+
+- Issue 目标、范围或验收标准不清楚、自相矛盾。
+- Issue 所在仓库与当前工作区 `origin` 不一致（或无法确认对应关系）。
+- 实现受阻：缺少设计决策、依赖外部凭证、环境/测试无法运行、需要产品取舍。
+
+## Issue 与链接
+
+1. 从用户输入解析 `owner`、`repo`、`issue_number`（标准 Issue URL：`https://github.com/<owner>/<repo>/issues/<n>`）。
+2. 用 **GitHub MCP** `get_issue` 或 **`gh issue view`**（其一即可）拉取标题与正文；需要评论里的补充时再用 `gh issue view <n> --comments` 或等价方式。
+3. 核对：当前仓库 remote 是否对应同一 `owner/repo`；否则说明差异并询问是否继续、是否换目录。
+
+## 分支
+
+1. 取最新 `develop`：`git fetch origin` 后 `git checkout develop` 并 `git pull`（按团队习惯可与 `origin/develop` 对齐）。
+2. 新分支名：`feature/<issue_number>-<短 slug>`  
+   - `slug`：来自 Issue 标题：小写、空格与连续符号转为 `-`，去掉不安全字符，尽量短（例如 3～6 个词以内）。  
+   - 示例：`feature/42-fix-lobby-timeout`。
+3. `git checkout -b feature/<issue_number>-<slug>`。
+
+## 开发
+
+1. 按 Issue 实现；可 touch 多个文件；遵循仓库既有风格与测试习惯。
+2. 在合理范围内跑项目已有的检查（build / test / lint），失败则排查或向用户说明阻塞。
+
+## 提交与 PR
+
+1. 工作完成后：阅读并**完整执行** [.cursor/skills/create-pr/SKILL.md](../create-pr/SKILL.md)（收集 diff、提交、推送、`gh pr create` 指向 `develop`、按模板写正文等）。  
+   - 分支名已含 issue 号时，create-pr 的 Issue 识别规则仍适用；正文关联 `fix #<n>` / checklist 与模板保持一致。
+2. 若 `gh` 不可用，可用 MCP 创建 PR，但正文与 checklist 仍应对齐 `.github/pull_request_template.md` 与 create-pr 中的 Release Note / changelog 规则。
+
+## 回报
+
+简要说明：分支名、核心改动、PR 链接；若已暂停提问，说明缺什么信息或阻塞原因。

--- a/game/scripts/npc/npc_items_override_neutral.txt
+++ b/game/scripts/npc/npc_items_override_neutral.txt
@@ -628,15 +628,14 @@
 	{
 		"AbilityValues"
 		{
-			"hp_regen"				"0"			//4
 			"damage_return_hero"
 			{
-				"value"					"90"		//30
+				"value"					"60"		//30
 				"apply_curio_bonus"		"1"
 			}
 			"damage_return_creep"
 			{
-				"value"					"60"		//20
+				"value"					"30"		//15
 				"apply_curio_bonus"		"1"
 			}
 		}
@@ -759,7 +758,6 @@
 	"item_crippling_crossbow"
 	{
 		"AbilityCooldown"				"6"			// 30
-		"AbilityManaCost"				"150"		// 50
 		"AbilityCastRange"				"1200"		// 650
 		"AbilityValues"
 		{
@@ -769,7 +767,7 @@
 				"apply_curio_bonus"		"1"
 			}
 			"duration"					"6"			// 4
-			"damage"					"150"		// 25
+			"damage"					"180"		// 25
 		}
 	}
 

--- a/game/scripts/npc/npc_items_override_neutral.txt
+++ b/game/scripts/npc/npc_items_override_neutral.txt
@@ -1134,6 +1134,7 @@
 	//巨人之槌
 	"item_giant_maul"
 	{
+		"AbilityCooldown"				"8"		// 15
 		"AbilityValues"
 		{
 			"crit_multiplier"
@@ -1144,6 +1145,7 @@
 			"movespeed_slow"			"20"	// 10
 			"attack_slow"				"60"	// 15
 			"cast_slow"					"40"	// 20
+			"debuff_duration"			"2"		// 3
 		}
 	}
 	//回响之笼

--- a/game/scripts/npc/npc_items_override_neutral.txt
+++ b/game/scripts/npc/npc_items_override_neutral.txt
@@ -1175,16 +1175,17 @@
 	// 剥皮血囊
 	"item_flayers_bota"
 	{
+		"AbilityCooldown"				"90"	// 65
 		"AbilityValues"
 		{
 			"base_damage"
 			{
-				"value"					"40"	// 15
+				"value"					"50"	// 15
 			}
 
 			"attack_speed"
 			{
-				"value"					"90"	// 30
+				"value"					"120"	// 30
 			}
 		}
 	}

--- a/game/scripts/npc/npc_items_override_neutral_passive.txt
+++ b/game/scripts/npc/npc_items_override_neutral_passive.txt
@@ -110,7 +110,8 @@
 	{
 		"AbilityValues"
 		{
-			"attack_range"						"80 120"	// 60 90 120
+			"attack_range"						"60 100"	// 60 90 120
+			"bonus_damage"						"10 20"		// 6 10 14
 		}
 	}
 	// 犀利 施法距离回蓝最大魔法

--- a/game/scripts/npc/npc_items_override_neutral_passive.txt
+++ b/game/scripts/npc/npc_items_override_neutral_passive.txt
@@ -150,7 +150,7 @@
 		"AbilityValues"
 		{
 			"health_restoration"		"20 30 40 50"				// 10 15 20
-			"bat_reduce"				"9 18 27 36"				// 6 9 12
+			"bat_reduce"				"9 15 21 27"				// 6 9 12
 			"intelligence_pct"			"-5 -10 -15 -20"			// -6
 		}
 	}

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -6,7 +6,7 @@ import { getHeroBuildConfig } from '../build-item/hero-build-config';
 import { HeroBuildManager } from '../build-item/hero-build-manager';
 import { HeroBuildState, InitializeHeroBuild } from '../build-item/hero-build-state';
 import { SellItem } from '../build-item/sell-item';
-import { NeutralItemManager, NeutralTierConfig } from '../item/neutral-item';
+import { NeutralItemConfig, NeutralItemManager, NeutralTierConfig } from '../item/neutral-item';
 import { UseItem } from '../item/use-item';
 import { ModeEnum } from '../mode/mode-enum';
 import { HeroUtil } from './hero-util';
@@ -19,6 +19,14 @@ export class BotBaseAIModifier extends BaseModifier {
   // 持续动作结束时间
   protected readonly continueActionTime: number = 8;
   protected continueActionEndTime: number = -60;
+
+  // 中立槽修复节奏：间隔与下次校验时间（gameTime）
+  protected readonly neutralItemRepairInterval: number = 5;
+  protected neutralItemRepairNextTime: number = -60;
+  // 中立槽状态
+  private neutralItemTier: number = 0;
+  private desiredNeutralActive: NeutralItemConfig | undefined;
+  private desiredNeutralPassive: NeutralItemConfig | undefined;
 
   protected readonly FindHeroRadius: number = 1600;
   protected readonly FindRadius: number = 1600;
@@ -44,8 +52,6 @@ export class BotBaseAIModifier extends BaseModifier {
   protected ability_5: CDOTABaseAbility | undefined;
   protected ability_utli: CDOTABaseAbility | undefined;
 
-  // 物品
-  private neutralItemTier: number = 0;
   protected getNeutralItemConfig(): Record<number, NeutralTierConfig> {
     return NeutralItemManager.GetDefaultConfig();
   }
@@ -366,6 +372,9 @@ export class BotBaseAIModifier extends BaseModifier {
     if (this.PickNeutralItem()) {
       return true;
     }
+    if (this.RepairNeutralSlotsIfStomped()) {
+      return true;
+    }
     return false;
   }
 
@@ -374,6 +383,45 @@ export class BotBaseAIModifier extends BaseModifier {
       return false;
     }
     return HeroBuildManager.TryPurchaseItem(this.hero, this.buildState);
+  }
+
+  /** 按间隔校验并修复中立主动/强化槽 */
+  private RepairNeutralSlotsIfStomped(): boolean {
+    if (this.gameTime < this.neutralItemRepairNextTime) {
+      return false;
+    }
+    this.neutralItemRepairNextTime = this.gameTime + this.neutralItemRepairInterval;
+
+    const desiredActive = this.desiredNeutralActive;
+    const desiredPassive = this.desiredNeutralPassive;
+    if (this.neutralItemTier <= 0 || desiredActive === undefined || desiredPassive === undefined) {
+      return false;
+    }
+
+    const active = this.hero.GetItemInSlot(InventorySlot.NEUTRAL_ACTIVE_SLOT);
+    const passive = this.hero.GetItemInSlot(InventorySlot.NEUTRAL_PASSIVE_SLOT);
+    const activeOk =
+      active !== undefined &&
+      active.GetAbilityName() === desiredActive.name &&
+      active.GetLevel() === desiredActive.level;
+    const passiveOk =
+      passive !== undefined &&
+      passive.GetAbilityName() === desiredPassive.name &&
+      passive.GetLevel() === desiredPassive.level;
+
+    if (activeOk && passiveOk) {
+      return false;
+    }
+
+    if (active !== undefined) {
+      UTIL_RemoveImmediate(active);
+    }
+    if (passive !== undefined) {
+      UTIL_RemoveImmediate(passive);
+    }
+    this.hero.AddItemByName(desiredActive.name).SetLevel(desiredActive.level);
+    this.hero.AddItemByName(desiredPassive.name).SetLevel(desiredPassive.level);
+    return true;
   }
 
   PickNeutralItem(): boolean {
@@ -415,6 +463,12 @@ export class BotBaseAIModifier extends BaseModifier {
 
     this.hero.AddItemByName(selectedItem.name).SetLevel(selectedItem.level);
     this.hero.AddItemByName(selectedEnhancement.name).SetLevel(selectedEnhancement.level);
+    this.desiredNeutralActive = { name: selectedItem.name, level: selectedItem.level };
+    this.desiredNeutralPassive = {
+      name: selectedEnhancement.name,
+      level: selectedEnhancement.level,
+    };
+    this.neutralItemRepairNextTime = this.gameTime + this.neutralItemRepairInterval;
     this.neutralItemTier = targetTier;
     return true;
   }

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -392,6 +392,7 @@ export class BotBaseAIModifier extends BaseModifier {
     const selectedEnhancement = NeutralItemManager.GetRandomTierEnhancements(
       targetTier,
       neutralItemConfig,
+      this.hero,
     );
     if (!selectedEnhancement) {
       print(`[AI] HeroBase PickNeutralItem ${this.hero.GetUnitName()} 没有找到中立增强`);

--- a/src/vscripts/ai/item/neutral-item.ts
+++ b/src/vscripts/ai/item/neutral-item.ts
@@ -45,8 +45,8 @@ export class NeutralItemManager {
       //延后4分钟
       addTimeMin = [4, 5, 6, 7, 9];
     } else {
-      // 延后6分钟
-      addTimeMin = [6, 7, 8, 9, 12];
+      // 延后5分钟
+      addTimeMin = [5, 6, 7, 8, 10];
     }
 
     const baseTime = baseTimeMin.map((time, index) => time * 60 + addTimeMin[index] * 60);

--- a/src/vscripts/ai/item/neutral-item.ts
+++ b/src/vscripts/ai/item/neutral-item.ts
@@ -1,14 +1,23 @@
-// 中立物品配置接口
+// 中立物品配置接口（与 game/scripts/npc/neutral_items.txt 同步）
 export interface NeutralItemConfig {
   name: string; // 物品名称
-  level: number; // 物品等级
+  level: number; // 物品等级（中立强化为 KV 中右侧数值）
   weight?: number; // 权重(用于概率计算，默认为1)
 }
 
-// 中立物品tier配置
+// 与 KV enhancements 下 global / 四属性池 一致
+export interface NeutralTierEnhancementPools {
+  global: NeutralItemConfig[];
+  strength: NeutralItemConfig[];
+  agility: NeutralItemConfig[];
+  intelligence: NeutralItemConfig[];
+  universal: NeutralItemConfig[];
+}
+
+// 中立物品 tier 配置
 export interface NeutralTierConfig {
-  items: NeutralItemConfig[]; // 主动物品列表
-  enhancements: NeutralItemConfig[]; // 被动增强列表
+  items: NeutralItemConfig[]; // 主动中立物品
+  enhancements: NeutralTierEnhancementPools;
 }
 
 // 中立物品管理类
@@ -44,31 +53,50 @@ export class NeutralItemManager {
     return baseTime;
   }
 
-  // 获取默认配置
+  // 获取默认配置（与 neutral_items.txt neutral_tiers 一致）
   public static GetDefaultConfig(): Record<number, NeutralTierConfig> {
     return {
       1: {
         items: [
+          { name: 'item_kobold_cup', level: 1 }, // 狗头人酒杯
           { name: 'item_chipped_vest', level: 1 }, // 碎裂背心
           { name: 'item_polliwog_charm', level: 1 }, // 蝌蚪护符
           { name: 'item_dormant_curio', level: 1 }, // 休眠珍品
           { name: 'item_duelist_gloves', level: 1 }, // 决斗家手套
-          // 7.40新增
-          { name: 'item_ash_legion_shield', level: 1 }, // 余烬军团战盾
           { name: 'item_weighted_dice', level: 1 }, // 加重骰子
-          // 额外添加
+          { name: 'item_ash_legion_shield', level: 1 }, // 余烬军团战盾
+          { name: 'item_possessed_mask', level: 1 }, // 附魂面具
+          { name: 'item_dagger_of_ristul', level: 1 }, // 瑞斯图尔的匕首
+          { name: 'item_foragers_kit', level: 1 }, // 采菌套具
+          { name: 'item_stonefeather_satchel', level: 1 }, // 石羽小包
           { name: 'item_safety_bubble', level: 1 }, // 安全泡泡
           { name: 'item_royal_jelly', level: 1 }, // 蜂王浆
+          { name: 'item_arcane_ring', level: 1 }, // 奥术指环
         ],
-        enhancements: [
-          { name: 'item_enhancement_mystical', level: 1 },
-          { name: 'item_enhancement_brawny', level: 1 },
-          { name: 'item_enhancement_alert', level: 1 },
-          { name: 'item_enhancement_tough', level: 1 },
-          { name: 'item_enhancement_quickened', level: 1 },
-          { name: 'item_enhancement_greedy', level: 1 },
-          { name: 'item_enhancement_wise', level: 1 },
-        ],
+        enhancements: {
+          global: [
+            { name: 'item_enhancement_quickened', level: 1 }, // 迅速 移速
+            { name: 'item_enhancement_vital', level: 1 }, // 活力 生命恢复
+            { name: 'item_enhancement_greedy', level: 1 }, // 贪婪 工资蓝量 -攻击
+            { name: 'item_enhancement_wise', level: 1 }, // 睿智 每分钟经验
+          ],
+          strength: [
+            { name: 'item_enhancement_brawny', level: 1 }, // 壮实 血量
+            { name: 'item_enhancement_tough', level: 1 }, // 坚强 攻击
+          ],
+          agility: [
+            { name: 'item_enhancement_alert', level: 1 }, // 警觉 攻速
+            { name: 'item_enhancement_brawny', level: 1 }, // 壮实 血量
+          ],
+          intelligence: [
+            { name: 'item_enhancement_mystical', level: 1 }, // 神秘 回蓝
+            { name: 'item_enhancement_tough', level: 1 }, // 坚强 攻击
+          ],
+          universal: [
+            { name: 'item_enhancement_alert', level: 1 }, // 警觉 攻速
+            { name: 'item_enhancement_mystical', level: 1 }, // 神秘 回蓝
+          ],
+        },
       },
       2: {
         items: [
@@ -76,25 +104,43 @@ export class NeutralItemManager {
           { name: 'item_mana_draught', level: 1 }, // 魔力药水
           { name: 'item_poor_mans_shield', level: 1 }, // 穷鬼盾
           { name: 'item_searing_signet', level: 1 }, // 炽热纹章
-          // 7.40回归
           { name: 'item_defiant_shell', level: 1 }, // 不羁甲壳
-          // 额外添加
+          { name: 'item_crippling_crossbow', level: 1 }, // 致残之弩
+          { name: 'item_medallion_of_courage', level: 1 }, // 勇气勋章
+          { name: 'item_seeds_of_serenity', level: 1 }, // 宁静种籽
           { name: 'item_orb_of_destruction', level: 1 }, // 毁灭灵球
           { name: 'item_misericorde', level: 1 }, // 飞贼之刃
-          { name: 'item_arcane_ring', level: 1 }, // 奥术指环
         ],
-        enhancements: [
-          { name: 'item_enhancement_mystical', level: 2 },
-          { name: 'item_enhancement_brawny', level: 2 },
-          { name: 'item_enhancement_alert', level: 2 },
-          { name: 'item_enhancement_tough', level: 2 },
-          { name: 'item_enhancement_quickened', level: 2 },
-          { name: 'item_enhancement_greedy', level: 2 },
-          { name: 'item_enhancement_wise', level: 2 },
-          { name: 'item_enhancement_keen_eyed', level: 1 },
-          { name: 'item_enhancement_vast', level: 1 },
-          { name: 'item_enhancement_vampiric', level: 1 },
-        ],
+        enhancements: {
+          global: [
+            { name: 'item_enhancement_quickened', level: 2 }, // 迅速 移速
+            { name: 'item_enhancement_greedy', level: 2 }, // 贪婪 工资蓝量 -攻击
+            { name: 'item_enhancement_vital', level: 2 }, // 活力 生命恢复
+            { name: 'item_enhancement_wise', level: 2 }, // 睿智 每分钟经验
+            { name: 'item_enhancement_vast', level: 1 }, // 高远 攻击距离
+            { name: 'item_enhancement_vampiric', level: 1 }, // 吸血鬼 双吸血
+          ],
+          strength: [
+            { name: 'item_enhancement_brawny', level: 2 }, // 壮实 血量
+            { name: 'item_enhancement_tough', level: 2 }, // 坚强 攻击
+            { name: 'item_enhancement_crude', level: 1 }, // 粗暴 减速抗性攻击间隔 -智力
+          ],
+          agility: [
+            { name: 'item_enhancement_alert', level: 2 }, // 警觉 攻速
+            { name: 'item_enhancement_brawny', level: 2 }, // 壮实 血量
+            { name: 'item_enhancement_nimble', level: 1 }, // 轻快 移速攻击力 -生命回复
+          ],
+          intelligence: [
+            { name: 'item_enhancement_mystical', level: 2 }, // 神秘 回蓝魔抗
+            { name: 'item_enhancement_tough', level: 2 }, // 坚强 攻击护甲
+            { name: 'item_enhancement_keen_eyed', level: 1 }, // 犀利 施法距离回蓝 -最大魔法值
+          ],
+          universal: [
+            { name: 'item_enhancement_alert', level: 2 }, // 警觉 攻速夜视
+            { name: 'item_enhancement_mystical', level: 2 }, // 神秘 回蓝魔抗
+            { name: 'item_enhancement_titanic', level: 1 }, // 巨神 基础攻击状态抗性 -攻击速度
+          ],
+        },
       },
       3: {
         items: [
@@ -102,64 +148,98 @@ export class NeutralItemManager {
           { name: 'item_gunpowder_gauntlets', level: 1 }, // 火药手套
           { name: 'item_jidi_pollen_bag', level: 1 }, // 基迪花粉袋
           { name: 'item_unrelenting_eye', level: 1 }, // 不屈之眼
-          // 级别移动
+          { name: 'item_cloak_of_flames', level: 1 }, // 火焰斗篷
+          { name: 'item_spellslinger', level: 1 }, // 咏咒之坠
+          { name: 'item_stormcrafter', level: 1 }, // 风暴宝器
+          { name: 'item_partisans_brand', level: 1 }, // 天游烙印
           { name: 'item_spider_legs', level: 1 }, // 网虫腿 原本是5级
-          // 额外添加
           { name: 'item_trickster_cloak', level: 1 }, // 欺诈师斗篷
           { name: 'item_penta_edged_sword', level: 1 }, // 五锋长剑
           { name: 'item_gale_guard', level: 1 }, // 烈风护体
+          { name: 'item_princes_knife', level: 1 }, // 亲王短刀
         ],
-        enhancements: [
-          { name: 'item_enhancement_mystical', level: 3 },
-          { name: 'item_enhancement_brawny', level: 3 },
-          { name: 'item_enhancement_alert', level: 3 },
-          { name: 'item_enhancement_tough', level: 3 },
-          { name: 'item_enhancement_quickened', level: 3 },
-          { name: 'item_enhancement_greedy', level: 3 },
-          { name: 'item_enhancement_keen_eyed', level: 2 },
-          { name: 'item_enhancement_vast', level: 2 },
-          { name: 'item_enhancement_vampiric', level: 2 },
-          { name: 'item_enhancement_feverish', level: 1 },
-          { name: 'item_enhancement_evolved', level: 1 },
-        ],
+        enhancements: {
+          global: [
+            { name: 'item_enhancement_quickened', level: 3 }, // 迅速 移速
+            { name: 'item_enhancement_greedy', level: 3 }, // 贪婪 工资蓝量 -攻击
+            { name: 'item_enhancement_vast', level: 2 }, // 高远 攻击距离
+            { name: 'item_enhancement_vampiric', level: 2 }, // 吸血鬼 双吸血
+            { name: 'item_enhancement_evolved', level: 1 }, // 进化 主属性
+            { name: 'item_enhancement_feverish', level: 1 }, // 狂热 冷却减少 蓝耗增加
+          ],
+          strength: [
+            { name: 'item_enhancement_brawny', level: 3 }, // 壮实 血量
+            { name: 'item_enhancement_tough', level: 3 }, // 坚强 攻击
+            { name: 'item_enhancement_crude', level: 2 }, // 粗暴 减速抗性攻击间隔 -智力
+          ],
+          agility: [
+            { name: 'item_enhancement_alert', level: 3 }, // 警觉 攻速
+            { name: 'item_enhancement_brawny', level: 3 }, // 壮实 血量
+            { name: 'item_enhancement_nimble', level: 2 }, // 轻快 移速攻击力 -生命回复
+          ],
+          intelligence: [
+            { name: 'item_enhancement_mystical', level: 3 }, // 神秘 回蓝魔抗
+            { name: 'item_enhancement_tough', level: 3 }, // 坚强 攻击护甲
+            { name: 'item_enhancement_keen_eyed', level: 2 }, // 犀利 施法距离回蓝 -最大魔法值
+          ],
+          universal: [
+            { name: 'item_enhancement_alert', level: 3 }, // 警觉 攻速夜视
+            { name: 'item_enhancement_mystical', level: 3 }, // 神秘 回蓝魔抗
+            { name: 'item_enhancement_titanic', level: 2 }, // 巨神 基础攻击状态抗性 -攻击速度
+          ],
+        },
       },
       4: {
         items: [
-          { name: 'item_crippling_crossbow', level: 1 }, // 致残之弩
           { name: 'item_giant_maul', level: 1 }, // 巨人之槌
           { name: 'item_rattlecage', level: 1 }, // 回响之笼
-          // 7.40新增
           { name: 'item_idol_of_screeauk', level: 1 }, // 丝奎奥克神像
           { name: 'item_flayers_bota', level: 1 }, // 剥皮血囊
           { name: 'item_metamorphic_mandible', level: 1 }, // 变态上颚
-          // 级别移动
+          { name: 'item_dandelion_amulet', level: 1 }, // 蒲公英护符
+          { name: 'item_prophets_pendulum', level: 1 }, // 先知灵摆
+          { name: 'item_conjurers_catalyst', level: 1 }, // 咒术师触媒
           { name: 'item_panic_button', level: 1 }, // 神妙明灯 原本是5级
           { name: 'item_havoc_hammer', level: 1 }, // 浩劫巨锤
-          // 额外添加
+          { name: 'item_imp_claw', level: 1 }, // 力量法则碎片
           { name: 'item_seer_stone', level: 1 }, // 先哲之石
-          { name: 'item_princes_knife', level: 1 }, // 亲王短刀
-          { name: 'item_stormcrafter', level: 1 }, // 风暴宝器
           { name: 'item_repair_kit', level: 1 }, // 维修器具
+          { name: 'item_mirror_shield', level: 1 }, // 神镜盾
+          { name: 'item_magnifying_monocle', level: 1 }, // 放大单片镜
         ],
-        enhancements: [
-          { name: 'item_enhancement_mystical', level: 4 },
-          { name: 'item_enhancement_brawny', level: 4 },
-          { name: 'item_enhancement_alert', level: 4 },
-          { name: 'item_enhancement_tough', level: 4 },
-          { name: 'item_enhancement_quickened', level: 4 },
-          { name: 'item_enhancement_vampiric', level: 3 },
-          { name: 'item_enhancement_timeless', level: 1 },
-          { name: 'item_enhancement_titanic', level: 3 },
-          { name: 'item_enhancement_crude', level: 3 },
-          // 级别移动
-          { name: 'item_enhancement_boundless', level: 1 },
-          { name: 'item_enhancement_evolved', level: 2 },
-          // 7.40新增
-          { name: 'item_enhancement_fierce', level: 1 }, // 凶猛
-          { name: 'item_enhancement_dominant', level: 1 }, // 专横
-          { name: 'item_enhancement_restorative', level: 1 }, // 滋补
-          { name: 'item_enhancement_thick', level: 1 }, // 厚重
-        ],
+        enhancements: {
+          global: [
+            { name: 'item_enhancement_quickened', level: 4 }, // 迅速 移速
+            { name: 'item_enhancement_timeless', level: 1 }, // 永恒 负面时间技能增强
+            { name: 'item_enhancement_vampiric', level: 3 }, // 吸血鬼 双吸血
+            { name: 'item_enhancement_boundless', level: 1 }, // 无边 攻击距离施法距离
+            { name: 'item_enhancement_evolved', level: 2 }, // 进化 主属性
+            { name: 'item_enhancement_fierce', level: 1 }, // 凶猛
+            { name: 'item_enhancement_dominant', level: 1 }, // 专横
+            { name: 'item_enhancement_restorative', level: 1 }, // 滋补
+            { name: 'item_enhancement_thick', level: 1 }, // 厚重
+          ],
+          strength: [
+            { name: 'item_enhancement_brawny', level: 4 }, // 壮实 血量
+            { name: 'item_enhancement_tough', level: 4 }, // 坚强 攻击护甲
+            { name: 'item_enhancement_crude', level: 3 }, // 粗暴 减速抗性攻击间隔 -智力
+          ],
+          agility: [
+            { name: 'item_enhancement_alert', level: 4 }, // 警觉 攻速夜视
+            { name: 'item_enhancement_brawny', level: 4 }, // 壮实 血量
+            { name: 'item_enhancement_nimble', level: 3 }, // 轻快 移速攻击力 -生命回复
+          ],
+          intelligence: [
+            { name: 'item_enhancement_mystical', level: 4 }, // 神秘 回蓝魔抗
+            { name: 'item_enhancement_tough', level: 4 }, // 坚强 攻击护甲
+            { name: 'item_enhancement_keen_eyed', level: 3 }, // 犀利 施法距离回蓝 -最大魔法值
+          ],
+          universal: [
+            { name: 'item_enhancement_alert', level: 4 }, // 警觉 攻速夜视
+            { name: 'item_enhancement_mystical', level: 4 }, // 神秘 回蓝魔抗
+            { name: 'item_enhancement_titanic', level: 3 }, // 巨神 基础攻击状态抗性 -攻击速度
+          ],
+        },
       },
       5: {
         items: [
@@ -167,41 +247,61 @@ export class NeutralItemManager {
           { name: 'item_fallen_sky', level: 1 }, // 天崩
           { name: 'item_demonicon', level: 1 }, // 死灵书
           { name: 'item_minotaur_horn', level: 1 }, // 恶牛角
-          { name: 'item_divine_regalia', level: 1 }, // 天赐华冠
-          { name: 'item_dezun_bloodrite', level: 1 }, // 德尊血式
           { name: 'item_riftshadow_prism', level: 1 }, // 影墟棱晶
-          // 级别移动
-          { name: 'item_nemesis_curse', level: 1 }, // 天诛之咒 原本是3级
-          { name: 'item_ceremonial_robe', level: 1 }, // 祭礼长袍 原本是4级
-          { name: 'item_magnifying_monocle', level: 1 }, // 放大单片镜 原本是4级
-          // 额外添加
-          { name: 'item_mirror_shield', level: 1 }, // 神镜盾
+          { name: 'item_dezun_bloodrite', level: 1 }, // 德尊血式
+          { name: 'item_divine_regalia', level: 1 }, // 天赐华冠
+          { name: 'item_harmonizer', level: 1 }, // 协和
+          { name: 'item_heavy_blade', level: 1 }, // 行巫之祸
+          { name: 'item_enchanters_bauble', level: 1 }, // 附魔师之椟
+          { name: 'item_nemesis_curse', level: 1 }, // 天诛之咒
+          { name: 'item_ceremonial_robe', level: 1 }, // 祭礼长袍
           { name: 'item_ballista', level: 1 }, // 弩炮
-          { name: 'item_imp_claw', level: 1 }, // 力量法则碎片
           { name: 'item_giants_ring', level: 1 }, // 巨人之戒
           { name: 'item_ex_machina', level: 1 }, // 机械之心
         ],
-        enhancements: [
-          { name: 'item_enhancement_timeless', level: 2 },
-          { name: 'item_enhancement_vampiric', level: 4 },
-          { name: 'item_enhancement_titanic', level: 4 },
-          { name: 'item_enhancement_crude', level: 4 },
-          { name: 'item_enhancement_fleetfooted', level: 1 },
-          { name: 'item_enhancement_audacious', level: 1 },
-          { name: 'item_enhancement_evolved', level: 3 },
-          { name: 'item_enhancement_boundless', level: 2 },
-          // 额外添加
-          { name: 'item_mysterious_hat', level: 2 },
-          { name: 'item_spell_prism', level: 1 },
-          { name: 'item_paladin_sword', level: 1 },
-          // 7.40新增
-          { name: 'item_enhancement_fierce', level: 2 }, // 凶猛
-          { name: 'item_enhancement_dominant', level: 2 }, // 专横
-          { name: 'item_enhancement_restorative', level: 2 }, // 滋补
-          { name: 'item_enhancement_thick', level: 2 }, // 厚重
-        ],
+        enhancements: {
+          global: [
+            { name: 'item_enhancement_timeless', level: 2 }, // 永恒 负面时间技能增强
+            { name: 'item_enhancement_evolved', level: 3 }, // 进化 主属性
+            { name: 'item_enhancement_fleetfooted', level: 1 }, // 捷足 移速
+            { name: 'item_enhancement_vampiric', level: 4 }, // 吸血鬼 双吸血
+            { name: 'item_enhancement_titanic', level: 4 }, // 巨神 基础攻击状态抗性 -攻击速度
+            { name: 'item_enhancement_crude', level: 4 }, // 粗暴 减速抗性攻击间隔 -智力
+            { name: 'item_enhancement_boundless', level: 2 }, // 无边 攻击距离施法距离
+            { name: 'item_enhancement_fierce', level: 2 }, // 凶猛
+            { name: 'item_enhancement_dominant', level: 2 }, // 专横
+            { name: 'item_enhancement_restorative', level: 2 }, // 滋补
+            { name: 'item_enhancement_thick', level: 2 }, // 厚重
+            { name: 'item_mysterious_hat', level: 2 }, // 仙灵饰品
+            { name: 'item_spell_prism', level: 1 }, // 法术棱镜
+            { name: 'item_paladin_sword', level: 1 }, // 骑士剑
+          ],
+          strength: [{ name: 'item_enhancement_hulking', level: 1 }], // 笨重
+          agility: [{ name: 'item_enhancement_audacious', level: 1 }], // 冒险
+          intelligence: [{ name: 'item_enhancement_feverish', level: 1 }], // 狂热
+          universal: [{ name: 'item_enhancement_manic', level: 1 }], // 癫狂
+        },
       },
     };
+  }
+
+  private static GetEnhancementPoolForHero(
+    pools: NeutralTierEnhancementPools,
+    hero: CDOTA_BaseNPC_Hero,
+  ): NeutralItemConfig[] {
+    const primary = hero.GetPrimaryAttribute();
+    switch (primary) {
+      case Attributes.STRENGTH:
+        return pools.strength;
+      case Attributes.AGILITY:
+        return pools.agility;
+      case Attributes.INTELLECT:
+        return pools.intelligence;
+      case Attributes.ALL:
+        return pools.universal;
+      default:
+        return pools.universal;
+    }
   }
 
   // 获取当前tier
@@ -228,15 +328,21 @@ export class NeutralItemManager {
     return this.SelectRandomItem(items);
   }
 
-  // 获取指定tier的增强名
+  // global 池 + 英雄主属性对应池，再加权随机
   public static GetRandomTierEnhancements(
     tier: number,
     neutralItemConfig: Record<number, NeutralTierConfig>,
+    hero: CDOTA_BaseNPC_Hero,
   ): NeutralItemConfig | undefined {
-    const enhancements = neutralItemConfig[tier]?.enhancements || [];
-    if (enhancements.length === 0) return undefined;
+    const tierCfg = neutralItemConfig[tier];
+    if (!tierCfg) return undefined;
 
-    return this.SelectRandomItem(enhancements);
+    const pools = tierCfg.enhancements;
+    const primaryPool = this.GetEnhancementPoolForHero(pools, hero);
+    const combined = [...pools.global, ...primaryPool];
+    if (combined.length === 0) return undefined;
+
+    return this.SelectRandomItem(combined);
   }
 
   // 根据权重随机选择物品


### PR DESCRIPTION
## Issue

- [x] fix #1958

## Checklist

- [x] `npm run build:vscripts` passes.
- [x] In-game: bot receives neutral trinket + enhancement matching tier; enhancement respects hero primary attribute pool + global pool.

## Release Note

```
[b]游戏性更新 v5.19a[/b]

- 修正电脑中立物品出装以匹配Dota2 7.41版本。
- 修正龙骑士「龙族血统」在技能抽选时的BUG。
- 微调中立物品数值。
```

```
[b]Gameplay update v5.19a[/b]

- Updated bot neutral item build to sync dota2 7.41.
- Fixed Dragon Knight's Dragon Blood bug in the ability draft pool.
- Slightly adjusted neutral item balance.
```
