### PR TITLE
抽选技能添加更多先天技能

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -212,24 +212,45 @@ CustomGameEventManager.RegisterListener("lottery_pick_ability", (userId, event) 
 - **Webpack 缓存**: 如果构建输出看起来过时,删除 `node_modules/.cache`
 - **行尾符**: TypeScript 文件使用 LF (Unix) 而不是 CRLF (Windows)
 
-### 读取 Dota 2 官方说明:
+### Dota 2 参考文件速查
+
+`<version>` 取 `docs/reference/` 下最新数字版本目录。
+
+| 用途 | 路径 |
+|------|------|
+| 原版技能（合并本） | `docs/reference/<version>/npc_abilities.txt` |
+| 原版技能（按英雄） | `docs/reference/<version>/heroes/npc_dota_hero_<hero>.txt` |
+| 英雄列表及技能槽位 | `docs/reference/<version>/npc_heroes.txt` |
+| 原版英文说明 | `docs/reference/<version>/abilities_english.txt` |
+| 原版中文说明 | `docs/reference/<version>/abilities_schinese.txt` |
+| Override KV | `game/scripts/npc/npc_abilities_override.txt` |
+| 抽奖技能 KV | `game/scripts/npc/npc_abilities_custom_lottery.txt` |
+| 单位/英雄专属技能 KV | `game/scripts/npc/npc_abilities_custom.txt` |
+| addon 英文本地化 | `game/resource/addon_english.txt` |
+| addon 简体中文本地化 | `game/resource/addon_schinese.txt` |
+
+#### 技能系统名查找
+
+用户给出**技能系统名**（如 `dragon_knight_dragon_blood`）时直接使用。
+
+用户给出**中文名**（如「龙血」「幻影之矛」）或**英雄名-技能名**（如「幻影刺客-幻影之矛」）时：
+1. 在 `abilities_schinese.txt` 中搜索中文技能名（匹配 `_Description` 行的上一行或 Tooltip 名称行）
+2. 提取匹配行的 key 中的技能系统名（`DOTA_Tooltip_ability_{系统名}` → `{系统名}`）
+3. 如有多个候选，用 `AskUserQuestion` 展示候选项让用户确认
+
+用户给出**英雄名**时，在 `npc_heroes.txt` 中用中/英文关键词搜索英雄 ID，再从对应英雄文件读取技能槽位。
+
+#### 读取 Dota 2 官方说明
 
 编写物品/技能说明时，应参考 Dota 2 官方文本以保持术语一致性。
-最新版本号：`docs/reference/` 目录下获取。
-
-**参考文件位置**:
-
-- 中文: `docs/reference/<version>/abilities_schinese.txt`
-- 英文: `docs/reference/<version>/abilities_english.txt`
-
-**使用方法**:
 
 ```bash
-# 搜索狂战斧的中文说明
-grep -A 5 "DOTA_Tooltip_ability_item_bfury_Description" docs/reference/<version>/abilities_schinese.txt
+# 搜索技能中文说明（先用中文名定位系统名）
+grep "龙血" docs/reference/<version>/abilities_schinese.txt
+grep "DOTA_Tooltip_ability_dragon_knight_dragon_blood" docs/reference/<version>/abilities_schinese.txt
 
-# 搜索狂战斧的英文说明
-grep -A 5 "DOTA_Tooltip_ability_item_bfury_Description" docs/reference/<version>/abilities_english.txt
+# 搜索英文说明
+grep "DOTA_Tooltip_ability_dragon_knight_dragon_blood" docs/reference/<version>/abilities_english.txt
 ```
 
 ### 查阅 Dota 2 VScript / 引擎 Lua API（函数签名、参数）

--- a/.claude/skills/custom-ability-lottery/SKILL.md
+++ b/.claude/skills/custom-ability-lottery/SKILL.md
@@ -1,23 +1,30 @@
 ---
-name: clone-ability
+name: custom-ability-lottery
 description: >-
   Create or fix a custom KV ability that inherits from a vanilla Dota ability
-  (BaseClass = original ability name). Handles both innate and regular source
-  abilities. Stops and asks for manual handling if BaseClass is ability_lua or
-  ability_datadriven. Uses interactive menus for ambiguous decisions.
+  (BaseClass = original ability name). Supports ability lookup by Chinese name
+  or hero-ability format. Merges vanilla KV with override extras. Syncs keys
+  on update. Handles innate and regular abilities. Interactive menus for
+  ambiguous decisions.
 ---
 
 # 自定义继承技能（新建 / 修正）
 
 将原版 Dota 技能（先天或普通）克隆为自定义技能名，写入本图 KV 并补全本地化。
 
+> 参考文件路径及技能系统名查找规则见 CLAUDE.md「Dota 2 参考文件速查」章节。
+
 ---
 
-## 第一步：前置交互（不明确时用菜单询问）
+## 第一步：解析技能输入
 
-**遇到任何不确定的情况，必须通过 `AskUserQuestion` 工具以选项菜单询问，不得自行假设。**
+按 CLAUDE.md「技能系统名查找」规则处理（支持系统名 / 中文名 / 英雄名-技能名）。
 
-### 1-A 目标文件（用户未指定时询问）
+---
+
+## 第二步：前置交互
+
+### 2-A 目标文件（用户未指定时询问）
 
 > 「请选择目标文件」
 
@@ -26,7 +33,7 @@ description: >-
 | 抽奖池技能 | `game/scripts/npc/npc_abilities_custom_lottery.txt` | 随机抽奖系统 |
 | 单位 / 英雄专属技能 | `game/scripts/npc/npc_abilities_custom.txt` | 特定单位或自定义英雄 |
 
-### 1-B 操作模式（用户未明确时询问）
+### 2-B 操作模式（用户未明确时询问）
 
 > 「请选择操作」
 
@@ -37,9 +44,9 @@ description: >-
 
 ---
 
-## 第二步：BaseClass 类型检查
+## 第三步：BaseClass 类型检查
 
-读取**目标技能块**（新建时读用户指定的原版名；修正时读现有块）的 `BaseClass`：
+读取**目标技能块**（新建时读原版名；修正时读现有块）的 `BaseClass`：
 
 | BaseClass 值 | 处理 |
 |---|---|
@@ -49,11 +56,25 @@ description: >-
 
 ---
 
-## 第三步：识别原版技能类型
+## 第四步：读取原版 KV 与 Override 合并
 
-在 `docs/reference/<版本>/heroes/npc_dota_hero_<英雄>.txt`（或合并本 `npc_abilities.txt`）中定位原版技能块，判断：
+**新建技能**时，KV 基础来源 = 原版 + Override 叠加：
 
-| 原版字段 | 判定结果 |
+1. 从 `docs/reference/<version>/npc_abilities.txt`（或对应英雄文件）读取原版技能块
+2. 在 `game/scripts/npc/npc_abilities_override.txt` 中查找同名技能块：
+   - 若存在，将 override 中的**额外设定**（与原版不同的键/值）叠加到原版上
+   - Override 中存在而原版没有的键（标注 `// 原版不存在，手动修改`）也需复制
+3. 合并结果作为新自定义技能的初始 KV
+
+**修正现有技能**时，跳过此步，直接进入第六步 K 键同步。
+
+---
+
+## 第五步：识别原版技能类型
+
+在合并后的 KV 中判断：
+
+| 字段 | 判定结果 |
 |----------|---------|
 | `"Innate" "1"` | **先天技能**，走 A 流程 |
 | `"Innate" "0"` 或无 Innate 字段 | **普通技能**，走 B 流程 |
@@ -61,11 +82,11 @@ description: >-
 
 ---
 
-## 第四步：KV 处理
+## 第六步：KV 处理
 
 ### 流程 A — 先天技能（原版 Innate "1"）
 
-1. 复制原版块结构，使用新 key（如 `xxx2`）写入目标文件。
+1. 以第四步合并结果为基础，使用新 key（如 `xxx2`）写入目标文件。
 2. `"BaseClass"` → 填原版技能名。
 3. `"Innate"` → 改为 `"0"`（**必须**，否则引擎仍按先天处理）。
 4. `"AbilityBehavior"` → 去掉 `DOTA_ABILITY_BEHAVIOR_HIDDEN`；抽奖用被动时改为 `"DOTA_ABILITY_BEHAVIOR_PASSIVE"`；保留主动/开关时按原版行为裁剪，确保无 `NOT_LEARNABLE` 等阻止显示的标志。
@@ -75,7 +96,7 @@ description: >-
 
 ### 流程 B — 普通技能（原版 Innate "0" 或无）
 
-1. 复制原版块结构，使用新 key 写入目标文件。
+1. 以第四步合并结果为基础，使用新 key 写入目标文件。
 2. `"BaseClass"` → 填原版技能名。
 3. `"Innate"` → 无需写（普通技能默认即为 0）。
 4. `"AbilityBehavior"` → 按需保留原版行为；若用于抽奖且为主动技能，确认无需调整 behavior。
@@ -85,12 +106,25 @@ description: >-
 
 ---
 
-## 第五步：本地化
+## 第七步：修正模式 — K 键同步原版
 
-1. grep 原版技能名的所有 Tooltip 键：
+仅在**修正现有技能**时执行此步。规则与 `update-abilities-override` 的 P1 相同：
+
+1. 从 `docs/reference/<version>/npc_abilities.txt` 读取原版当前版本的完整键集合
+2. **删除**现有自定义块中已与原版**同值**的键（原版合并时会自动继承，无需重复写）
+3. **删除**原版已不存在的键（除非行尾明确注释 `// 原版不存在，手动修改`）
+4. **补充**原版新增但自定义块缺失的多档键（按 P2 差分/扩展规则填写）
+5. 结合 override 叠加逻辑：若原版键值已被 override 修改，同步使用 override 的值
+
+---
+
+## 第八步：本地化
+
+1. 用 Grep 工具搜索原版技能名的所有 Tooltip 键：
    ```
-   grep "DOTA_Tooltip_ability_<原版名>" docs/reference/<版本>/abilities_english.txt
-   grep "DOTA_Tooltip_ability_<原版名>" docs/reference/<版本>/abilities_schinese.txt
+   pattern: DOTA_Tooltip_ability_<原版名>
+   file: docs/reference/<version>/abilities_english.txt
+   file: docs/reference/<version>/abilities_schinese.txt
    ```
 2. 将键名中的原版技能名替换为自定义技能名，值保持与原版一致。
 3. 至少包含：`DOTA_Tooltip_ability_<name>`、`_Description`，以及说明中 `%变量名%` 对应的 `_<suffix>` 行。
@@ -105,23 +139,6 @@ description: >-
 
 ---
 
-## 仓库路径速查
-
-| 用途 | 路径 |
-|------|------|
-| 抽奖技能 KV | `game/scripts/npc/npc_abilities_custom_lottery.txt` |
-| 单位/英雄专属技能 KV | `game/scripts/npc/npc_abilities_custom.txt` |
-| 原版技能（按英雄） | `docs/reference/<版本>/heroes/npc_dota_hero_<英雄>.txt` |
-| 原版技能（合并本） | `docs/reference/<版本>/npc_abilities.txt` |
-| 原版英文说明 | `docs/reference/<版本>/abilities_english.txt` |
-| 原版中文说明 | `docs/reference/<版本>/abilities_schinese.txt` |
-| addon 英文 | `game/resource/addon_english.txt` |
-| addon 简体中文 | `game/resource/addon_schinese.txt` |
-| 抽奖池注册 | `src/vscripts/modules/lottery/lottery-abilities.ts` |
-| 本地化格式细则 | `.claude/skills/localization-format-guide/SKILL.md` |
-
-`<版本>`：取 `docs/reference/` 下最新数字版本目录。
-
 ## 参考范例
 
 `npc_abilities_custom_lottery.txt` 中 `dragon_knight_dragon_blood2`（先天→普通，流程 A）；本地化在 `addon_english.txt` / `addon_schinese.txt` 中检索同名。
@@ -130,10 +147,13 @@ description: >-
 
 ## 自检清单
 
+- [ ] 技能系统名已正确解析（中文/英雄名-技能名格式已转换）
 - [ ] BaseClass 为原版技能名（非 `ability_lua` / `ability_datadriven`）
+- [ ] 新建时已叠加 override 额外设定
 - [ ] 流程 A：`"Innate" "0"` 且 `AbilityBehavior` 无 `HIDDEN`
 - [ ] 流程 B：Innate 字段按需处理，Behavior 与原版一致
 - [ ] `AbilityValues` 所有覆盖项带 `//` 原版对照
 - [ ] `AbilityTextureName` 已填写
+- [ ] 修正模式：已按原版同步 K 键（删同值、删已废键、补新键）
 - [ ] `addon_english.txt` 与 `addon_schinese.txt` 键集合一致，占位符与原版一致
 - [ ] 若进抽奖池，已改 lottery TS 列表

--- a/.claude/skills/custom-ability-lottery/SKILL.md
+++ b/.claude/skills/custom-ability-lottery/SKILL.md
@@ -90,7 +90,12 @@ description: >-
 2. `"BaseClass"` → 填原版技能名。
 3. `"Innate"` → 改为 `"0"`（**必须**，否则引擎仍按先天处理）。
 4. `"AbilityBehavior"` → 去掉 `DOTA_ABILITY_BEHAVIOR_HIDDEN`；抽奖用被动时改为 `"DOTA_ABILITY_BEHAVIOR_PASSIVE"`；保留主动/开关时按原版行为裁剪，确保无 `NOT_LEARNABLE` 等阻止显示的标志。
-5. `"AbilityValues"` → 复制全部字段与子键；每个数值右侧用 `//` 标注原版数值（多档整串对照）。
+5. `"AbilityValues"` → 复制字段与子键，但**排除以下项**（与 `update-abilities-override` P1 绝对禁止项保持一致）：
+   - 子块内含 `special_bonus_unique_*` / `special_bonus_facet_*` 的行 → 直接删除该行（天赋引用原版技能名，对自定义技能无效）
+   - 删除天赋行后，若子块的 `value` 为 `"0"` 且无其他有效子键 → 删除整个子块
+   - 子块内含 `special_bonus_scepter` / `special_bonus_shard` → 同上处理
+   
+   其余每个数值右侧用 `//` 标注原版数值（多档整串对照）。
 6. `"AbilityTextureName"` → 必填；参考原版资源或同英雄 persona 路径。
 7. 仅机制需要时补其他键（`MaxLevel`、`AbilityUnitDamageType` 等）；不删减仍被 Lua 读取的键。
 
@@ -128,7 +133,7 @@ description: >-
    ```
 2. 将键名中的原版技能名替换为自定义技能名，值保持与原版一致。
 3. 至少包含：`DOTA_Tooltip_ability_<name>`、`_Description`，以及说明中 `%变量名%` 对应的 `_<suffix>` 行。
-4. 同步写入 `game/resource/addon_english.txt` 与 `addon_schinese.txt`，遵循 localization-format-guide 的缩进与 tab 规则。
+4. 同步写入 `game/resource/addon_english.txt` 与 `addon_schinese.txt`，遵循 localization-format-guide 的缩进与 tab 规则。每组技能条目前加 `// 英雄名 技能名` 注释，条目后留一个空行；两个文件的注释内容**完全相同**（均使用中文注释）。
 5. 不沿用原版 Facet 文案键时可跳过 `Facet_` 条目。
 
 ---
@@ -152,6 +157,7 @@ description: >-
 - [ ] 新建时已叠加 override 额外设定
 - [ ] 流程 A：`"Innate" "0"` 且 `AbilityBehavior` 无 `HIDDEN`
 - [ ] 流程 B：Innate 字段按需处理，Behavior 与原版一致
+- [ ] `AbilityValues` 已排除 `special_bonus_unique_*` / `special_bonus_facet_*` / `special_bonus_scepter` / `special_bonus_shard` 天赋引用行；删除天赋行后 value 为 "0" 的子块已整块删除
 - [ ] `AbilityValues` 所有覆盖项带 `//` 原版对照
 - [ ] `AbilityTextureName` 已填写
 - [ ] 修正模式：已按原版同步 K 键（删同值、删已废键、补新键）

--- a/.claude/skills/update-abilities-override/SKILL.md
+++ b/.claude/skills/update-abilities-override/SKILL.md
@@ -12,16 +12,9 @@ description: >-
 
 ## 前置条件
 
-- `docs/reference/{version}/npc_heroes.txt` — 英雄槽位
-- `docs/reference/{version}/heroes/npc_dota_hero_{hero}.txt` — 技能 KV 参考
-- 用 `grep` / 片段读取定位，**禁止**一次读入整个 override 文件
+参考文件路径见 CLAUDE.md「Dota 2 参考文件速查」。英雄名 / 技能名查找规则见「技能系统名查找」章节。
 
-## 英雄名查找规则
-
-用户给出中文英雄名时：
-1. **优先**用用户给的原文（中文）直接在 `npc_heroes.txt` 或 override 文件中的注释里搜索（如 `grep -i "巫医"`）
-2. 找到则直接使用对应的英雄 ID，**不必确认**
-3. 找不到时，再尝试用其他关键词搜索；若仍不确定，将候选结果展示给用户确认
+用 `grep` / 片段读取定位，**禁止**一次读入整个 override 文件。
 
 ## 技能范围
 

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -643,6 +643,12 @@
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_wave_count"								"ARROWS FIRED:"
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_range"									"RANGE:"
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_damage_pct"								"%DAMAGE PER ARROW:"
+		// 冰女 冰川护体
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2"						"Glacial Guard"
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2_Description"			"A portion of the mana Crystal Maiden spends on her abilities is converted into a physical barrier."
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2_barrier_duration"		"BARRIER DURATION:"
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2_mana_multiplier"		"%MANA SPENT TO BARRIER:"
+
 		//冰爆
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion"				"Ice Explosion"
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_Description"	"Each attack has a 35% chance to summon an icy blast to strike a random area around you, dealing damage and slowing enemies for 1 second. Passively grants attack speed."
@@ -698,6 +704,13 @@
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_spell_amp"	"%SPELL AMP REDUCTION:"
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_mana_cost"	"%MANACOST INCREASE:"
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_cd"			"%COOLDOWN INCREASE:"
+		// 冰魂 刺骨严寒
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2"						"Bone Chill"
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_Description"			"When Ancient Apparition deals Magic damage to an enemy with his abilities, it is slowed for a short duration. If the target is a Hero, its Strength is also reduced. Multiple instances of this effect stack and have independent durations."
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_str_reduction_duration"	"DURATION:"
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_str_reduction"			"STRENGTH REDUCTION:"
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_movement_slow_pct"		"MOVEMENT SLOW:"
+
 		//冰霜法球
 		"DOTA_Tooltip_ability_ancient_apparition_frost_orb"		"Frost Orb"
 		"DOTA_Tooltip_ability_ancient_apparition_frost_orb_Description"		"Every %attack_count%th attack launches an orb of chilling frost, dealing extra AoE damage and greatly slowing the primary target's movement speed briefly."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -889,7 +889,14 @@
 		"DOTA_Tooltip_ability_riki_innate_backstab2_bonus_xp_assist"						"BONUS XP ASSIST:"
 		"DOTA_Tooltip_ability_riki_innate_backstab2_bonus_xp_assist_other"				"BONUS XP WARD/COURIER KILL:"
 
-		// 力量与魔法
+		// 拉比克 奇心
+		"DOTA_Tooltip_ability_rubick_curiosity2"								"Curiosity"
+		"DOTA_Tooltip_ability_rubick_curiosity2_Description"					"Rubick gains %curiosity_per_level% stack of Curiosity per level that grants him %curiosity_attack_damage% base damage, %curiosity_modifier_amp%%% Buff/Debuff Duration, and %curiosity_aoe_bonus% AOE Bonus. <br><br>If Rubick sees an enemy Hero cast an ability within %charge_radius% distance of him, he gains %curiosity_per_spell_cast% Curiosity for %curiosity_duration% seconds.  If an enemy Hero dies while Rubick has Curiosity from them and he damaged them in the last %grace_period% seconds, he gains %curiosity_per_kill% Curiosity permanently."
+		"DOTA_Tooltip_ability_rubick_curiosity2_curiosity_permanent_gain"		"CURIOSITY GAINED:"
+		"DOTA_Tooltip_ability_rubick_curiosity2_current_debuff_amp"				"%BUFF/DEBUFF AMP:"
+		"DOTA_Tooltip_ability_rubick_curiosity2_current_aoe_bonus"				"AREA OF EFFECT BONUS:"
+
+		// 拉比克 力量与魔法
 		"DOTA_Tooltip_ability_rubick_might_and_magus2"							"Might and Magus"
 		"DOTA_Tooltip_ability_rubick_might_and_magus2_Description"				"Rubick gains stacking bonus area of effect when he casts a spell."
 		"DOTA_Tooltip_ability_rubick_might_and_magus2_aoe_bonus"					"AOE BONUS:"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -881,7 +881,14 @@
 		"DOTA_Tooltip_ability_riki_innate_backstab2_bonus_xp_assist"						"助攻经验奖励："
 		"DOTA_Tooltip_ability_riki_innate_backstab2_bonus_xp_assist_other"				"击杀守卫/信使奖励经验："
 
-		// 力量与魔法
+		// 拉比克 奇心
+		"DOTA_Tooltip_ability_rubick_curiosity2"								"奇心"
+		"DOTA_Tooltip_ability_rubick_curiosity2_Description"					"拉比克现在每级获得%curiosity_per_level%层奇心的叠加效果，每层奇心提供%curiosity_attack_damage%点基础攻击力，%curiosity_modifier_amp%%%增益/减益增强，和%curiosity_aoe_bonus%作用范围加成。<br><br>如果拉比克看到%charge_radius%范围内有敌方英雄施放技能，他就会获得%curiosity_per_spell_cast%层奇心，持续%curiosity_duration%秒。如果当前提供临时奇心的敌人在受到来自拉比克的伤害后%grace_period%秒内阵亡，他就会永久获得%curiosity_per_kill%层奇心."
+		"DOTA_Tooltip_ability_rubick_curiosity2_curiosity_permanent_gain"		"奇心层数："
+		"DOTA_Tooltip_ability_rubick_curiosity2_current_debuff_amp"				"%增益/减益增强："
+		"DOTA_Tooltip_ability_rubick_curiosity2_current_aoe_bonus"				"%作用范围加成："
+
+		// 拉比克 力量与魔法
 		"DOTA_Tooltip_ability_rubick_might_and_magus2"							"力量与魔法"
 		"DOTA_Tooltip_ability_rubick_might_and_magus2_Description"				"拉比克施放法术时获得可叠加的作用范围加成。"
 		"DOTA_Tooltip_ability_rubick_might_and_magus2_aoe_bonus"				"作用范围加成："

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -646,6 +646,12 @@
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_wave_count"								"发射箭矢数量："
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_range"										"距离："
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_damage_pct"								"%每支箭矢伤害："
+		// 冰女 冰川护体
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2"						"冰川护体"
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2_Description"			"水晶室女消耗在她技能上的一部分魔法会转化为物理护盾。"
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2_barrier_duration"		"护盾持续时间："
+		"DOTA_Tooltip_ability_crystal_maiden_glacial_guard2_mana_multiplier"		"%魔法转为护盾："
+
 		//冰爆
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion"				"冰爆"
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_Description"	"增加额外攻击速度，攻击有35%概率召唤一个冰爆打击随机区域，造成伤害和1秒减速"
@@ -701,6 +707,13 @@
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_spell_amp"	"%技能伤害降低："
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_mana_cost"	"%魔法消耗增加："
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_cd"			"%cd增加："
+
+		// 冰魂 刺骨严寒
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2"						"刺骨严寒"
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_Description"			"每当远古冰魄通过他的技能对敌人造成魔法伤害，敌人就会减速一段时间。如果目标是英雄，力量还会降低。多个本效果会叠加，并且持续时间相互独立。"
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_str_reduction_duration"	"持续时间："
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_str_reduction"			"力量降低："
+		"DOTA_Tooltip_ability_ancient_apparition_bone_chill2_movement_slow_pct"		"移动速度减缓：:"
 
 		"DOTA_Tooltip_ability_ancient_apparition_frost_orb"		"冰霜法球"
 		"DOTA_Tooltip_ability_ancient_apparition_frost_orb_Description"		"每%attack_count%次攻击发射一枚冰霜法球，造成范围伤害，并减速目标%slow_duration%秒"

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -635,6 +635,45 @@
 			"tick_attack_damage_pct"		"20 25 30 35 40"
 		}
 	}
