### PR TITLE
Fix skill reset tome causing 0CD bug and Morphling stuck form

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3094,10 +3094,10 @@
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"Redesign your ability path."
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"Respec Tome"
-		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets hero ability levels and refunds spent skill points. Active abilities reset to 0; passive and attack-modifier abilities are kept at level 1."
+		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets hero ability levels and refunds spent skill points. Active abilities reset to 0; passive and attack-triggered abilities are kept at level 1."
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"Everyone deserves a second chance."
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"Innate abilities with a max level of 1 are not affected."
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Passive and attack-modifier abilities are kept at level 1 (not reset to 0) to avoid cooldown bugs."
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Passive and attack-triggered abilities are kept at level 1 (not reset to 0) to avoid cooldown bugs."
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"Rune Signer"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>Use: Re-sign</h1>Re-signs the owner mark on all runes and sacred beast sigils in your inventory.<br><br>Only affects runes and sacred beast sigils not owned by you; has no effect on your own runes."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3094,10 +3094,10 @@
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"Redesign your ability path."
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"Respec Tome"
-		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets hero ability levels and refunds spent skill points. Active abilities reset to 0; passive and attack-triggered abilities are kept at level 1."
+		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets hero ability levels and refunds spent skill points. Active abilities reset to 0; passive, attack-triggered and toggle abilities are kept at level 1."
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"Everyone deserves a second chance."
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"Innate abilities with a max level of 1 are not affected."
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Passive and attack-triggered abilities are kept at level 1 (not reset to 0) to avoid cooldown bugs."
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Passive, attack-triggered and toggle abilities are kept at level 1 (not reset to 0) to avoid cooldown bugs."
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"Rune Signer"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>Use: Re-sign</h1>Re-signs the owner mark on all runes and sacred beast sigils in your inventory.<br><br>Only affects runes and sacred beast sigils not owned by you; has no effect on your own runes."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3097,6 +3097,7 @@
 		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets all hero ability levels to 0 and refunds all spent skill points."
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"Everyone deserves a second chance."
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"Innate abilities with a max level of 1 are not affected."
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Attack-modifier abilities (e.g. Glaives of Wisdom, Walrus Punch, Jinada, Geminate Attack, Hammer of Purity) are kept at level 1 to avoid cooldown bugs."
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"Rune Signer"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>Use: Re-sign</h1>Re-signs the owner mark on all runes and sacred beast sigils in your inventory.<br><br>Only affects runes and sacred beast sigils not owned by you; has no effect on your own runes."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3094,10 +3094,10 @@
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"Redesign your ability path."
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"Respec Tome"
-		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets all hero ability levels to 0 and refunds all spent skill points."
+		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets hero ability levels and refunds spent skill points. Active abilities reset to 0; passive and attack-modifier abilities are kept at level 1."
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"Everyone deserves a second chance."
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"Innate abilities with a max level of 1 are not affected."
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Attack-modifier or attack-triggered abilities (e.g. Glaives of Wisdom, Walrus Punch, Jinada, Geminate Attack, Hammer of Purity, Double Trouble, Time Lock) are kept at level 1 to avoid cooldown bugs."
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Passive and attack-modifier abilities are kept at level 1 (not reset to 0) to avoid cooldown bugs."
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"Rune Signer"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>Use: Re-sign</h1>Re-signs the owner mark on all runes and sacred beast sigils in your inventory.<br><br>Only affects runes and sacred beast sigils not owned by you; has no effect on your own runes."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3097,7 +3097,7 @@
 		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>Use: Respec</h1>Resets all hero ability levels to 0 and refunds all spent skill points."
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"Everyone deserves a second chance."
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"Innate abilities with a max level of 1 are not affected."
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Attack-modifier abilities (e.g. Glaives of Wisdom, Walrus Punch, Jinada, Geminate Attack, Hammer of Purity) are kept at level 1 to avoid cooldown bugs."
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"Attack-modifier or attack-triggered abilities (e.g. Glaives of Wisdom, Walrus Punch, Jinada, Geminate Attack, Hammer of Purity, Double Trouble, Time Lock) are kept at level 1 to avoid cooldown bugs."
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"Rune Signer"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>Use: Re-sign</h1>Re-signs the owner mark on all runes and sacred beast sigils in your inventory.<br><br>Only affects runes and sacred beast sigils not owned by you; has no effect on your own runes."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3149,10 +3149,10 @@
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。"
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"技能洗点书"
-		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>将英雄所有技能等级重置为0，返还全部已花费的技能点。"
+		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>重置英雄技能等级并返还已花费的技能点。主动技能清零，被动及攻击替代类技能保留至1级。"
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"最高等级只有1级的先天技能不受影响。"
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"攻击替代或攻击触发类技能（如智慧之刃、海象神拳、忍术、连击、纯洁之锤、天生一对、时间锁定等）会保留至1级，避免出现冷却异常。"
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"被动及攻击替代类技能会保留至1级（不清零），避免出现冷却异常等问题。"
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"洗炼石"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>使用：洗炼</h1>洗炼背包中所有符文、圣兽符的拥有者印记<br><br>只洗炼拥有者不是自己的符文、圣兽符，对自己的符文不会生效"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3149,10 +3149,10 @@
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。"
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"技能洗点书"
-		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>重置英雄技能等级并返还已花费的技能点。主动技能清零，被动及攻击触发类技能保留至1级。"
+		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>重置英雄技能等级并返还已花费的技能点。主动技能清零，被动、攻击触发及开关型技能保留至1级。"
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"最高等级只有1级的先天技能不受影响。"
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"被动及攻击触发类技能会保留至1级（不清零），避免出现冷却异常等问题。"
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"被动、攻击触发及开关型技能会保留至1级（不清零），避免出现冷却异常等问题。"
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"洗炼石"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>使用：洗炼</h1>洗炼背包中所有符文、圣兽符的拥有者印记<br><br>只洗炼拥有者不是自己的符文、圣兽符，对自己的符文不会生效"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3152,7 +3152,7 @@
 		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>将英雄所有技能等级重置为0，返还全部已花费的技能点。"
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"最高等级只有1级的先天技能不受影响。"
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"攻击替代类技能（如智慧之刃、海象神拳、忍术、连击、净化锤等）会保留至1级，避免出现冷却异常。"
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"攻击替代或攻击触发类技能（如智慧之刃、海象神拳、忍术、连击、纯洁之锤、天生一对、时间锁定等）会保留至1级，避免出现冷却异常。"
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"洗炼石"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>使用：洗炼</h1>洗炼背包中所有符文、圣兽符的拥有者印记<br><br>只洗炼拥有者不是自己的符文、圣兽符，对自己的符文不会生效"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3152,6 +3152,7 @@
 		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>将英雄所有技能等级重置为0，返还全部已花费的技能点。"
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"最高等级只有1级的先天技能不受影响。"
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"攻击替代类技能（如智慧之刃、海象神拳、忍术、连击、净化锤等）会保留至1级，避免出现冷却异常。"
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"洗炼石"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>使用：洗炼</h1>洗炼背包中所有符文、圣兽符的拥有者印记<br><br>只洗炼拥有者不是自己的符文、圣兽符，对自己的符文不会生效"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3149,10 +3149,10 @@
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。"
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"技能洗点书"
-		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>重置英雄技能等级并返还已花费的技能点。主动技能清零，被动及攻击替代类技能保留至1级。"
+		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>重置英雄技能等级并返还已花费的技能点。主动技能清零，被动及攻击触发类技能保留至1级。"
 		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"最高等级只有1级的先天技能不受影响。"
