### PR TITLE
fix: treasure chest proximity check ignores magic immunity

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -351,6 +351,22 @@ grep "DOTA_Tooltip_ability_dragon_knight_dragon_blood" docs/reference/<version>/
 
 **主文档（检索入口）**: [ModDota API · vscripts](https://moddota.com/api/#/vscripts)
 
+## KV Configuration
+
+技能射程、伤害值及其他可调参数一律从 KV 文件**动态读取**，不要硬编码已存在于 KV 中的数值。
+
+## Repo Context
+
+当引用的 GitHub issue 或路径可能属于其他仓库或本地参考目录（如 `tenvten`）时，先确认其归属位置，再去 GitHub 搜索或动手实现。
+
+## Implementation Style
+
+代码改动保持最小化，优先用最简单的机制实现：
+
+- 把 timer 延迟设为 0，而不是另加一次冗余调用
+- 复用一个字符串事件，而不是新增自定义事件
+- 避免过度还原、过度分析
+
 ## 注释规约
 
 代码注释只写**为什么这样做**，不写**这行代码做了什么**。读者能从代码本身读懂的，就不要再用注释复述一遍。
@@ -395,10 +411,16 @@ Release Note 段按照 `.claude/skills/release-note/SKILL.md` 文件的规则生
 简短单行标题（≤72 字符）+ 正文只写 `Co-Authored-By`，不写其他正文、不写 bullet 说明。
 详细说明由 PR description 承担，commit message 保持简洁。
 
+### Git & Commits
+
+只 stage 与本次请求明确相关的文件，无需逐个列给用户确认。但提交前若当前分支不符合预期（如本应在 feature 分支却处于 `develop`/`main`），先提示用户确认目标分支再提交。
+
 
 ## 文档自维护规范
 
 当用户纠正 Claude 的做法、发现文档与实际代码矛盾、或用户补充了新约定时，触发 `doc-update` skill 将有价值的内容沉淀到文档中。执行流程见 `.claude/skills/doc-update/SKILL.md`。
+
+文档与 skill 专属规则应写入对应的 `SKILL.md`，**不要**放进 CLAUDE.md；CLAUDE.md 只保留项目级通用规则。文档更新应作为完成一次改动的一部分（自维护），不要等用户催促。
 
 ## Skill 交互规范
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -355,10 +355,6 @@ grep "DOTA_Tooltip_ability_dragon_knight_dragon_blood" docs/reference/<version>/
 
 技能射程、伤害值及其他可调参数一律从 KV 文件**动态读取**，不要硬编码已存在于 KV 中的数值。
 
-## Repo Context
-
-当引用的 GitHub issue 或路径可能属于其他仓库或本地参考目录（如 `tenvten`）时，先确认其归属位置，再去 GitHub 搜索或动手实现。
-
 ## Implementation Style
 
 代码改动保持最小化，优先用最简单的机制实现：

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "if": "Bash(git commit*)",
+            "command": "files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^src/'); if [ -z \"$files\" ]; then exit 0; fi; echo 'Staged src files detected, running lint:fix...' >&2; npm run lint:fix || exit 2; echo \"$files\" | tr '\\n' '\\0' | xargs -0 git add",
+            "statusMessage": "Linting staged src files before commit...",
+            "timeout": 180
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,14 +6,19 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "bash",
-            "if": "Bash(git commit*)",
             "command": "files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^src/'); if [ -z \"$files\" ]; then exit 0; fi; echo 'Staged src files detected, running lint:fix...' >&2; npm run lint:fix || exit 2; echo \"$files\" | tr '\\n' '\\0' | xargs -0 git add",
-            "statusMessage": "Linting staged src files before commit...",
-            "timeout": 180
+            "if": "Bash(git commit*)",
+            "shell": "bash",
+            "timeout": 180,
+            "statusMessage": "Linting staged src files before commit..."
           }
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "context7@claude-plugins-official": true
   }
 }

--- a/.claude/skills/doc-update/SKILL.md
+++ b/.claude/skills/doc-update/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: doc-update
 description: >-