+	//奇心 拉比克 先天
+	"rubick_curiosity2"
+	{
+		"BaseClass"						"rubick_curiosity"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"Innate"						"0"
+		"MaxLevel"						"1"
+		"IsBreakable"					"1"
+		"AbilityTextureName"			"rubick_curiosity"
+
+		"AbilityValues"
+		{
+			"curiosity_per_spell_cast"			"2"				// 2
+			"curiosity_duration"				"20"			// 20
+			"curiosity_per_level"				"1"				// 1
+			"curiosity_attack_damage"			"1"				// 1
+			"curiosity_modifier_amp"			"0.3"			// 0.3
+			"curiosity_aoe_bonus"				"2"				// 2
+			"curiosity_per_kill"				"1"				// 1
+			"grace_period"						"3"				// 3
+			"charge_radius"
+			{
+				"value"						"1200"				// 1200
+				"affected_by_aoe_increase"	"1"
+			}
+			"curiosity_permanent_gain"
+			{
+				"dynamic_value"				"true"
+			}
+			"current_debuff_amp"
+			{
+				"dynamic_value"				"true"
+			}
+			"current_aoe_bonus"
+			{
+				"dynamic_value"				"true"
+			}
+		}
+	}
 	//力量与魔法 拉比克
 	"rubick_might_and_magus2"
 	{

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -512,6 +512,26 @@
 			"archers_use_barrage"		"0"
 		}
 	}