-		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"被动及攻击替代类技能会保留至1级（不清零），避免出现冷却异常等问题。"
+		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"被动及攻击触发类技能会保留至1级（不清零），避免出现冷却异常等问题。"
 
 		"DOTA_Tooltip_Ability_item_rune_transmuter_random"								"洗炼石"
 		"DOTA_Tooltip_ability_item_rune_transmuter_random_Description"					"<h1>使用：洗炼</h1>洗炼背包中所有符文、圣兽符的拥有者印记<br><br>只洗炼拥有者不是自己的符文、圣兽符，对自己的符文不会生效"

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -1,5 +1,11 @@
 item_skill_reset = class({})
 
+-- 完全跳过洗点的技能：会破坏机制（如水人变身后的形态切换依赖原大招等级）
+local SKILL_RESET_BLACKLIST = {
+    morphling_replicate = true,
+    morphling_morph_replicate = true,
+}
+
 function item_skill_reset:OnSpellStart()
     if not IsServer() then return end
 
@@ -35,9 +41,18 @@ function item_skill_reset:OnSpellStart()
             local maxLevel = ability:GetMaxLevel()
             local behavior = ability:GetBehavior()
             if type(behavior) ~= "number" then behavior = tonumber(tostring(behavior)) or 0 end
-            if level > 0 and maxLevel > 1 and bit.band(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) == 0 then
-                totalPoints = totalPoints + level
-                ability:SetLevel(0)
+            if level > 0 and maxLevel > 1 and bit.band(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) == 0
+                and not SKILL_RESET_BLACKLIST[ability:GetAbilityName()] then
+                -- 含 ATTACK behavior 的攻击替代型技能在 level=0 时会出现 0CD bug，保留 1 级
+                if bit.band(behavior, DOTA_ABILITY_BEHAVIOR_ATTACK) ~= 0 then
+                    if level > 1 then
+                        totalPoints = totalPoints + level - 1
+                        ability:SetLevel(1)
+                    end
+                else
+                    totalPoints = totalPoints + level
+                    ability:SetLevel(0)
+                end
             end
         end
     end

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -6,6 +6,13 @@ local SKILL_RESET_BLACKLIST = {
     morphling_morph_replicate = true,
 }
 
