### PR TITLE
Add mid only mode

### DIFF
--- a/content/panorama/layout/custom_game/custom_loading_screen.xml
+++ b/content/panorama/layout/custom_game/custom_loading_screen.xml
@@ -159,6 +159,11 @@
 						<Label id="PlayerAttributeTitle" class="GameOptionsLabel" text="#enable_player_attribute" />
 						<ToggleButton checked="true" class="GameOptionsToggle" id="enable_player_attribute" onactivate="SendGameOptionsToServer()"/>
 					</Panel>
+					<!-- 中路乱斗模式 -->
+					<Panel id="MidOnlyModePanel" class="GameOptionsSubPanel">
+						<Label id="MidOnlyModeTitle" class="GameOptionsLabel" text="#mid_only_mode" />
+						<ToggleButton checked="false" class="GameOptionsToggle" id="mid_only_mode" onactivate="SendGameOptionsToServer()"/>
+					</Panel>
 				</Panel>
 			</Panel>
 			<!-- 游戏选项显示 START-->

--- a/content/panorama/scripts/custom_game/game_mode.js
+++ b/content/panorama/scripts/custom_game/game_mode.js
@@ -69,6 +69,7 @@ function ShowChatTeamActivate() {
 function InitCustomSetting() {
   $('#force_random_hero').checked = false; // 默认不强制随机
   $('#enable_player_attribute').checked = true;
+  $('#mid_only_mode').checked = false;
   $('#player_gold_xp_multiplier_dropdown').SetSelected('1.5');
   $('#bot_gold_xp_multiplier_dropdown').SetSelected('10');
   $('#radiant_player_number_dropdown').SetSelected('1');
@@ -109,6 +110,7 @@ function LockOption() {
   $('#fixed_ability_dropdown').enabled = false;
   $('#force_random_hero').enabled = false;
   $('#enable_player_attribute').enabled = false;
+  $('#mid_only_mode').enabled = false;
 }
 
 function UnLockOptionAll() {
@@ -126,6 +128,7 @@ function UnLockOptionAll() {
   $('#fixed_ability_dropdown').enabled = true;
   $('#force_random_hero').enabled = true;
   $('#enable_player_attribute').enabled = true;
+  $('#mid_only_mode').enabled = true;
 }
 
 // N1-N6 通用设置
@@ -139,6 +142,7 @@ function InitDifficultyCommonSetting() {
   $('#fixed_ability_dropdown').SetSelected('none');
   $('#force_random_hero').checked = false;
   $('#enable_player_attribute').checked = true;
+  $('#mid_only_mode').checked = false;
 }
 
 function InitN1Setting() {
@@ -250,6 +254,7 @@ function SendGameOptionsToServer() {
   const fixedAbility = $('#fixed_ability_dropdown').GetSelected().id;
   const forceRandomHero = $('#force_random_hero').checked;
   const enablePlayerAttribute = $('#enable_player_attribute').checked;
+  const midOnlyMode = $('#mid_only_mode').checked;
 
   GameEvents.SendCustomGameEventToServer('game_options_change', {
     multiplier_radiant: Number(playerGoldXpMultiplier),
@@ -264,6 +269,7 @@ function SendGameOptionsToServer() {
     fixed_ability: fixedAbility,
     force_random_hero: forceRandomHero,
     enable_player_attribute: enablePlayerAttribute,
+    mid_only_mode: midOnlyMode,
   });
 }
 

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -42,6 +42,7 @@
 		"fixed_ability"				"Fixed Ability"
 		"force_random_hero"			"Force Random Hero"
 		"enable_player_attribute"	"Enable Player Attribute"
+		"mid_only_mode"				"Mid Only Mode"
 		"hide_chat_team"			"Hide Chat and Team"
 		"show_chat_team"			"Show Chat and Team"
 

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -42,6 +42,7 @@
 		"fixed_ability"				"固定技能"
 		"force_random_hero"			"强制随机英雄"
 		"enable_player_attribute"	"启用玩家属性"
+		"mid_only_mode"				"中路乱斗模式"
 		"hide_chat_team"			"隐藏聊天框"
 		"show_chat_team"			"显示聊天框"
 

--- a/game/scripts/vscripts/bot/bot_think_modifier.lua
+++ b/game/scripts/vscripts/bot/bot_think_modifier.lua
@@ -99,7 +99,7 @@ function modifier_bot_think_ward:OnCreated()
 	if IsClient() then return end
 	if not self then return end
 	local interval = 120
-	if AIGameMode.DebugMode then interval = 30 end
+	-- if AIGameMode.DebugMode then interval = 30 end
 	self:StartIntervalThink(interval)
 end
 

--- a/src/common/events.d.ts
+++ b/src/common/events.d.ts
@@ -45,6 +45,7 @@ interface GameOptionsChangeEventData {
   fixed_ability: string;
   force_random_hero: number;
   enable_player_attribute: number;
+  mid_only_mode: number;
 }
 
 interface LoadingSetOptionsEventData {

--- a/src/common/net_tables.d.ts
+++ b/src/common/net_tables.d.ts
@@ -96,4 +96,5 @@ export interface GameOptions {
   max_level: number;
   force_random_hero: number;
   enable_player_attribute: number;
+  mid_only_mode: number;
 }

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -33,10 +33,7 @@ export class BotBaseAIModifier extends BaseModifier {
   protected readonly NotAttactTowerHeroAttackRangeBuff: number = 400;
   protected readonly CastRange: number = 900;
 
-  // 中路模式缩短一半（与 BotTeam.botPushLevel 保持一致的逻辑）
-  public get PushLevel(): number {
-    return GameRules.Option.midOnlyMode ? 5 : 10;
-  }
+  public PushLevel: number = 10;
 
   protected hero: CDOTA_BaseNPC_Hero;
   public GetHero(): CDOTA_BaseNPC_Hero {
@@ -80,6 +77,11 @@ export class BotBaseAIModifier extends BaseModifier {
   Init() {
     this.hero = this.GetParent() as CDOTA_BaseNPC_Hero;
     print(`[AI] HeroBase OnCreated ${this.hero.GetUnitName()}`);
+
+    // 中路模式：推进所需等级缩短一半
+    if (GameRules.Option.midOnlyMode) {
+      this.PushLevel = Math.floor(this.PushLevel / 2);
+    }
 
     // 初始化出装状态
     // FIXME 待所有英雄使用新出装系统后删除

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -33,7 +33,10 @@ export class BotBaseAIModifier extends BaseModifier {
   protected readonly NotAttactTowerHeroAttackRangeBuff: number = 400;
   protected readonly CastRange: number = 900;
 
-  public readonly PushLevel: number = 10;
+  // 中路模式缩短一半（与 BotTeam.botPushLevel 保持一致的逻辑）
+  public get PushLevel(): number {
+    return GameRules.Option.midOnlyMode ? 5 : 10;
+  }
 
   protected hero: CDOTA_BaseNPC_Hero;
   public GetHero(): CDOTA_BaseNPC_Hero {

--- a/src/vscripts/ai/team/bot-team.ts
+++ b/src/vscripts/ai/team/bot-team.ts
@@ -114,28 +114,57 @@ export class BotTeam {
 
   /**
    * 根据防御塔状态计算推进层级
-   * @returns 推进层级
+   * 中路模式与普通模式阈值不同，分开处理
    */
   private calculatePushTierByTowerStatus(): number {
-    // 优先检查兵营状态（优先级更高）
+    if (GameRules.Option.midOnlyMode) {
+      return this.calculatePushTierMidOnly();
+    }
+    return this.calculatePushTierNormal();
+  }
+
+  /**
+   * 普通模式推进层级计算
+   * 每队每层有3座塔（上中下），阈值>=2表示超过一半路被推
+   */
+  private calculatePushTierNormal(): number {
+    // 优先检查兵营状态
     if (TowerPushStatus.barrackPushedGood > 5 || TowerPushStatus.barrackPushedBad > 5) {
       return -1; // 无限制推进
     } else if (TowerPushStatus.barrackPushedGood > 2 || TowerPushStatus.barrackPushedBad > 2) {
       return 5;
     }
 
-    // 检查三塔状态
     if (TowerPushStatus.tower3PushedGood >= 2 || TowerPushStatus.tower3PushedBad >= 2) {
       return 4;
     }
-
-    // 检查二塔状态
     if (TowerPushStatus.tower2PushedGood >= 2 || TowerPushStatus.tower2PushedBad >= 2) {
       return 3;
     }
-
-    // 检查一塔状态
     if (TowerPushStatus.tower1PushedGood >= 2 || TowerPushStatus.tower1PushedBad >= 2) {
+      return 2;
+    }
+
+    return 1;
+  }
+
+  /**
+   * 中路模式推进层级计算
+   * 每队每层只有1座塔（mid），阈值>=1即升层
+   */
+  private calculatePushTierMidOnly(): number {
+    // 优先检查兵营状态
+    if (TowerPushStatus.barrackPushedGood >= 1 || TowerPushStatus.barrackPushedBad >= 1) {
+      return -1; // 无限制推进
+    }
+
+    if (TowerPushStatus.tower3PushedGood >= 1 || TowerPushStatus.tower3PushedBad >= 1) {
+      return 4;
+    }
+    if (TowerPushStatus.tower2PushedGood >= 1 || TowerPushStatus.tower2PushedBad >= 1) {
+      return 3;
+    }
+    if (TowerPushStatus.tower1PushedGood >= 1 || TowerPushStatus.tower1PushedBad >= 1) {
       return 2;
     }
 

--- a/src/vscripts/ai/team/bot-team.ts
+++ b/src/vscripts/ai/team/bot-team.ts
@@ -63,8 +63,13 @@ export class BotTeam {
     print(`[BotTeam] Base bot push min: ${this.baseBotPushMin}`);
 
     // 根据难度计算电脑推进等级
-    const randomLevel = RandomInt(0, 2); // 随机额外增等级
-    this.botPushLevel = this.getTowerRequiredLevel() + randomLevel;
+    // 中路模式：仅需6级即开始推进（只有一条中路，更早推进）
+    if (GameRules.Option.midOnlyMode) {
+      this.botPushLevel = 6;
+    } else {
+      const randomLevel = RandomInt(0, 2); // 随机额外增等级
+      this.botPushLevel = this.getTowerRequiredLevel() + randomLevel;
+    }
     print(`[BotTeam] Bot push level: ${this.botPushLevel}`);
   }
 

--- a/src/vscripts/ai/team/bot-team.ts
+++ b/src/vscripts/ai/team/bot-team.ts
@@ -63,12 +63,13 @@ export class BotTeam {
     print(`[BotTeam] Base bot push min: ${this.baseBotPushMin}`);
 
     // 根据难度计算电脑推进等级
-    // 中路模式：仅需6级即开始推进（只有一条中路，更早推进）
+    const randomLevel = RandomInt(0, 2); // 随机额外增等级
+    const requiredLevel = this.getTowerRequiredLevel();
+    // 中路模式：推进所需等级缩短一半（更早推进）
     if (GameRules.Option.midOnlyMode) {
-      this.botPushLevel = 6;
+      this.botPushLevel = Math.floor(requiredLevel / 2) + randomLevel;
     } else {
-      const randomLevel = RandomInt(0, 2); // 随机额外增等级
-      this.botPushLevel = this.getTowerRequiredLevel() + randomLevel;
+      this.botPushLevel = requiredLevel + randomLevel;
     }
     print(`[BotTeam] Bot push level: ${this.botPushLevel}`);
   }

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.20';
+  public static readonly GAME_VERSION = 'v5.21';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数

--- a/src/vscripts/modules/event/event-game-state-change.ts
+++ b/src/vscripts/modules/event/event-game-state-change.ts
@@ -306,11 +306,7 @@ export class EventGameStateChange {
       const steamId = PlayerResource.GetSteamAccountID(playerId);
       const playerLang = Analytics.PLAYER_LANGUAGES.players.find((p) => p.steamId === steamId);
       if (!playerLang) return;
-      if (
-        playerLang.language === 'schinese' ||
-        playerLang.language === 'tchinese' ||
-        playerLang.language === 'zh'
-      ) {
+      if (playerLang.language === 'schinese' || playerLang.language === 'tchinese') {
         hasChinese = true;
       } else {
         hasNonChinese = true;

--- a/src/vscripts/modules/event/event-game-state-change.ts
+++ b/src/vscripts/modules/event/event-game-state-change.ts
@@ -1,6 +1,7 @@
 import { InitializeItemUpgrades } from '../../ai/build-item/item-tier-config';
 import { FusionRuneManager } from '../../ai/item/fusion-rune-manager';
 import { BotTeam } from '../../ai/team/bot-team';
+import { Analytics } from '../../api/analytics/analytics';
 import { GA4 } from '../../api/analytics/ga4';
 import { Game } from '../../api/game';
 import { Ranking } from '../../api/ranking';
@@ -269,11 +270,7 @@ export class EventGameStateChange {
    */
   private applyMidOnlyMode(): void {
     print(`[EventGameStateChange] applyMidOnlyMode`);
-    GameRules.SendCustomMessage(
-      "<font color='#FFD700'>中路乱斗模式已启用：仅保留中路，Bot会更早推进</font>",
-      0,
-      0,
-    );
+    this.sendMidOnlyModeMessage();
 
     const towers = Entities.FindAllByClassname('npc_dota_tower') as CDOTA_BaseNPC[];
     for (const tower of towers) {
@@ -290,5 +287,27 @@ export class EventGameStateChange {
         barrack.ForceKill(false);
       }
     }
+  }
+
+  /**
+   * 根据玩家语言发送中路模式提示消息
+   */
+  private sendMidOnlyModeMessage(): void {
+    const msgChinese =
+      "<font color='#FFD700'>中路乱斗模式已启用：仅保留中路，小兵金钱经验×3</font>";
+    const msgEnglish =
+      "<font color='#FFD700'>Mid Only Mode enabled: only mid lane remains, creep gold/XP x3</font>";
+
+    PlayerHelper.ForEachPlayer((playerId) => {
+      const steamId = PlayerResource.GetSteamAccountID(playerId);
+      const playerLang = Analytics.PLAYER_LANGUAGES.players.find((p) => p.steamId === steamId);
+      const isChinese =
+        !playerLang ||
+        playerLang.language === 'schinese' ||
+        playerLang.language === 'tchinese' ||
+        playerLang.language === 'zh';
+      const msg = isChinese ? msgChinese : msgEnglish;
+      GameRules.SendCustomMessage(msg, playerId, 0);
+    });
   }
 }

--- a/src/vscripts/modules/event/event-game-state-change.ts
+++ b/src/vscripts/modules/event/event-game-state-change.ts
@@ -290,7 +290,8 @@ export class EventGameStateChange {
   }
 
   /**
-   * 根据玩家语言发送中路模式提示消息
+   * 根据所有玩家的语言，全局发送中路模式提示消息
+   * 中文玩家存在时发送一次中文，英文（非中文）玩家存在时发送一次英文
    */
   private sendMidOnlyModeMessage(): void {
     const msgChinese =
@@ -298,16 +299,29 @@ export class EventGameStateChange {
     const msgEnglish =
       "<font color='#FFD700'>Mid Only Mode enabled: only mid lane remains, creep gold/XP x3</font>";
 
+    let hasChinese = false;
+    let hasNonChinese = false;
+
     PlayerHelper.ForEachPlayer((playerId) => {
       const steamId = PlayerResource.GetSteamAccountID(playerId);
       const playerLang = Analytics.PLAYER_LANGUAGES.players.find((p) => p.steamId === steamId);
-      const isChinese =
-        !playerLang ||
+      if (!playerLang) return;
+      if (
         playerLang.language === 'schinese' ||
         playerLang.language === 'tchinese' ||
-        playerLang.language === 'zh';
-      const msg = isChinese ? msgChinese : msgEnglish;
-      GameRules.SendCustomMessage(msg, playerId, 0);
+        playerLang.language === 'zh'
+      ) {
+        hasChinese = true;
+      } else {
+        hasNonChinese = true;
+      }
     });
+
+    if (hasChinese) {
+      GameRules.SendCustomMessage(msgChinese, 0, 0);
+    }
+    if (hasNonChinese) {
+      GameRules.SendCustomMessage(msgEnglish, 0, 0);
+    }
   }
 }

--- a/src/vscripts/modules/event/event-game-state-change.ts
+++ b/src/vscripts/modules/event/event-game-state-change.ts
@@ -67,6 +67,11 @@ export class EventGameStateChange {
     // 初始化游戏
     print(`[EventGameStateChange] OnPreGame`);
 
+    // 中路模式：移除上下路建筑
+    if (GameRules.Option.midOnlyMode) {
+      this.applyMidOnlyMode();
+    }
+
     // 初始化小兵buff管理器
     new CreepBuffManager();
 
@@ -257,5 +262,33 @@ export class EventGameStateChange {
       return 10;
     }
     return 10;
+  }
+
+  /**
+   * 中路模式：移除上路和下路的防御塔和兵营
+   */
+  private applyMidOnlyMode(): void {
+    print(`[EventGameStateChange] applyMidOnlyMode`);
+    GameRules.SendCustomMessage(
+      "<font color='#FFD700'>中路乱斗模式已启用：仅保留中路，Bot会更早推进</font>",
+      0,
+      0,
+    );
+
+    const towers = Entities.FindAllByClassname('npc_dota_tower') as CDOTA_BaseNPC[];
+    for (const tower of towers) {
+      const unitName = tower.GetUnitName();
+      if (unitName.includes('top') || unitName.includes('bot')) {
+        tower.ForceKill(false);
+      }
+    }
+
+    const barracks = Entities.FindAllByClassname('npc_dota_barracks') as CDOTA_BaseNPC[];
+    for (const barrack of barracks) {
+      const unitName = barrack.GetUnitName();
+      if (unitName.includes('top') || unitName.includes('bot')) {
+        barrack.ForceKill(false);
+      }
+    }
   }
 }

--- a/src/vscripts/modules/event/event-game-state-change.ts
+++ b/src/vscripts/modules/event/event-game-state-change.ts
@@ -1,7 +1,6 @@
 import { InitializeItemUpgrades } from '../../ai/build-item/item-tier-config';
 import { FusionRuneManager } from '../../ai/item/fusion-rune-manager';
 import { BotTeam } from '../../ai/team/bot-team';
-import { Analytics } from '../../api/analytics/analytics';
 import { GA4 } from '../../api/analytics/ga4';
 import { Game } from '../../api/game';
 import { Ranking } from '../../api/ranking';
@@ -12,6 +11,7 @@ import { PlayerHelper } from '../helper/player-helper';
 import { HeroBuyback } from '../hero/hero-buyback';
 import { HeroPick } from '../hero/hero-pick';
 import { CreepBuffManager } from './game-in-progress/creep-buff-manager';
+import { MidOnlyMode } from './pre-game/mid-only-mode';
 
 export class EventGameStateChange {
   constructor() {
@@ -70,7 +70,7 @@ export class EventGameStateChange {
 
     // 中路模式：移除上下路建筑
     if (GameRules.Option.midOnlyMode) {
-      this.applyMidOnlyMode();
+      MidOnlyMode.Apply();
     }
 
     // 初始化小兵buff管理器
@@ -265,59 +265,4 @@ export class EventGameStateChange {
     return 10;
   }
 
-  /**
-   * 中路模式：移除上路和下路的防御塔和兵营
-   */
-  private applyMidOnlyMode(): void {
-    print(`[EventGameStateChange] applyMidOnlyMode`);
-    this.sendMidOnlyModeMessage();
-
-    const towers = Entities.FindAllByClassname('npc_dota_tower') as CDOTA_BaseNPC[];
-    for (const tower of towers) {
-      const unitName = tower.GetUnitName();
-      if (unitName.includes('top') || unitName.includes('bot')) {
-        tower.ForceKill(false);
-      }
-    }
-
-    const barracks = Entities.FindAllByClassname('npc_dota_barracks') as CDOTA_BaseNPC[];
-    for (const barrack of barracks) {
-      const unitName = barrack.GetUnitName();
-      if (unitName.includes('top') || unitName.includes('bot')) {
-        barrack.ForceKill(false);
-      }
-    }
-  }
-
-  /**
-   * 根据所有玩家的语言，全局发送中路模式提示消息
-   * 中文玩家存在时发送一次中文，英文（非中文）玩家存在时发送一次英文
-   */
-  private sendMidOnlyModeMessage(): void {
-    const msgChinese =
-      "<font color='#FFD700'>中路乱斗模式已启用：仅保留中路，小兵金钱经验×3</font>";
-    const msgEnglish =
-      "<font color='#FFD700'>Mid Only Mode enabled: only mid lane remains, creep gold/XP x3</font>";
-
-    let hasChinese = false;
-    let hasNonChinese = false;
-
-    PlayerHelper.ForEachPlayer((playerId) => {
-      const steamId = PlayerResource.GetSteamAccountID(playerId);
-      const playerLang = Analytics.PLAYER_LANGUAGES.players.find((p) => p.steamId === steamId);
-      if (!playerLang) return;
-      if (playerLang.language === 'schinese' || playerLang.language === 'tchinese') {
-        hasChinese = true;
-      } else {
-        hasNonChinese = true;
-      }
-    });
-
-    if (hasChinese) {
-      GameRules.SendCustomMessage(msgChinese, 0, 0);
-    }
-    if (hasNonChinese) {
-      GameRules.SendCustomMessage(msgEnglish, 0, 0);
-    }
-  }
 }

--- a/src/vscripts/modules/event/event-game-state-change.ts
+++ b/src/vscripts/modules/event/event-game-state-change.ts
@@ -264,5 +264,4 @@ export class EventGameStateChange {
     }
     return 10;
   }
-
 }

--- a/src/vscripts/modules/event/game-end/game-end-point.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.ts
@@ -139,6 +139,10 @@ export class GameEndPoint {
     if (option.fixedAbility !== 'none') {
       multiplier -= 0.2;
     }
+    // 中路模式，降低倍率
+    if (option.midOnlyMode) {
+      multiplier -= 0.2;
+    }
 
     // ---- 以上使用加减法计算倍率 ----
 

--- a/src/vscripts/modules/event/game-in-progress/creep-buff-manager.ts
+++ b/src/vscripts/modules/event/game-in-progress/creep-buff-manager.ts
@@ -7,6 +7,13 @@ import { TowerPushStatus } from '../event-entity-killed';
  */
 @reloadable
 export class CreepBuffManager {
+  /**
+   * 中路模式：小兵金钱经验加倍
+   */
+  private readonly MID_ONLY_MODE_CREEP_BOUNTY_MULTIPLIER = 3;
+  /**
+   * 当前小兵buff等级
+   */
   private currentBuffLevels = {
     buffLevelGood: 0,
     buffLevelBad: 0,
@@ -51,10 +58,14 @@ export class CreepBuffManager {
           entity.ForceKill(false);
           return;
         }
-        // 中路小兵金钱经验3倍
-        entity.SetMaximumGoldBounty(entity.GetMaximumGoldBounty() * 3);
-        entity.SetMinimumGoldBounty(entity.GetMinimumGoldBounty() * 3);
-        entity.SetDeathXP(entity.GetDeathXP() * 3);
+        // 中路小兵金钱经验加倍
+        entity.SetMaximumGoldBounty(
+          entity.GetMaximumGoldBounty() * this.MID_ONLY_MODE_CREEP_BOUNTY_MULTIPLIER,
+        );
+        entity.SetMinimumGoldBounty(
+          entity.GetMinimumGoldBounty() * this.MID_ONLY_MODE_CREEP_BOUNTY_MULTIPLIER,
+        );
+        entity.SetDeathXP(entity.GetDeathXP() * this.MID_ONLY_MODE_CREEP_BOUNTY_MULTIPLIER);
       }
       this.applyCreepBuff(entity);
     }

--- a/src/vscripts/modules/event/game-in-progress/creep-buff-manager.ts
+++ b/src/vscripts/modules/event/game-in-progress/creep-buff-manager.ts
@@ -44,8 +44,37 @@ export class CreepBuffManager {
     const name = entity.GetName();
     // 检查是否为小兵或攻城单位
     if (name === 'npc_dota_creep_lane' || name === 'npc_dota_creep_siege') {
+      // 中路模式：只保留中路小兵
+      if (GameRules.Option.midOnlyMode) {
+        const lane = this.getCreepLane(entity.GetAbsOrigin());
+        if (lane !== 'mid') {
+          entity.ForceKill(false);
+          return;
+        }
+        // 中路小兵金钱经验3倍
+        entity.SetMaximumGoldBounty(entity.GetMaximumGoldBounty() * 3);
+        entity.SetMinimumGoldBounty(entity.GetMinimumGoldBounty() * 3);
+        entity.SetDeathXP(entity.GetDeathXP() * 3);
+      }
       this.applyCreepBuff(entity);
     }
+  }
+
+  /**
+   * 根据坐标判断小兵所在路线 中路模式专用
+   */
+  private getCreepLane(position: Vector): 'mid' | 'top' | 'bot' | 'unknown' {
+    const x = position.x;
+    const y = position.y;
+    const diff = Math.abs(Math.abs(x) - Math.abs(y));
+    if (diff < 1500) {
+      return 'mid';
+    } else if (x > 0 && y < 0) {
+      return 'bot';
+    } else if (x < 0 && y > 0) {
+      return 'top';
+    }
+    return 'unknown';
   }
 
   private applyCreepBuff(creep: CDOTA_BaseNPC): void {

--- a/src/vscripts/modules/event/pre-game/mid-only-mode.ts
+++ b/src/vscripts/modules/event/pre-game/mid-only-mode.ts
@@ -1,0 +1,66 @@
+import { Analytics } from '../../../api/analytics/analytics';
+import { PlayerHelper } from '../../helper/player-helper';
+
+/**
+ * 中路乱斗模式
+ * PRE_GAME 阶段：移除上下路防御塔和兵营，并广播提示消息
+ */
+export class MidOnlyMode {
+  static Apply(): void {
+    print(`[MidOnlyMode] Apply`);
+    this.removeTopBotBuildings();
+    this.sendMessage();
+  }
+
+  /**
+   * 移除上路和下路的防御塔与兵营
+   */
+  private static removeTopBotBuildings(): void {
+    const towers = Entities.FindAllByClassname('npc_dota_tower') as CDOTA_BaseNPC[];
+    for (const tower of towers) {
+      const unitName = tower.GetUnitName();
+      if (unitName.includes('top') || unitName.includes('bot')) {
+        tower.ForceKill(false);
+      }
+    }
+
+    const barracks = Entities.FindAllByClassname('npc_dota_barracks') as CDOTA_BaseNPC[];
+    for (const barrack of barracks) {
+      const unitName = barrack.GetUnitName();
+      if (unitName.includes('top') || unitName.includes('bot')) {
+        barrack.ForceKill(false);
+      }
+    }
+  }
+
+  /**
+   * 遍历所有玩家语言，中文玩家存在时发送一次中文，非中文玩家存在时发送一次英文
+   */
+  private static sendMessage(): void {
+    const msgChinese =
+      "<font color='#FFD700'>中路乱斗模式已启用：仅保留中路，小兵金钱经验更多</font>";
+    const msgEnglish =
+      "<font color='#FFD700'>Mid Only Mode enabled: only mid lane remains, creep gold/XP increased</font>";
+
+    let hasChinese = false;
+    let hasNonChinese = false;
+
+    PlayerHelper.ForEachPlayer((playerId) => {
+      const steamId = PlayerResource.GetSteamAccountID(playerId);
+      const playerLang = Analytics.PLAYER_LANGUAGES.players.find((p) => p.steamId === steamId);
+      if (!playerLang) return;
+      if (playerLang.language === 'schinese' || playerLang.language === 'tchinese') {
+        hasChinese = true;
+      } else {
+        hasNonChinese = true;
+      }
+    });
+
+    if (hasChinese) {
+      GameRules.SendCustomMessage(msgChinese, 0, 0);
+    }
+    if (hasNonChinese) {
+      GameRules.SendCustomMessage(msgEnglish, 0, 0);
+    }
+  }
+}

--- a/src/vscripts/modules/filter/gold-xp-filter.test.ts
+++ b/src/vscripts/modules/filter/gold-xp-filter.test.ts
@@ -22,10 +22,9 @@ describe('GoldFilter', () => {
     });
 
     it('should reduce the multiplier correctly when it is greater than 1', () => {
-      expect(goldFilter.filterHeroKillGoldByMultiplier(1.5)).toBe(1.2);
-      expect(goldFilter.filterHeroKillGoldByMultiplier(2)).toBe(1.4);
-      expect(goldFilter.filterHeroKillGoldByMultiplier(6)).toBe(3);
-      expect(goldFilter.filterHeroKillGoldByMultiplier(10)).toBeCloseTo(4.6, 1);
+      expect(goldFilter.filterHeroKillGoldByMultiplier(1.5)).toBe(1.25);
+      expect(goldFilter.filterHeroKillGoldByMultiplier(2)).toBe(1.5);
+      expect(goldFilter.filterHeroKillGoldByMultiplier(10)).toBeCloseTo(5.5, 1);
     });
   });
 

--- a/src/vscripts/modules/filter/gold-xp-filter.ts
+++ b/src/vscripts/modules/filter/gold-xp-filter.ts
@@ -3,9 +3,9 @@ import { PlayerHelper } from '../helper/player-helper';
 
 @reloadable
 export class GoldXPFilter {
-  private readonly REDUCE_RATE_3_MIN = 0.4;
-  private readonly REDUCE_RATE_6_MIN = 0.7;
-  private readonly REDUCE_RATE_HERO_KILL = 0.4;
+  private readonly REDUCE_RATE_3_MIN = 0.5;
+  private readonly REDUCE_RATE_6_MIN = 0.75;
+  private readonly REDUCE_RATE_HERO_KILL = 0.5;
 
   constructor() {
     GameRules.GetGameModeEntity().SetModifyGoldFilter((args) => this.filterGold(args), this);

--- a/src/vscripts/modules/option.ts
+++ b/src/vscripts/modules/option.ts
@@ -18,6 +18,7 @@ export class Option {
   enablePlayerAttribute = true;
 
   gameDifficulty = 0;
+  midOnlyMode = false;
 
   constructor() {
     CustomGameEventManager.RegisterListener('game_options_change', (_, keys) => {
@@ -46,6 +47,7 @@ export class Option {
     this.fixedAbility = keys.fixed_ability;
     this.forceRandomHero = keys.force_random_hero === 1;
     this.enablePlayerAttribute = keys.enable_player_attribute === 1;
+    this.midOnlyMode = keys.mid_only_mode === 1;
     CustomNetTables.SetTableValue('game_options', 'game_options', keys);
     CustomNetTables.SetTableValue('game_options', 'point_multiplier', {
       point_multiplier: GameEndPoint.GetDifficultyMultiplier(


### PR DESCRIPTION
## Issue

- [x] fix #1918

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.21[/b]

- 新增中路乱斗模式：仅保留中路，上下路防御塔和兵营被移除，中路小兵金钱经验×3。
- 中路乱斗模式积分倍率降低0.2。
```

```
[b]Gameplay update v5.21[/b]

- Added Mid Only Mode: only mid lane remains, top/bot towers and barracks are removed, mid creep gold/XP tripled.
- Mid Only Mode reduces point multiplier by 0.2.
```