-  Capture valuable learnings from the current conversation into CLAUDE.md or skill
-  files to improve future sessions. Reviews conversation for corrections, new
-  conventions, and doc-reality mismatches; proposes targeted updates confirmed by
-  user before writing. Use when user corrects Claude's approach, when a discrepancy
-  between docs and actual code is discovered, or when user provides new conventions
-  not yet in current docs.
+  Capture-correction workflow: record valuable learnings from the current
+  conversation into CLAUDE.md or the relevant SKILL.md so the same mistake never
+  recurs. Reviews conversation for corrections, new conventions, and doc-reality
+  mismatches; proposes targeted updates confirmed by user before writing. TRIGGER
+  whenever the user corrects Claude's approach or rejects an action — signals like
+  "不对", "不要这样", "应该是", "错了", "其实是", "no, do X instead", "that's wrong" —
+  and the correction reflects a reusable convention rather than a one-off. Also use
+  when a doc-vs-code discrepancy is found, or the user supplies a convention Claude
+  could not infer.
 ---
 
 # doc-update

--- a/src/panorama/tsconfig.json
+++ b/src/panorama/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["es2020"],
     "resolveJsonModule": true,
     "types": ["@moddota/panorama-types"],
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "strict": true,
     "preserveSymlinks": false,
     "allowSyntheticDefaultImports": true,

--- a/src/panorama/tsconfig.json
+++ b/src/panorama/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["es2020"],
     "resolveJsonModule": true,
     "types": ["@moddota/panorama-types"],
-    "moduleResolution": "node10",
+    "moduleResolution": "bundler",
     "strict": true,
     "preserveSymlinks": false,
     "allowSyntheticDefaultImports": true,

--- a/src/vscripts/modifiers/global/modifier_treasure_chest.ts
+++ b/src/vscripts/modifiers/global/modifier_treasure_chest.ts
@@ -67,7 +67,7 @@ export class modifier_treasure_chest extends BaseModifier {
       modifier_treasure_chest.PROXIMITY_RADIUS,
       UnitTargetTeam.BOTH,
       UnitTargetType.HERO,
-      UnitTargetFlags.NONE,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
       FindOrder.CLOSEST,
       false,
     );

--- a/src/vscripts/tsconfig.json
+++ b/src/vscripts/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["esnext"],
     "types": ["@moddota/dota-lua-types/normalized", "jest"],
     "plugins": [{ "transform": "@moddota/dota-lua-types/transformer" }],
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "noImplicitReturns": true,

--- a/src/vscripts/tsconfig.json
+++ b/src/vscripts/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["esnext"],
     "types": ["@moddota/dota-lua-types/normalized", "jest"],
     "plugins": [{ "transform": "@moddota/dota-lua-types/transformer" }],
-    "moduleResolution": "node10",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Summary

**宝箱修复**
- 修复宝箱开启时检测周围单位忽略魔免状态的问题
- 将 `FindUnitsInRadius` 的 `UnitTargetFlags.NONE` 改为 `UnitTargetFlags.MAGIC_IMMUNE_ENEMIES`，使魔免状态下的英雄也能触发宝箱开启

**Claude 配置 / 文档（`.claude/`）**
- CLAUDE.md 补充 KV Configuration、Implementation Style、Git & Commits、文档自维护等项目约定
- 新增 pre-commit hook：`git commit` 时若暂存区含 `src/` 改动则先跑 `npm run lint:fix` 并重新 add（`.claude/settings.json`，需 Git Bash）
- 优化 `doc-update` skill 触发描述，作为 capture-correction 工作流；移除低频的 Repo Context 约定

## Test plan
- [x] 英雄处于魔免状态（BKB/无敌等）时靠近宝箱，确认宝箱正常开启
- [x] 非魔免状态下靠近宝箱，确认行为不变
- [x] pre-commit hook 实测：暂存 src 文件触发 lint:fix，无 src 改动直接放行

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aqi4rbQytUj6UND5raScZr)_