+-- 强制保留 1 级而非清零的技能：level=0 时会出现冷却异常的攻击触发型被动
+-- （ATTACK behavior 的技能由代码自动识别，这里只列被动型例外）
+local SKILL_RESET_KEEP_LEVEL_1 = {
+    faceless_void_time_lock = true,
+    jakiro_double_trouble2 = true,
+}
+
 function item_skill_reset:OnSpellStart()
     if not IsServer() then return end
 
@@ -41,10 +48,13 @@ function item_skill_reset:OnSpellStart()
             local maxLevel = ability:GetMaxLevel()
             local behavior = ability:GetBehavior()
             if type(behavior) ~= "number" then behavior = tonumber(tostring(behavior)) or 0 end
+            local name = ability:GetAbilityName()
             if level > 0 and maxLevel > 1 and bit.band(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) == 0
-                and not SKILL_RESET_BLACKLIST[ability:GetAbilityName()] then
-                -- 含 ATTACK behavior 的攻击替代型技能在 level=0 时会出现 0CD bug，保留 1 级
-                if bit.band(behavior, DOTA_ABILITY_BEHAVIOR_ATTACK) ~= 0 then
+                and not SKILL_RESET_BLACKLIST[name] then
+                -- 攻击替代/攻击触发型技能在 level=0 时会出现 0CD bug，保留 1 级
+                local keepLevel1 = SKILL_RESET_KEEP_LEVEL_1[name]
+                    or bit.band(behavior, DOTA_ABILITY_BEHAVIOR_ATTACK) ~= 0
+                if keepLevel1 then
                     if level > 1 then
                         totalPoints = totalPoints + level - 1
                         ability:SetLevel(1)

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -13,6 +13,27 @@ local function hasFlag(behavior, mask)
     return bit.band(behavior, mask) ~= 0
 end
 
+-- 返回应退还的技能点数；同时按规则把 ability 等级降到 0 或 1
+local function resetAbility(ability)
+    if not ability then return 0 end
+    local level = ability:GetLevel()
+    if level <= 0 then return 0 end
+    if ability:GetMaxLevel() <= 1 then return 0 end
+    local behavior = ability:GetBehavior()
+    if hasFlag(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) then return 0 end
+    if SKILL_RESET_BLACKLIST[ability:GetAbilityName()] then return 0 end
+
+    -- 被动/攻击触发类技能 level=0 时会出现冷却异常（如智慧之刃、海象神拳 0CD），保留 1 级
+    if hasFlag(behavior, PASSIVE_MASK) then
+        if level <= 1 then return 0 end
+        ability:SetLevel(1)
+        return level - 1
+    end
+
+    ability:SetLevel(0)
+    return level
+end
+
 function item_skill_reset:OnSpellStart()
     if not IsServer() then return end
 
@@ -43,26 +64,7 @@ function item_skill_reset:OnSpellStart()
 
     local totalPoints = 0
     for _, ability in ipairs(abilities) do
-        repeat
-            if not ability then break end
-            local level = ability:GetLevel()
-            if level <= 0 then break end
-            if ability:GetMaxLevel() <= 1 then break end
-            local behavior = ability:GetBehavior()
-            if hasFlag(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) then break end
-            if SKILL_RESET_BLACKLIST[ability:GetAbilityName()] then break end
-
-            -- 被动/攻击触发类技能 level=0 时会出现冷却异常（如智慧之刃、海象神拳 0CD），保留 1 级
-            if hasFlag(behavior, PASSIVE_MASK) then
-                if level > 1 then
-                    totalPoints = totalPoints + level - 1
-                    ability:SetLevel(1)
-                end
-            else
-                totalPoints = totalPoints + level
-                ability:SetLevel(0)
-            end
-        until true
+        totalPoints = totalPoints + resetAbility(ability)
     end
 
     if totalPoints > 0 then

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -11,7 +11,9 @@ local SKILL_RESET_KEEP_LEVEL_1 = {
     winter_wyvern_arctic_burn = true,
 }
 