+	//冰女 先天 冰川护体
+	"crystal_maiden_glacial_guard2"
+	{
+		"BaseClass"						"crystal_maiden_glacial_guard"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"Innate"						"0"
+		"MaxLevel"						"1"
+		"IsBreakable"					"1"
+		"AbilityTextureName"			"crystal_maiden_glacial_guard"
+
+		"AbilityValues"
+		{
+			"mana_multiplier"
+			{
+				"value"					"30"		// 30
+				"hero_levelup"			"+2"		// +2
+			}
+			"barrier_duration"			"8"			// 8
+		}
+	}
 	//冰女 冰暴
 	"crystal_maiden_ice_explosion"
 	{
@@ -810,6 +830,25 @@
 			"spell_amp"			"30"
 			"mana_cost"			"100"
 			"cd"				"50"
+		}
+	}
+	//冰魂 先天 刺骨严寒
+	"ancient_apparition_bone_chill2"
+	{
+		"BaseClass"						"ancient_apparition_bone_chill"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"Innate"						"0"
+		"MaxLevel"						"1"
+		"AbilityTextureName"			"ancient_apparition_bone_chill"
+
+		"AbilityValues"
+		{
+			"str_reduction"
+			{
+				"value"					"0.6"		// .2
+				"hero_levelup"			"0.1"		// 0.1
+				"levelup_interval"		"2"			// 3
+			}
 		}
 	}
 	//极寒光环

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -845,9 +845,18 @@
 		{
 			"str_reduction"
 			{
-				"value"					"0.6"		// .2
+				"value"					"1"			// .2 无法继承A杖，加强基础效果
 				"hero_levelup"			"0.1"		// 0.1
-				"levelup_interval"		"2"			// 3
+				"levelup_interval"		"1"			// 3 多数英雄没有持续伤害，加强成长速度
+			}
+			"str_reduction_duration"
+			{
+				"value"							"4.0"
+			}
+			"movement_slow_pct"
+			{
+				"value"					"2"
+				"display_type"			"kDebuffPercentage"
 			}
 		}
 	}

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -2226,14 +2226,6 @@
 			{
 				"value"				"6 9 12 15 18"
 			}
