### PR TITLE
额外技能刷新次数

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -225,6 +225,8 @@ GameEvents.SendCustomGameEventToAllClients('hud_open_page', { page: 'home', play
 
 `hud_main` 的 `NavigationProvider` 通过 `GameEvents.Subscribe('hud_open_page', ...)` 监听，过滤 `playerId === Game.GetLocalPlayerID()` 后切换 currentPage。事件类型在 `src/common/events.d.ts` 的 `CustomGameEventDeclarations` 中声明。
 
+`param` 支持 `'tab:subTab'` 复合格式定位一级 tab 内的子页：页面组件用 `split(':')` 拆解，将 subTab 透传给 tab 组件（如 `ProfilePage` 把 `'member:points'` 拆出后传给 `MemberTab` 的 `initialSubTab`）。
+
 **通用资源位置**：
 
 - 通用组件 / 对话框骨架：`src/panorama/react/shared/components/`

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -226,8 +226,8 @@
 		"lottery_tooltip_ability_refresh_used"					"Ability has been rerolled."
 		"lottery_tooltip_ability_refresh_picked"				"Ability has been selected."
 		"lottery_tooltip_ability_refresh_not_member"			"Members can reroll abilities once per game. Click this button to open the membership page in your browser."
-		"lottery_tooltip_ability_refresh_paid"					"Reroll for {cost} member points."
-		"lottery_tooltip_ability_refresh_insufficient"			"Not enough member points (need {cost}). Click to open the membership page."
+		"lottery_tooltip_ability_refresh_paid"					"{cost} useable points to reroll (membership level unchanged)."
+		"lottery_tooltip_ability_refresh_insufficient"			"Not enough useable points (need {cost}). Click to open the membership page."
 
 		"lottery_tooltip_item_refresh"							"Click to reroll items."
 		"lottery_tooltip_item_refresh_used"						"Items have been rerolled."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -226,7 +226,7 @@
 		"lottery_tooltip_ability_refresh_used"					"Ability has been rerolled."
 		"lottery_tooltip_ability_refresh_picked"				"Ability has been selected."
 		"lottery_tooltip_ability_refresh_not_member"			"Members can reroll abilities once per game. Click this button to open the membership page in your browser."
-		"lottery_tooltip_ability_refresh_paid"					"{cost} useable points to reroll (membership level unchanged)."
+		"lottery_tooltip_ability_refresh_paid"					"Spend {cost} useable points to reroll (membership level unchanged)."
 		"lottery_tooltip_ability_refresh_insufficient"			"Not enough useable points (need {cost}). Click to open the membership page."
 
 		"lottery_tooltip_item_refresh"							"Click to reroll items."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -226,8 +226,8 @@
 		"lottery_tooltip_ability_refresh_used"					"Ability has been rerolled."
 		"lottery_tooltip_ability_refresh_picked"				"Ability has been selected."
 		"lottery_tooltip_ability_refresh_not_member"			"Members can reroll abilities once per game. Click this button to open the membership page in your browser."
-		"lottery_tooltip_ability_refresh_paid"					"Spend {cost} useable points to reroll (membership level unchanged)."
-		"lottery_tooltip_ability_refresh_insufficient"			"Not enough useable points (need {cost}). Click to open the membership page."
+		"lottery_tooltip_ability_refresh_paid"					"Spend <font color='#FFD700'>{cost}</font> useable points to reroll (membership level unchanged)."
+		"lottery_tooltip_ability_refresh_insufficient"			"Not enough useable points. Click to open the membership page."
 
 		"lottery_tooltip_item_refresh"							"Click to reroll items."
 		"lottery_tooltip_item_refresh_used"						"Items have been rerolled."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -222,10 +222,12 @@
 		"lottery_active_ability_title"							"Select active ability"
 		"lottery_passive_ability_title"							"Select passive ability"
 
-		"lottery_tooltip_ability_refresh"						"Click to reroll bonus abilities."
+		"lottery_tooltip_ability_refresh"						"Click to reroll abilities for free."
 		"lottery_tooltip_ability_refresh_used"					"Ability has been rerolled."
 		"lottery_tooltip_ability_refresh_picked"				"Ability has been selected."
 		"lottery_tooltip_ability_refresh_not_member"			"Members can reroll abilities once per game. Click this button to open the membership page in your browser."
+		"lottery_tooltip_ability_refresh_paid"					"Reroll for {cost} member points."
+		"lottery_tooltip_ability_refresh_insufficient"			"Not enough member points (need {cost}). Click to open the membership page."
 
 		"lottery_tooltip_item_refresh"							"Click to reroll items."
 		"lottery_tooltip_item_refresh_used"						"Items have been rerolled."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -180,7 +180,7 @@
 		"lottery_tooltip_ability_refresh_used"					"Способности изменены"
 		"lottery_tooltip_ability_refresh_picked"				"Способность выбрана"
 		"lottery_tooltip_ability_refresh_not_member"			"Поддержавшие разработчика могут изменить способности один раз. Нажмите на эту кнопку, чтобы открыть страницу поддержки в браузере"
-		"lottery_tooltip_ability_refresh_paid"					"{cost} доступных очков для изменения (уровень поддержки не меняется)"
+		"lottery_tooltip_ability_refresh_paid"					"Потратить {cost} доступных очков на изменение (уровень поддержки не меняется)"
 		"lottery_tooltip_ability_refresh_insufficient"			"Недостаточно доступных очков (нужно {cost}). Нажмите, чтобы открыть страницу поддержки"
 
 		"lottery_tooltip_item_refresh"							"Нажмите, чтобы изменить предметы"

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -180,8 +180,8 @@
 		"lottery_tooltip_ability_refresh_used"					"Способности изменены"
 		"lottery_tooltip_ability_refresh_picked"				"Способность выбрана"
 		"lottery_tooltip_ability_refresh_not_member"			"Поддержавшие разработчика могут изменить способности один раз. Нажмите на эту кнопку, чтобы открыть страницу поддержки в браузере"
-		"lottery_tooltip_ability_refresh_paid"					"Потратить {cost} доступных очков на изменение (уровень поддержки не меняется)"
-		"lottery_tooltip_ability_refresh_insufficient"			"Недостаточно доступных очков (нужно {cost}). Нажмите, чтобы открыть страницу поддержки"
+		"lottery_tooltip_ability_refresh_paid"					"Потратить <font color='#FFD700'>{cost}</font> доступных очков на изменение (уровень поддержки не меняется)"
+		"lottery_tooltip_ability_refresh_insufficient"			"Недостаточно доступных очков. Нажмите, чтобы открыть страницу поддержки"
 
 		"lottery_tooltip_item_refresh"							"Нажмите, чтобы изменить предметы"
 		"lottery_tooltip_item_refresh_used"						"Предметы изменены"

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -180,8 +180,8 @@
 		"lottery_tooltip_ability_refresh_used"					"Способности изменены"
 		"lottery_tooltip_ability_refresh_picked"				"Способность выбрана"
 		"lottery_tooltip_ability_refresh_not_member"			"Поддержавшие разработчика могут изменить способности один раз. Нажмите на эту кнопку, чтобы открыть страницу поддержки в браузере"
-		"lottery_tooltip_ability_refresh_paid"					"Изменить за {cost} очков поддержки"
-		"lottery_tooltip_ability_refresh_insufficient"			"Недостаточно очков поддержки (нужно {cost}). Нажмите, чтобы открыть страницу поддержки"
+		"lottery_tooltip_ability_refresh_paid"					"{cost} доступных очков для изменения (уровень поддержки не меняется)"
+		"lottery_tooltip_ability_refresh_insufficient"			"Недостаточно доступных очков (нужно {cost}). Нажмите, чтобы открыть страницу поддержки"
 
 		"lottery_tooltip_item_refresh"							"Нажмите, чтобы изменить предметы"
 		"lottery_tooltip_item_refresh_used"						"Предметы изменены"

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -180,6 +180,8 @@
 		"lottery_tooltip_ability_refresh_used"					"Способности изменены"
 		"lottery_tooltip_ability_refresh_picked"				"Способность выбрана"
 		"lottery_tooltip_ability_refresh_not_member"			"Поддержавшие разработчика могут изменить способности один раз. Нажмите на эту кнопку, чтобы открыть страницу поддержки в браузере"
+		"lottery_tooltip_ability_refresh_paid"					"Изменить за {cost} очков поддержки"
+		"lottery_tooltip_ability_refresh_insufficient"			"Недостаточно очков поддержки (нужно {cost}). Нажмите, чтобы открыть страницу поддержки"
 
 		"lottery_tooltip_item_refresh"							"Нажмите, чтобы изменить предметы"
 		"lottery_tooltip_item_refresh_used"						"Предметы изменены"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -226,8 +226,8 @@
 		"lottery_tooltip_ability_refresh_used"					"技能已刷新"
 		"lottery_tooltip_ability_refresh_picked"				"技能已选择"
 		"lottery_tooltip_ability_refresh_not_member"			"会员可刷新一次技能，点击开通会员"
-		"lottery_tooltip_ability_refresh_paid"					"消耗 {cost} 会员积分刷新技能"
-		"lottery_tooltip_ability_refresh_insufficient"			"会员积分不足（需 {cost}），点击前往会员页"
+		"lottery_tooltip_ability_refresh_paid"					"{cost} 可用积分刷新技能（不降低会员等级）"
+		"lottery_tooltip_ability_refresh_insufficient"			"可用积分不足（需 {cost}），点击前往会员页"
 
 		"lottery_tooltip_item_refresh"							"点击刷新物品"
 		"lottery_tooltip_item_refresh_used"						"物品已刷新"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -226,8 +226,8 @@
 		"lottery_tooltip_ability_refresh_used"					"技能已刷新"
 		"lottery_tooltip_ability_refresh_picked"				"技能已选择"
 		"lottery_tooltip_ability_refresh_not_member"			"会员可刷新一次技能，点击开通会员"
-		"lottery_tooltip_ability_refresh_paid"					"消耗 {cost} 可用积分刷新技能（不降低会员等级）"
-		"lottery_tooltip_ability_refresh_insufficient"			"可用积分不足（需 {cost}），点击前往会员页"
+		"lottery_tooltip_ability_refresh_paid"					"消耗 <font color='#FFD700'>{cost}</font> 可用积分刷新技能（不降低会员等级）"
+		"lottery_tooltip_ability_refresh_insufficient"			"可用积分不足，点击前往会员页"
 
 		"lottery_tooltip_item_refresh"							"点击刷新物品"
 		"lottery_tooltip_item_refresh_used"						"物品已刷新"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -222,10 +222,12 @@
 		"lottery_active_ability_title"							"选择主动技能"
 		"lottery_passive_ability_title"							"选择被动技能"
 
-		"lottery_tooltip_ability_refresh"						"点击刷新技能"
+		"lottery_tooltip_ability_refresh"						"点击免费刷新技能"
 		"lottery_tooltip_ability_refresh_used"					"技能已刷新"
 		"lottery_tooltip_ability_refresh_picked"				"技能已选择"
 		"lottery_tooltip_ability_refresh_not_member"			"会员可刷新一次技能，点击开通会员"
+		"lottery_tooltip_ability_refresh_paid"					"消耗 {cost} 会员积分刷新技能"
+		"lottery_tooltip_ability_refresh_insufficient"			"会员积分不足（需 {cost}），点击前往会员页"
 
 		"lottery_tooltip_item_refresh"							"点击刷新物品"
 		"lottery_tooltip_item_refresh_used"						"物品已刷新"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -226,7 +226,7 @@
 		"lottery_tooltip_ability_refresh_used"					"技能已刷新"
 		"lottery_tooltip_ability_refresh_picked"				"技能已选择"
 		"lottery_tooltip_ability_refresh_not_member"			"会员可刷新一次技能，点击开通会员"
-		"lottery_tooltip_ability_refresh_paid"					"{cost} 可用积分刷新技能（不降低会员等级）"
+		"lottery_tooltip_ability_refresh_paid"					"消耗 {cost} 可用积分刷新技能（不降低会员等级）"
 		"lottery_tooltip_ability_refresh_insufficient"			"可用积分不足（需 {cost}），点击前往会员页"
 
 		"lottery_tooltip_item_refresh"							"点击刷新物品"

--- a/src/common/dto/lottery-status.d.ts
+++ b/src/common/dto/lottery-status.d.ts
@@ -14,6 +14,11 @@ export interface LotteryStatusDto {
   passiveAbilityLevel2?: number;
   isPassiveAbilityRefreshed2: boolean;
 
+  // 各槽位已付费刷新的次数，决定下次累进消耗；洗技能(reset)后归零
+  activePaidRefreshCount: number;
+  passivePaidRefreshCount: number;
+  passivePaidRefreshCount2: number;
+
   // 可重选技能的次数
   abilityResettableCount: number;
   showAbilityResetButton: boolean;

--- a/src/panorama/react/hud_lottery/components/LotteryRow.tsx
+++ b/src/panorama/react/hud_lottery/components/LotteryRow.tsx
@@ -38,6 +38,7 @@ const LotteryRow: React.FC<LotteryRowProps> = ({ type, onOpenMember }) => {
   const lotteryStatus = useNetTable('lottery_status', steamAccountId);
   const player = useNetTable('player_table', steamAccountId);
   const member = player?.member ?? null;
+  const useableMemberPoint = player?.useableMemberPoint ?? 0;
 
   // 监听抽奖数据变化（lotteryDataTableName 为动态 key，无法直接走 useNetTable）
   useEffect(() => {
@@ -81,6 +82,7 @@ const LotteryRow: React.FC<LotteryRowProps> = ({ type, onOpenMember }) => {
         type={type}
         lotteryStatus={lotteryStatus}
         member={member}
+        useableMemberPoint={useableMemberPoint}
         onOpenMember={onOpenMember}
       />
     </Panel>

--- a/src/panorama/react/hud_lottery/components/RefreshButton.tsx
+++ b/src/panorama/react/hud_lottery/components/RefreshButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { LotteryStatusDto } from '../../../../common/dto/lottery-status';
 import { MemberDto } from '../../../../vscripts/api/player';
 import { AbilityItemType } from '../../../../common/dto/lottery';
@@ -118,6 +118,17 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
     );
   };
 
+  const tooltipText = getTooltipText();
+
+  // DOTAShowTextTooltip 是快照式：悬停期间数据变化（点击付费刷新后 cost 进档、积分减少）
+  // 不会自动更新已显示的文本，需在仍悬停时主动重新 dispatch。
+  const hoverPanelRef = useRef<Panel | null>(null);
+  useEffect(() => {
+    if (hoverPanelRef.current) {
+      $.DispatchEvent('DOTAShowTextTooltip', hoverPanelRef.current, tooltipText);
+    }
+  }, [tooltipText]);
+
   const handleButtonClick = () => {
     if (guideToMember) {
       GameEvents.SendCustomGameEventToAllClients('hud_open_page', {
@@ -145,8 +156,14 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
       onactivate={handleButtonClick}
       style={buttonStyle}
       enabled={enabled}
-      onmouseover={(panel) => $.DispatchEvent('DOTAShowTextTooltip', panel, getTooltipText())}
-      onmouseout={() => $.DispatchEvent('DOTAHideTextTooltip')}
+      onmouseover={(panel) => {
+        hoverPanelRef.current = panel;
+        $.DispatchEvent('DOTAShowTextTooltip', panel, tooltipText);
+      }}
+      onmouseout={() => {
+        hoverPanelRef.current = null;
+        $.DispatchEvent('DOTAHideTextTooltip');
+      }}
     >
       <Image src={imageSrc} style={imageStyle} />
     </Button>

--- a/src/panorama/react/hud_lottery/components/RefreshButton.tsx
+++ b/src/panorama/react/hud_lottery/components/RefreshButton.tsx
@@ -128,9 +128,11 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
 
   const handleButtonClick = () => {
     if (guideToMember) {
+      // 积分不足直达购买积分子页；非会员到会员页
+      const param = isMember && !canAfford ? 'member:points' : 'member';
       GameEvents.SendCustomGameEventToAllClients('hud_open_page', {
         page: 'profile',
-        param: 'member',
+        param,
         playerId: Game.GetLocalPlayerID(),
       });
       onOpenMember?.();

--- a/src/panorama/react/hud_lottery/components/RefreshButton.tsx
+++ b/src/panorama/react/hud_lottery/components/RefreshButton.tsx
@@ -4,10 +4,14 @@ import { MemberDto } from '../../../../vscripts/api/player';
 import { AbilityItemType } from '../../../../common/dto/lottery';
 import { isMemberActive } from '../../shared/utils/member';
 
+// 与后端 ability-lottery.ts paidRefreshCosts 保持一致
+const PAID_REFRESH_COSTS = [10, 20, 30, 50];
+
 interface RefreshButtonProps {
   type: AbilityItemType;
   lotteryStatus: LotteryStatusDto | null;
   member: MemberDto | null;
+  useableMemberPoint: number;
   onOpenMember?: () => void;
 }
 
@@ -20,24 +24,6 @@ const imageStyle: Partial<VCSSStyleDeclaration> = {
   marginBottom: '20px',
   width: '50px',
   height: '50px',
-};
-
-const getTooltipTextToken = (
-  type: AbilityItemType,
-  isMember: boolean | undefined,
-  isRefreshed: boolean | undefined,
-  pickedName: string | undefined,
-) => {
-  if (!isMember) {
-    return '#lottery_tooltip_ability_refresh_not_member';
-  }
-  if (isRefreshed) {
-    return '#lottery_tooltip_ability_refresh_used';
-  }
-  if (pickedName) {
-    return '#lottery_tooltip_ability_refresh_picked';
-  }
-  return '#lottery_tooltip_ability_refresh';
 };
 
 const getIsRefreshed = (type: AbilityItemType, lotteryStatus: LotteryStatusDto | null) => {
@@ -66,33 +52,74 @@ const getPickedName = (type: AbilityItemType, lotteryStatus: LotteryStatusDto | 
   return undefined;
 };
 
+const getPaidCount = (type: AbilityItemType, lotteryStatus: LotteryStatusDto | null) => {
+  if (type === 'abilityActive') {
+    return lotteryStatus?.activePaidRefreshCount ?? 0;
+  }
+  if (type === 'abilityPassive') {
+    return lotteryStatus?.passivePaidRefreshCount ?? 0;
+  }
+  if (type === 'abilityPassive2') {
+    return lotteryStatus?.passivePaidRefreshCount2 ?? 0;
+  }
+  return 0;
+};
+
+const getPaidRefreshCost = (paidCount: number) =>
+  PAID_REFRESH_COSTS[Math.min(paidCount, PAID_REFRESH_COSTS.length - 1)];
+
 const RefreshButton: React.FC<RefreshButtonProps> = ({
   type,
   lotteryStatus,
   member,
+  useableMemberPoint,
   onOpenMember,
 }) => {
-  // 根据会员 抽选状态判断是否禁用
   const isMember = isMemberActive(member);
   const isRefreshed = getIsRefreshed(type, lotteryStatus);
   const pickedName = getPickedName(type, lotteryStatus);
+  const paidCount = getPaidCount(type, lotteryStatus);
 
-  // 禁用刷新按钮的条件
-  const enabled = isMember && !isRefreshed && !pickedName;
+  // 付费阶段（免费已用过）下次消耗，免费阶段为 0
+  const nextCost = isRefreshed ? getPaidRefreshCost(paidCount) : 0;
+  const canAfford = useableMemberPoint >= nextCost;
 
-  const imageSrc = enabled
-    ? 'file://{images}/custom_game/lottery/icon_rerolltoken.png'
-    : 'file://{images}/custom_game/lottery/icon_rerolltoken_disabled.png';
+  // 引导态：非会员、或会员付费但积分不足，按钮可点但点击跳转会员/充值页
+  const guideToMember = !isMember || (isRefreshed && !canAfford);
 
-  // 提示文本
-  const tooltipTextToken = getTooltipTextToken(type, isMember, isRefreshed, pickedName);
-  const tooltipText = $.Localize(tooltipTextToken);
+  // 已选技能锁定该行，禁用；其余情况按钮都可点（引导态点击跳转）
+  const enabled = !pickedName;
 
-  // 刷新事件
-  const refreshEventName = 'lottery_refresh_ability';
+  // 仅可正常刷新时显示亮色 token，引导态/禁用态用灰显图标
+  const imageSrc =
+    enabled && !guideToMember
+      ? 'file://{images}/custom_game/lottery/icon_rerolltoken.png'
+      : 'file://{images}/custom_game/lottery/icon_rerolltoken_disabled.png';
+
+  const getTooltipText = () => {
+    if (!isMember) {
+      return $.Localize('#lottery_tooltip_ability_refresh_not_member');
+    }
+    if (pickedName) {
+      return $.Localize('#lottery_tooltip_ability_refresh_picked');
+    }
+    if (!isRefreshed) {
+      return $.Localize('#lottery_tooltip_ability_refresh');
+    }
+    if (!canAfford) {
+      return $.Localize('#lottery_tooltip_ability_refresh_insufficient').replace(
+        '{cost}',
+        nextCost.toString(),
+      );
+    }
+    return $.Localize('#lottery_tooltip_ability_refresh_paid').replace(
+      '{cost}',
+      nextCost.toString(),
+    );
+  };
 
   const handleButtonClick = () => {
-    if (!isMember) {
+    if (guideToMember) {
       GameEvents.SendCustomGameEventToAllClients('hud_open_page', {
         page: 'profile',
         param: 'member',
@@ -102,13 +129,13 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
       return;
     }
 
-    if (isRefreshed) {
-      $.Msg('[RefreshButton] Already refreshed, ignoring click');
+    if (pickedName) {
+      $.Msg('[RefreshButton] Already picked, ignoring click');
       return;
     }
 
     $.Msg('[RefreshButton] Sending refresh event');
-    GameEvents.SendCustomGameEventToServer(refreshEventName, {
+    GameEvents.SendCustomGameEventToServer('lottery_refresh_ability', {
       type,
     });
   };
@@ -117,7 +144,8 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
     <Button
       onactivate={handleButtonClick}
       style={buttonStyle}
-      onmouseover={(panel) => $.DispatchEvent('DOTAShowTextTooltip', panel, tooltipText)}
+      enabled={enabled}
+      onmouseover={(panel) => $.DispatchEvent('DOTAShowTextTooltip', panel, getTooltipText())}
       onmouseout={() => $.DispatchEvent('DOTAHideTextTooltip')}
     >
       <Image src={imageSrc} style={imageStyle} />

--- a/src/panorama/react/hud_lottery/components/RefreshButton.tsx
+++ b/src/panorama/react/hud_lottery/components/RefreshButton.tsx
@@ -107,10 +107,7 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
       return $.Localize('#lottery_tooltip_ability_refresh');
     }
     if (!canAfford) {
-      return $.Localize('#lottery_tooltip_ability_refresh_insufficient').replace(
-        '{cost}',
-        nextCost.toString(),
-      );
+      return $.Localize('#lottery_tooltip_ability_refresh_insufficient');
     }
     return $.Localize('#lottery_tooltip_ability_refresh_paid').replace(
       '{cost}',

--- a/src/panorama/react/hud_main/pages/profile/ProfilePage.tsx
+++ b/src/panorama/react/hud_main/pages/profile/ProfilePage.tsx
@@ -5,11 +5,13 @@ import { GetLocalPlayerSteamAccountID } from '@utils/utils';
 import { useNavigation } from '../../store/NavigationContext';
 import { StatsTab } from './tabs/StatsTab';
 import { MemberTab } from './tabs/member';
+import { MemberSubTab } from './tabs/member/constants';
 
 export type ProfileTabId = 'stats' | 'member';
 
 interface ProfilePageProps {
-  initialTab?: ProfileTabId;
+  // 支持 'tab' 或 'tab:subTab'（如 'member:points'）定位到一级 tab 内的子页
+  initialTab?: string;
 }
 
 const PROFILE_TABS: { id: ProfileTabId; label: string }[] = [
@@ -18,7 +20,8 @@ const PROFILE_TABS: { id: ProfileTabId; label: string }[] = [
 ];
 
 export function ProfilePage({ initialTab = 'stats' }: ProfilePageProps) {
-  const [currentTab, setCurrentTab] = useState<ProfileTabId>(initialTab);
+  const [tab, subTab] = initialTab.split(':');
+  const [currentTab, setCurrentTab] = useState<ProfileTabId>(tab as ProfileTabId);
   const { closePage } = useNavigation();
   const steamId = GetLocalPlayerSteamAccountID();
   const player = useNetTable('player_table', steamId);
@@ -87,7 +90,9 @@ export function ProfilePage({ initialTab = 'stats' }: ProfilePageProps) {
 
       <Panel className="content-area">
         {currentTab === 'stats' && <StatsTab />}
-        {currentTab === 'member' && <MemberTab />}
+        {currentTab === 'member' && (
+          <MemberTab initialSubTab={subTab as MemberSubTab | undefined} />
+        )}
       </Panel>
     </Panel>
   );

--- a/src/panorama/react/hud_main/pages/profile/tabs/member/MemberTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/member/MemberTab.tsx
@@ -10,8 +10,13 @@ import { PointsPage } from './PointsPage';
 // 模块级缓存：MemberTab unmount/remount 之间保留上一次的 sub tab 选择
 let lastMemberSubTab: MemberSubTab = 'status';
 
-export function MemberTab() {
-  const [subTab, setSubTabRaw] = useState<MemberSubTab>(lastMemberSubTab);
+interface MemberTabProps {
+  // 外部跳转指定的初始子页（如积分不足跳转 'points'），优先于模块级缓存
+  initialSubTab?: MemberSubTab;
+}
+
+export function MemberTab({ initialSubTab }: MemberTabProps) {
+  const [subTab, setSubTabRaw] = useState<MemberSubTab>(initialSubTab ?? lastMemberSubTab);
   const setSubTab = (next: MemberSubTab) => {
     lastMemberSubTab = next;
     setSubTabRaw(next);

--- a/src/vscripts/api/analytics/ga4/ga4-treasure-tracker.ts
+++ b/src/vscripts/api/analytics/ga4/ga4-treasure-tracker.ts
@@ -16,7 +16,7 @@ export class GA4TreasureTracker {
   public static SendOpen(
     opener: CDOTA_BaseNPC,
     spawnCount: number,
-    point: Vector,
+    vector: Vector,
     tier: TreasureTier,
   ): void {
     const playerId = opener.GetPlayerOwnerID();
@@ -33,7 +33,7 @@ export class GA4TreasureTracker {
       is_bot: isBot,
       level: spawnCount,
       // 与 treasure.ts 中点位定义文本对齐，便于统计每个点被开次数
-      point: `Vector(${point.x}, ${point.y}, ${point.z})`,
+      vector: `Vector(${vector.x}, ${vector.y}, ${vector.z})`,
       tier,
       dota_duration: Math.floor(GameRules.GetDOTATime(false, true)),
     });

--- a/src/vscripts/api/player-member-point.ts
+++ b/src/vscripts/api/player-member-point.ts
@@ -1,0 +1,27 @@
+import { ApiClient, HttpMethod } from './api-client';
+import { Player, PlayerInfoDto } from './player';
+
+/**
+ * 消耗可用会员积分。fire-and-forget：调用方在发请求前已乐观更新本地状态，
+ * 这里只负责发请求并用回包的服务端真实积分纠正本地值（绝大多数情况扣分成功）。
+ */
+export class PlayerMemberPointApi {
+  public static UseMemberPoint(steamId: number, memberPoint: number, reason: string) {
+    ApiClient.sendWithRetry({
+      method: HttpMethod.POST,
+      path: `/player/member-points/use`,
+      body: {
+        steamId,
+        memberPoint,
+        reason,
+      },
+      successFunc: (data) => {
+        const player = json.decode(data)[0] as PlayerInfoDto;
+        Player.MergePlayerInfo(player);
+      },
+      failureFunc: (data) => {
+        print(`[PlayerMemberPoint] UseMemberPoint failed: ${data}`);
+      },
+    });
+  }
+}

--- a/src/vscripts/api/player.ts
+++ b/src/vscripts/api/player.ts
@@ -136,4 +136,24 @@ export class Player {
     const player = Player.playerInfoMap.get(steamId.toString());
     return player?.seasonLevel ?? 0;
   }
+
+  public static GetUseableMemberPoint(steamId: number) {
+    const player = Player.playerInfoMap.get(steamId.toString());
+    return player?.useableMemberPoint ?? 0;
+  }
+
+  /**
+   * 本地预扣可用会员积分（乐观更新），同步到 net table。
+   * 服务端真实扣分以 member-points/use 回包 merge 为准，此处仅消除回包前的显示延迟。
+   */
+  public static DeductUseableMemberPoint(steamId: number, point: number) {
+    const player = Player.playerInfoMap.get(steamId.toString());
+    if (!player) {
+      return;
+    }
+    Player.MergePlayerInfo({
+      id: player.id,
+      useableMemberPoint: Math.max(0, player.useableMemberPoint - point),
+    });
+  }
 }

--- a/src/vscripts/modules/helper/net-table-helper.ts
+++ b/src/vscripts/modules/helper/net-table-helper.ts
@@ -14,6 +14,9 @@ export class NetTableHelper {
         isActiveAbilityRefreshed: false,
         isPassiveAbilityRefreshed: false,
         isPassiveAbilityRefreshed2: false,
+        activePaidRefreshCount: 0,
+        passivePaidRefreshCount: 0,
+        passivePaidRefreshCount2: 0,
         abilityResettableCount: 0,
         showAbilityResetButton: false,
       };
@@ -29,6 +32,9 @@ export class NetTableHelper {
       passiveAbilityName2: lotteryStatusData.passiveAbilityName2,
       passiveAbilityLevel2: lotteryStatusData.passiveAbilityLevel2,
       isPassiveAbilityRefreshed2: Boolean(lotteryStatusData.isPassiveAbilityRefreshed2),
+      activePaidRefreshCount: lotteryStatusData.activePaidRefreshCount ?? 0,
+      passivePaidRefreshCount: lotteryStatusData.passivePaidRefreshCount ?? 0,
+      passivePaidRefreshCount2: lotteryStatusData.passivePaidRefreshCount2 ?? 0,
       abilityResettableCount: lotteryStatusData.abilityResettableCount,
       showAbilityResetButton: Boolean(lotteryStatusData.showAbilityResetButton),
     };

--- a/src/vscripts/modules/lottery/ability/ability-lottery.ts
+++ b/src/vscripts/modules/lottery/ability/ability-lottery.ts
@@ -1,4 +1,7 @@
 import { AbilityItemType, LotteryDto } from '../../../../common/dto/lottery';
+import { LotteryStatusDto } from '../../../../common/dto/lottery-status';
+import { ApiClient } from '../../../api/api-client';
+import { PlayerMemberPointApi } from '../../../api/player-member-point';
 import { MemberLevel, Player } from '../../../api/player';
 import { reloadable } from '../../../utils/tstl-utils';
 import { NetTableHelper } from '../../helper/net-table-helper';
@@ -11,6 +14,9 @@ import { abilityTiersActive, abilityTiersPassive } from './lottery-abilities';
 export class AbilityLottery {
   readonly randomCountBase = 6;
   readonly randomCountExtra = 2;
+
+  // 付费刷新累进消耗：首次免费后，第 n 次付费(n 从 0)取此表，封顶 50
+  readonly paidRefreshCosts = [10, 20, 30, 50];
 
   constructor() {
     // 启动物品抽奖
@@ -63,6 +69,9 @@ export class AbilityLottery {
         isActiveAbilityRefreshed: false,
         isPassiveAbilityRefreshed: false,
         isPassiveAbilityRefreshed2: false,
+        activePaidRefreshCount: 0,
+        passivePaidRefreshCount: 0,
+        passivePaidRefreshCount2: 0,
         abilityResettableCount: 0,
         showAbilityResetButton: false,
       },
@@ -233,33 +242,21 @@ export class AbilityLottery {
   refreshAbility(userId: EntityIndex, event: LotteryRefreshEventData & CustomGameEventDataBase) {
     const steamAccountID = PlayerResource.GetSteamAccountID(event.PlayerID).toString();
     const lotteryStatus = NetTableHelper.GetLotteryStatus(steamAccountID);
+    const abilityType = event.type;
     if (
-      event.type !== AbilityItemTypes.Active &&
-      event.type !== AbilityItemTypes.Passive &&
-      event.type !== AbilityItemTypes.Passive2
+      abilityType !== AbilityItemTypes.Active &&
+      abilityType !== AbilityItemTypes.Passive &&
+      abilityType !== AbilityItemTypes.Passive2
     ) {
       print('刷新技能类型错误');
       return;
     }
-    if (event.type === AbilityItemTypes.Active) {
-      if (lotteryStatus.isActiveAbilityRefreshed || lotteryStatus.activeAbilityName) {
-        print('已经刷新/抽取过主动技能');
-        return;
-      }
-    }
-    // 将被动技能刷新检查改为：
-    if (event.type === AbilityItemTypes.Passive) {
-      if (lotteryStatus.isPassiveAbilityRefreshed || lotteryStatus.passiveAbilityName) {
-        print('已经刷新/抽取过被动技能');
-        return;
-      }
-    }
-    // 检查第二个被动技能槽位刷新
-    if (event.type === AbilityItemTypes.Passive2) {
-      if (lotteryStatus.isPassiveAbilityRefreshed2 || lotteryStatus.passiveAbilityName2) {
-        print('已经刷新/抽取过第二个被动技能');
-        return;
-      }
+
+    // 已选技能的槽位锁定，不可再刷新
+    const pickedName = this.getPickedName(lotteryStatus, abilityType);
+    if (pickedName) {
+      print('已经抽取过技能，不能刷新');
+      return;
     }
 
     if (!Player.IsMemberStatic(Number(steamAccountID))) {
@@ -267,18 +264,91 @@ export class AbilityLottery {
       return;
     }
 
-    // 刷新技能
-    this.randomAbilityForPlayer(event.PlayerID, event.type);
-
-    // 记录刷新状态
-    if (event.type === AbilityItemTypes.Active) {
-      lotteryStatus.isActiveAbilityRefreshed = true;
-    } else if (event.type === AbilityItemTypes.Passive) {
-      lotteryStatus.isPassiveAbilityRefreshed = true;
-    } else if (event.type === AbilityItemTypes.Passive2) {
-      lotteryStatus.isPassiveAbilityRefreshed2 = true;
+    const isRefreshed = this.isSlotRefreshed(lotteryStatus, abilityType);
+    if (!isRefreshed) {
+      // 免费刷新：首次不消耗积分
+      this.randomAbilityForPlayer(event.PlayerID, abilityType);
+      this.setSlotRefreshed(lotteryStatus, abilityType, true);
+      CustomNetTables.SetTableValue('lottery_status', steamAccountID, lotteryStatus);
+      return;
     }
+
+    // 付费刷新仅限官方服务器
+    if (ApiClient.IsLocalhost()) {
+      print('非官方服务器不能付费刷新');
+      return;
+    }
+
+    const paidCount = this.getSlotPaidCount(lotteryStatus, abilityType);
+    const cost = this.getPaidRefreshCost(paidCount);
+
+    // 乐观更新：不等 API 回包，直接重抽并本地预扣积分；回包再以服务端真实积分纠正
+    const steamId = Number(steamAccountID);
+    if (Player.GetUseableMemberPoint(steamId) < cost) {
+      print('会员积分不足，无法付费刷新');
+      return;
+    }
+    Player.DeductUseableMemberPoint(steamId, cost);
+    PlayerMemberPointApi.UseMemberPoint(steamId, cost, 'lottery_refresh_ability');
+
+    this.randomAbilityForPlayer(event.PlayerID, abilityType);
+    this.setSlotPaidCount(lotteryStatus, abilityType, paidCount + 1);
     CustomNetTables.SetTableValue('lottery_status', steamAccountID, lotteryStatus);
+  }
+
+  /** 第 paidCount 次付费(从 0 起)的积分消耗，封顶为表内最后一档 */
+  private getPaidRefreshCost(paidCount: number): number {
+    const index = Math.min(paidCount, this.paidRefreshCosts.length - 1);
+    return this.paidRefreshCosts[index];
+  }
+
+  private getPickedName(
+    lotteryStatus: LotteryStatusDto,
+    abilityType: AbilityItemType,
+  ): string | undefined {
+    if (abilityType === AbilityItemTypes.Active) return lotteryStatus.activeAbilityName;
+    if (abilityType === AbilityItemTypes.Passive) return lotteryStatus.passiveAbilityName;
+    return lotteryStatus.passiveAbilityName2;
+  }
+
+  private isSlotRefreshed(lotteryStatus: LotteryStatusDto, abilityType: AbilityItemType): boolean {
+    if (abilityType === AbilityItemTypes.Active) return lotteryStatus.isActiveAbilityRefreshed;
+    if (abilityType === AbilityItemTypes.Passive) return lotteryStatus.isPassiveAbilityRefreshed;
+    return lotteryStatus.isPassiveAbilityRefreshed2;
+  }
+
+  private setSlotRefreshed(
+    lotteryStatus: LotteryStatusDto,
+    abilityType: AbilityItemType,
+    value: boolean,
+  ) {
+    if (abilityType === AbilityItemTypes.Active) {
+      lotteryStatus.isActiveAbilityRefreshed = value;
+    } else if (abilityType === AbilityItemTypes.Passive) {
+      lotteryStatus.isPassiveAbilityRefreshed = value;
+    } else {
+      lotteryStatus.isPassiveAbilityRefreshed2 = value;
+    }
+  }
+
+  private getSlotPaidCount(lotteryStatus: LotteryStatusDto, abilityType: AbilityItemType): number {
+    if (abilityType === AbilityItemTypes.Active) return lotteryStatus.activePaidRefreshCount;
+    if (abilityType === AbilityItemTypes.Passive) return lotteryStatus.passivePaidRefreshCount;
+    return lotteryStatus.passivePaidRefreshCount2;
+  }
+
+  private setSlotPaidCount(
+    lotteryStatus: LotteryStatusDto,
+    abilityType: AbilityItemType,
+    value: number,
+  ) {
+    if (abilityType === AbilityItemTypes.Active) {
+      lotteryStatus.activePaidRefreshCount = value;
+    } else if (abilityType === AbilityItemTypes.Passive) {
+      lotteryStatus.passivePaidRefreshCount = value;
+    } else {
+      lotteryStatus.passivePaidRefreshCount2 = value;
+    }
   }
 
   /**
@@ -355,19 +425,22 @@ export class AbilityLottery {
       );
     }
 
-    // 清除对应的技能名称和等级
+    // 清除对应的技能名称和等级，付费刷新计数一并归零（消耗梯度回到第一档）
     if (abilityType === AbilityItemTypes.Active) {
       lotteryStatus.activeAbilityName = undefined;
       lotteryStatus.activeAbilityLevel = undefined;
       lotteryStatus.isActiveAbilityRefreshed = false;
+      lotteryStatus.activePaidRefreshCount = 0;
     } else if (abilityType === AbilityItemTypes.Passive) {
       lotteryStatus.passiveAbilityName = undefined;
       lotteryStatus.passiveAbilityLevel = undefined;
       lotteryStatus.isPassiveAbilityRefreshed = false;
+      lotteryStatus.passivePaidRefreshCount = 0;
     } else if (abilityType === AbilityItemTypes.Passive2) {
       lotteryStatus.passiveAbilityName2 = undefined;
       lotteryStatus.passiveAbilityLevel2 = undefined;
       lotteryStatus.isPassiveAbilityRefreshed2 = false;
+      lotteryStatus.passivePaidRefreshCount2 = 0;
     }
 
     // 重新生成该行的技能


### PR DESCRIPTION
## Issue

- [x] fix #1887

## Release Note

```
[b]游戏性更新 v5.32b[/b]

- 会员可消耗可用会员积分额外刷新抽选技能，不会降低会员等级。
```

```
[b]Gameplay update v5.32b[/b]

- Members can spend useable member points to reroll drafted abilities, without lowering membership level.
```