-local PASSIVE_MASK = DOTA_ABILITY_BEHAVIOR_PASSIVE + DOTA_ABILITY_BEHAVIOR_ATTACK
+local KEEP_LEVEL_1_MASK = DOTA_ABILITY_BEHAVIOR_PASSIVE
+    + DOTA_ABILITY_BEHAVIOR_ATTACK
+    + DOTA_ABILITY_BEHAVIOR_TOGGLE
 
 local function hasFlag(behavior, mask)
     if type(behavior) ~= "number" then behavior = tonumber(tostring(behavior)) or 0 end
@@ -28,8 +30,8 @@ local function resetAbility(ability)
     if hasFlag(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) then return 0 end
     if SKILL_RESET_BLACKLIST[ability:GetAbilityName()] then return 0 end
 
-    -- 被动/攻击触发类技能 level=0 时会出现冷却异常（如智慧之刃、海象神拳 0CD），保留 1 级
-    local keepLevel1 = hasFlag(behavior, PASSIVE_MASK)
+    -- 被动/攻击触发/开关型技能 level=0 时会出现冷却异常或状态错乱（如智慧之刃 0CD），保留 1 级
+    local keepLevel1 = hasFlag(behavior, KEEP_LEVEL_1_MASK)
         or SKILL_RESET_KEEP_LEVEL_1[ability:GetAbilityName()]
     if keepLevel1 then
         if level <= 1 then return 0 end

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -6,6 +6,11 @@ local SKILL_RESET_BLACKLIST = {
     morphling_morph_replicate = true,
 }
 
+-- 主动技能但 level=0 会破坏机制，强制保留至 1 级
+local SKILL_RESET_KEEP_LEVEL_1 = {
+    winter_wyvern_arctic_burn = true,
+}
+
 local PASSIVE_MASK = DOTA_ABILITY_BEHAVIOR_PASSIVE + DOTA_ABILITY_BEHAVIOR_ATTACK
 
 local function hasFlag(behavior, mask)
@@ -24,7 +29,9 @@ local function resetAbility(ability)
     if SKILL_RESET_BLACKLIST[ability:GetAbilityName()] then return 0 end
 
     -- 被动/攻击触发类技能 level=0 时会出现冷却异常（如智慧之刃、海象神拳 0CD），保留 1 级
-    if hasFlag(behavior, PASSIVE_MASK) then
+    local keepLevel1 = hasFlag(behavior, PASSIVE_MASK)
+        or SKILL_RESET_KEEP_LEVEL_1[ability:GetAbilityName()]
+    if keepLevel1 then
         if level <= 1 then return 0 end
         ability:SetLevel(1)
         return level - 1

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -1,6 +1,6 @@
 item_skill_reset = class({})
 
