### PR TITLE
feat: mid only mode starts players at level 3 and exclude butterfly passives from bots

### DIFF
--- a/content/panorama/scripts/custom_game/game_mode.js
+++ b/content/panorama/scripts/custom_game/game_mode.js
@@ -335,8 +335,8 @@ function OnGameDifficultyChoiceChange(table, key, value) {
 // -------- 链接按钮 --------
 function DispatchLinkPanel() {
   const random = Math.random();
-  const chanceSurvivor = 0.2;
-  const chanceOMGAI = 0.4;
+  const chanceSurvivor = 0.5;
+  const chanceOMGAI = 1;
   if (random < chanceSurvivor) {
     $('#DotaSurvivorPanel').visible = true;
     $('#OMGAIPanel').visible = false;

--- a/src/vscripts/modules/event/event-npc-spawned.ts
+++ b/src/vscripts/modules/event/event-npc-spawned.ts
@@ -140,6 +140,12 @@ export class EventNpcSpawned {
     hero.AddNewModifier(hero, undefined, modifier_intelect_magic_resist.name, {});
 
     if (PlayerHelper.IsHumanPlayer(hero)) {
+      // 中路乱斗模式：玩家出门 3 级，节奏更快
+      if (GameRules.Option.midOnlyMode) {
+        while (hero.GetLevel() < 3) {
+          hero.HeroLevelUp(false);
+        }
+      }
       // 设置会员
       MemberHelper.ApplyMemberModifier(hero);
       const steamAccountId = PlayerResource.GetSteamAccountID(hero.GetPlayerID());

--- a/src/vscripts/modules/helper/bot-ability.ts
+++ b/src/vscripts/modules/helper/bot-ability.ts
@@ -1,5 +1,8 @@
-import { abilityTiersPassive } from '../lottery/ability/lottery-abilities';
 import { AbilityLotteryHelper } from '../lottery/ability/ability-lottery-helper';
+import {
+  abilityTiersPassive,
+  butterflyPassiveAbilities,
+} from '../lottery/ability/lottery-abilities';
 import { GetBotBuildConfig } from './bot-build-config';
 
 export class BotAbility {
@@ -29,7 +32,7 @@ export class BotAbility {
       abilityTiersPassive,
       2,
       currentHero,
-      [],
+      [...butterflyPassiveAbilities],
       isHighTier,
     );
     const abilityName1 = results[0].name;

--- a/src/vscripts/modules/lottery/ability/lottery-abilities.ts
+++ b/src/vscripts/modules/lottery/ability/lottery-abilities.ts
@@ -362,3 +362,14 @@ export const abilityTiersPassive: Tier[] = [
     ],
   },
 ];
+
+// 蝴蝶系列被动过强，bot 抽到会严重影响玩家体验，需从 bot 抽取池中排除
+export const butterflyPassiveAbilities = [
+  'ability_trigger_on_active', // 紫蝴蝶
+  'ability_trigger_learned_skills', // 蓝蝴蝶
+  'ability_trigger_on_spell_reflect', // 绿蝴蝶
+  'ability_charge_damage', // 青蝴蝶
+  'ability_trigger_on_cast', // 红蝴蝶
+  'ability_trigger_on_attacked', // 金蝴蝶
+  'ability_trigger_on_move', // 橙影蝴蝶
+];


### PR DESCRIPTION
﻿## Issue

- [ ] fix #9999

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.32b[/b]

- 中路乱斗模式：玩家出生时为 3 级
- 优化机器人技能：机器人不再随机到蝴蝶系列被动
```

```
[b]Gameplay update v5.32b[/b]

- Mid Only Mode: players now start at level 3
- Bots no longer roll butterfly-series passives
```