### PR TITLE
Add respawnTimePct and update localizations

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -290,7 +290,7 @@
 		"profile_stat_lifetime_hero_damage"	"Hero Damage"
 		"profile_stat_lifetime_damage_taken"	"Damage Taken"
 		"profile_stat_lifetime_healing"		"Healing"
-		"profile_stat_lifetime_tower_kills"	"Towers"
+		"profile_stat_lifetime_tower_kills"	"Tower Kills"
 		"profile_stat_lifetime_total_gold"	"Gold Earned"
 		"profile_stat_conduct_tooltip"	"Conduct Score reflects your in-game behavior. Default <font color='#7FD47F'>100</font>, cap <font color='#FFD700'>120</font>.<br><br><b>Score changes</b><br>• Finish a game: <font color='#7FD47F'>+1</font> (only below 100)<br>• Early disconnect: <font color='#E87D7D'>-10</font> (solo / all quit doesn't count)<br>• Commended <font color='#7FD47F'>+2</font> / Reported <font color='#E87D7D'>-2</font> (same player counts at most once per week)<br><br><b>End-game points multiplier</b> (team games only)<br>• <font color='#FFD700'>≥110</font>: ×1.1<br>• <font color='#7FD47F'>80–109</font>: ×1.0<br>• <font color='#F5A623'>60–79</font>: ×0.8<br>• <font color='#E87D7D'>&lt;60</font>: ×0.5"
 		"profile_stat_conduct_net_tooltip"	"Total Commends minus Total Reports"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -291,7 +291,7 @@
 		"profile_stat_lifetime_damage_taken"	"承受伤害"
 		"profile_stat_lifetime_healing"		"治疗"
 		"profile_stat_lifetime_tower_kills"	"推塔数"
-		"profile_stat_lifetime_total_gold"	"财产"
+		"profile_stat_lifetime_total_gold"	"金钱"
 		"profile_stat_conduct_tooltip"	"行为分反映你的游戏行为，默认 <font color='#7FD47F'>100</font> 分，上限 <font color='#FFD700'>120</font> 分。<br><br><b>分数变化</b><br>• 完成一局 <font color='#7FD47F'>+1</font>（仅限 100 分以内）<br>• 秒退一局 <font color='#E87D7D'>-10</font>（单人 / 全员退出不计）<br>• 被点赞 <font color='#7FD47F'>+2</font> / 被举报 <font color='#E87D7D'>-2</font>（同一玩家每周对你最多生效一次）<br><br><b>结算积分倍率</b>（仅组队局）<br>• <font color='#FFD700'>≥110</font>：×1.1<br>• <font color='#7FD47F'>80–109</font>：×1.0<br>• <font color='#F5A623'>60–79</font>：×0.8<br>• <font color='#E87D7D'>&lt;60</font>：×0.5"
 		"profile_stat_conduct_net_tooltip"	"累计点赞 减 累计举报"
 

--- a/src/vscripts/api/analytics/dto/game-end-dto.ts
+++ b/src/vscripts/api/analytics/dto/game-end-dto.ts
@@ -6,6 +6,7 @@ export class GameEndGameOptionsDto {
   playerNumberRadiant: number;
   playerNumberDire: number;
   towerPowerPct: number;
+  respawnTimePct: number;
 }
 
 export class GameEndPlayerDto {

--- a/src/vscripts/modules/event/game-end/game-end.ts
+++ b/src/vscripts/modules/event/game-end/game-end.ts
@@ -43,6 +43,7 @@ export class GameEnd {
       playerNumberRadiant: gameOptionsData.player_number_radiant,
       playerNumberDire: gameOptionsData.player_number_dire,
       towerPowerPct: gameOptionsData.tower_power_pct,
+      respawnTimePct: gameOptionsData.respawn_time_pct,
     };
 
     const gameTime = GameRules.GetGameTime();


### PR DESCRIPTION
Include respawnTimePct in GameEndGameOptionsDto and map gameOptionsData.respawn_time_pct in the game-end event so the respawn time percentage is captured for end-game analytics. Also adjust localization strings: change English "Towers" to "Tower Kills" and Simplified Chinese "财产" to "金钱" for the total gold label.



## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.00a[/b]

- 修正一些bug和平衡性改动。
```

```
[b]Gameplay update v5.00a[/b]

- Fixed some bugs and balance.
```