--- 完全跳过洗点的技能：会破坏机制（如水人变身后的形态切换依赖原大招等级）
+-- 完全跳过洗点的技能：变身中改动等级可能破坏形态切换机制
 local SKILL_RESET_BLACKLIST = {
     morphling_replicate = true,
     morphling_morph_replicate = true,

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -6,13 +6,6 @@ local SKILL_RESET_BLACKLIST = {
     morphling_morph_replicate = true,
 }
 
--- 强制保留 1 级而非清零的技能：level=0 时会出现冷却异常的攻击触发型被动
--- （ATTACK behavior 的技能由代码自动识别，这里只列被动型例外）
-local SKILL_RESET_KEEP_LEVEL_1 = {
-    faceless_void_time_lock = true,
-    jakiro_double_trouble2 = true,
-}
-
 function item_skill_reset:OnSpellStart()
     if not IsServer() then return end
 
@@ -51,10 +44,10 @@ function item_skill_reset:OnSpellStart()
             local name = ability:GetAbilityName()
             if level > 0 and maxLevel > 1 and bit.band(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) == 0
                 and not SKILL_RESET_BLACKLIST[name] then
-                -- 攻击替代/攻击触发型技能在 level=0 时会出现 0CD bug，保留 1 级
-                local keepLevel1 = SKILL_RESET_KEEP_LEVEL_1[name]
+                -- 被动技能 level=0 时会出现冷却异常等 bug（如智慧之刃、海象神拳 0CD），保留 1 级
+                local isPassive = bit.band(behavior, DOTA_ABILITY_BEHAVIOR_PASSIVE) ~= 0
                     or bit.band(behavior, DOTA_ABILITY_BEHAVIOR_ATTACK) ~= 0
-                if keepLevel1 then
+                if isPassive then
                     if level > 1 then
                         totalPoints = totalPoints + level - 1
                         ability:SetLevel(1)

--- a/game/scripts/vscripts/items/item_skill_reset.lua
+++ b/game/scripts/vscripts/items/item_skill_reset.lua
@@ -6,6 +6,13 @@ local SKILL_RESET_BLACKLIST = {
     morphling_morph_replicate = true,
 }
 
+local PASSIVE_MASK = DOTA_ABILITY_BEHAVIOR_PASSIVE + DOTA_ABILITY_BEHAVIOR_ATTACK
+
+local function hasFlag(behavior, mask)
+    if type(behavior) ~= "number" then behavior = tonumber(tostring(behavior)) or 0 end
+    return bit.band(behavior, mask) ~= 0
+end
+
 function item_skill_reset:OnSpellStart()
     if not IsServer() then return end
 
@@ -36,28 +43,26 @@ function item_skill_reset:OnSpellStart()
 
     local totalPoints = 0
     for _, ability in ipairs(abilities) do
-        if ability then
+        repeat
+            if not ability then break end
             local level = ability:GetLevel()
-            local maxLevel = ability:GetMaxLevel()
+            if level <= 0 then break end
+            if ability:GetMaxLevel() <= 1 then break end
             local behavior = ability:GetBehavior()
-            if type(behavior) ~= "number" then behavior = tonumber(tostring(behavior)) or 0 end
-            local name = ability:GetAbilityName()
-            if level > 0 and maxLevel > 1 and bit.band(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) == 0
-                and not SKILL_RESET_BLACKLIST[name] then
-                -- 被动技能 level=0 时会出现冷却异常等 bug（如智慧之刃、海象神拳 0CD），保留 1 级
-                local isPassive = bit.band(behavior, DOTA_ABILITY_BEHAVIOR_PASSIVE) ~= 0
-                    or bit.band(behavior, DOTA_ABILITY_BEHAVIOR_ATTACK) ~= 0
-                if isPassive then
-                    if level > 1 then
-                        totalPoints = totalPoints + level - 1
-                        ability:SetLevel(1)
-                    end
-                else
-                    totalPoints = totalPoints + level
-                    ability:SetLevel(0)
+            if hasFlag(behavior, DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE) then break end
+            if SKILL_RESET_BLACKLIST[ability:GetAbilityName()] then break end
+
+            -- 被动/攻击触发类技能 level=0 时会出现冷却异常（如智慧之刃、海象神拳 0CD），保留 1 级
+            if hasFlag(behavior, PASSIVE_MASK) then
+                if level > 1 then
+                    totalPoints = totalPoints + level - 1
+                    ability:SetLevel(1)
                 end
+            else
+                totalPoints = totalPoints + level
+                ability:SetLevel(0)
             end
-        end
+        until true
     end
 
     if totalPoints > 0 then

--- a/src/vscripts/modules/lottery/ability/lottery-abilities.ts
+++ b/src/vscripts/modules/lottery/ability/lottery-abilities.ts
@@ -110,7 +110,6 @@ export const abilityTiersActive: Tier[] = [
       'mars_gods_rebuke', // 神之遣戒
       'antimage_blink', // 闪烁
       'ringmaster_tame_the_beasts', // 驯兽术
-      'slark_saltwater_shiv', // 海浪短刀
       'treant_natures_grasp', // 自然卷握
       'abyssal_underlord_firestorm', // 火焰风暴
       'obsidian_destroyer_objurgation', // 责难
@@ -311,6 +310,7 @@ export const abilityTiersPassive: Tier[] = [
       'tusk_walrus_punch', //海象神拳
       'kunkka_tidebringer', // 潮汐使者 水刀
       'mirana_celestial_quiver', // 米拉娜 天界箭袋
+      'slark_saltwater_shiv', // 海浪短刀
 
       // 自定义技能
       'ursa_maul2', // 拍拍 暴烈之爪 +攻击


### PR DESCRIPTION
## Issue

- [x] fix #2095

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.00a[/b]

- 技能洗点书改版：主动技能清零，被动、攻击触发及开关型技能保留至 1 级。修复了洗点后部分技能出现 0CD 的问题。
- 水人的大招及形态切换技能现在不会被洗点影响，修复变身状态下洗点无法切回原形态的问题。
```

```
[b]Gameplay update v5.00a[/b]

- Respec Tome reworked: active abilities reset to 0, while passive, attack-triggered and toggle abilities are kept at level 1. Fixes the 0-cooldown exploit after respec.
- Morphling's Replicate and Morph Replicate are now skipped by Respec Tome, fixing the issue where Morphling could get stuck in replicated form after respec.
```