-			"status_resist"
-			{
-				"value"				"20"		// 0
-			}
-			"bonus_armor"
-			{
-				"value"				"5 10 15 20 25"		// 0 差值5
-			}
 		}
 	}
 	// 盛宴 life_stealer_feast

--- a/src/vscripts/modules/lottery/lottery-abilities.ts
+++ b/src/vscripts/modules/lottery/lottery-abilities.ts
@@ -198,6 +198,7 @@ export const abilityTiersPassive: Tier[] = [
       'jakiro_double_trouble2', // 双头龙 天生一对
       'leshrac_defilement2', // 大肆污染 拉席克
       'tinker_eureka2', // 修补匠 尤里卡！
+      'rubick_curiosity2', // 拉比克 先天 奇心
       'rubick_might_and_magus2', // 拉比克 力量与魔法
 
       'ability_trigger_learned_skills', //蓝蝴蝶

--- a/src/vscripts/modules/lottery/lottery-abilities.ts
+++ b/src/vscripts/modules/lottery/lottery-abilities.ts
@@ -200,6 +200,7 @@ export const abilityTiersPassive: Tier[] = [
       'tinker_eureka2', // 修补匠 尤里卡！
       'rubick_curiosity2', // 拉比克 先天 奇心
       'rubick_might_and_magus2', // 拉比克 力量与魔法
+      'ancient_apparition_bone_chill2', // 冰魂 先天 刺骨严寒
 
       'ability_trigger_learned_skills', //蓝蝴蝶
       'ability_trigger_on_spell_reflect', //绿蝴蝶
@@ -270,6 +271,7 @@ export const abilityTiersPassive: Tier[] = [
       'black_drake_magic_amplification_aura', // 黑蜉蝣 魔法增强光环
 
       // 自定义技能
+      'crystal_maiden_glacial_guard2', // 冰女 先天 冰川护体
       'crystal_maiden_ice_explosion', // 冰女 冰暴
       'abyssal_underlord_firestorm2', // 火雨降临
       'ursa_maul2', // 拍拍 天生技能 +攻击


### PR DESCRIPTION
## Issue

- #1996

## Release Note

```
[b]游戏性更新 v5.21[/b]

- 技能抽选池新增拉比克、冰女、远古冰魄的先天技能：奇心、冰川护体、刺骨严寒。
```

```
[b]Gameplay update v5.21[/b]

- Added innate abilities to the ability draft pool: Rubick's Curiosity, Crystal Maiden's Glacial Guard, and Ancient Apparition's Bone Chill.
```
