### PR TITLE
Tune treasure chest spawns: more visible start, mid-game cap 2

### DIFF
--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -186,6 +186,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["wisp_spirits_in"] = true,
     ["wisp_spirits_out"] = true,
     ["warlock_fatal_bonds"] = true, -- 术士 致命连接（计算量大可能导致游戏崩溃）
+    ["lich_chain_frost"] = true,    -- 巫妖 连环霜冻
     -- ========================================
     -- 玛西技能组
     -- 原因:玛西的技能组有特殊的联动机制,随机触发会破坏技能连招

--- a/src/vscripts/modules/treasure/treasure.test.ts
+++ b/src/vscripts/modules/treasure/treasure.test.ts
@@ -185,11 +185,12 @@ describe('Treasure', () => {
       expect(treasure.getActiveChestCount()).toBe(1);
     });
 
-    it('GAME_IN_PROGRESS 时挂上周期 timer', () => {
+    it('GAME_IN_PROGRESS 时立即刷新一次并挂上周期 timer', () => {
       mockState = global.GameState.GAME_IN_PROGRESS;
       listeners['game_rules_state_change']?.({});
-      const [interval] = (global.Timers.CreateTimer as jest.Mock).mock.calls[0];
-      expect(interval).toBe(Treasure.RESPAWN_INTERVAL);
+      const [delay, callback] = (global.Timers.CreateTimer as jest.Mock).mock.calls[0];
+      expect(delay).toBe(0);
+      expect(callback()).toBe(Treasure.RESPAWN_INTERVAL);
     });
   });
 });

--- a/src/vscripts/modules/treasure/treasure.ts
+++ b/src/vscripts/modules/treasure/treasure.ts
@@ -1,23 +1,22 @@
 import { GA4TreasureTracker, TreasureTier } from '../../api/analytics/ga4/ga4-treasure-tracker';
-import { ItemLotteryTier } from '../lottery/item/item-lottery-helper';
 import { modifier_treasure_chest } from '../../modifiers/global/modifier_treasure_chest';
 import { reloadable } from '../../utils/tstl-utils';
+import { ItemLotteryTier } from '../lottery/item/item-lottery-helper';
 
 @reloadable
 export class Treasure {
   static readonly UNIT_NAME = 'npc_treasure_chest';
   static readonly RESPAWN_INTERVAL = 180;
-  static readonly MAX_ACTIVE_CHESTS = 1;
+  static readonly MAX_ACTIVE_CHESTS = 2;
   static readonly Z_SINK = 64;
   static readonly OPEN_PARTICLE = 'particles/items2_fx/hand_of_midas.vpcf';
   static readonly OPEN_SOUND = 'ui.treasure_01';
 
   // 开局点位：仅天辉高地附近，开局走两步就能看到
   static readonly SPAWN_POINTS_INITIAL: Vector[] = [
-    Vector(-7343, -5279, 256), // 高低左近
+    Vector(-7314, -5346, 256), // 高低左近
     Vector(-7492, -3646, 256), // 高地左远
-    Vector(-5527, -6858, 256), // 高地右近
-    Vector(-4367, -7499, 262), // 高地右远
+    Vector(-4317, -7208, 263), // 高地右远
   ];
 
   // 中期点位：天辉野区
@@ -78,6 +77,8 @@ export class Treasure {
   // 后期点位：天辉野区
   // 这些点位都在阴间位置，很难找到
   static readonly SPAWN_POINTS_RADIANT_HARD: Vector[] = [
+    Vector(-5527, -6858, 256), // 高地右近
+
     // 天辉左侧外野区
     Vector(-8672, -2592, 256),
     Vector(-8416, 96, 256),

--- a/src/vscripts/modules/treasure/treasure.ts
+++ b/src/vscripts/modules/treasure/treasure.ts
@@ -118,8 +118,7 @@ export class Treasure {
         if (state === GameState.PRE_GAME) {
           this.spawnOne();
         } else if (state === GameState.GAME_IN_PROGRESS) {
-          this.spawnOne();
-          Timers.CreateTimer(Treasure.RESPAWN_INTERVAL, () => {
+          Timers.CreateTimer(0, () => {
             this.spawnOne();
             return Treasure.RESPAWN_INTERVAL;
           });

--- a/src/vscripts/modules/treasure/treasure.ts
+++ b/src/vscripts/modules/treasure/treasure.ts
@@ -118,6 +118,7 @@ export class Treasure {
         if (state === GameState.PRE_GAME) {
           this.spawnOne();
         } else if (state === GameState.GAME_IN_PROGRESS) {
+          this.spawnOne();
           Timers.CreateTimer(Treasure.RESPAWN_INTERVAL, () => {
             this.spawnOne();
             return Treasure.RESPAWN_INTERVAL;


### PR DESCRIPTION
## Issue

- [ ] no issue

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.30a[/b]

- 调整开局宝箱刷新位置，更容易找到
- 游戏中期同时存在的宝箱上限从 1 个提升至 2 个
```

```
[b]Gameplay update v5.30a[/b]

- Adjusted initial treasure chest spawn points to make them easier to find
- Raised the simultaneous active treasure chest cap from 1 to 2 during mid-game
```
