### PR TITLE
Add member point item lottery refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+本仓库唯一项目规范文件是 `.claude/CLAUDE.md`。
+
+在进行任何代码修改、issue 处理、review、测试、构建或发布前，必须先读取 `.claude/CLAUDE.md`，并遵守其中规则。
+
+如果任务涉及特定 workflow，还必须读取 `.claude/skills/<skill-name>/SKILL.md` 中对应规则。
+
+不要在本文件维护重复项目规范；规范变更只修改 `.claude/CLAUDE.md`。

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -223,16 +223,20 @@
 		"lottery_active_ability_title"							"Select active ability"
 		"lottery_passive_ability_title"							"Select passive ability"
 
-		"lottery_tooltip_ability_refresh"						"Click to reroll abilities for free."
+		"lottery_tooltip_ability_refresh"						"Members can reroll abilities once for free."
 		"lottery_tooltip_ability_refresh_used"					"Ability has been rerolled."
 		"lottery_tooltip_ability_refresh_picked"				"Ability has been selected."
 		"lottery_tooltip_ability_refresh_not_member"			"Members can reroll abilities once per game. Click this button to open the membership page in your browser."
-		"lottery_tooltip_ability_refresh_paid"					"Spend <font color='#FFD700'>{cost}</font> useable points to reroll (membership level unchanged)."
+		"lottery_tooltip_ability_refresh_paid"					"Spend <font color='#FFD700'>{cost}</font> useable points to reroll<br>Remaining available rerolls: {remaining}<br>(total member points and membership level unchanged)."
+		"lottery_tooltip_ability_refresh_limit"					"No available rerolls left.<br>Remaining available rerolls: 0"
 		"lottery_tooltip_ability_refresh_insufficient"			"Not enough useable points. Click to open the membership page."
 
-		"lottery_tooltip_item_refresh"							"Click to reroll items."
+		"lottery_tooltip_item_refresh"							"Premium members can reroll items once for free."
 		"lottery_tooltip_item_refresh_used"						"Items have been rerolled."
-		"lottery_tooltip_item_refresh_not_premium"				"Premium members can reroll items once per box. Click to open the membership page."
+		"lottery_tooltip_item_refresh_not_premium"				"Premium members can reroll items. Click to open the membership page."
+		"lottery_tooltip_item_refresh_paid"						"Spend <font color='#FFD700'>{cost}</font> useable points to reroll items<br>Remaining available rerolls: {remaining}<br>(total member points and membership level unchanged)."
+		"lottery_tooltip_item_refresh_limit"					"No available rerolls left.<br>Remaining available rerolls: 0"
+		"lottery_tooltip_item_refresh_insufficient"				"Not enough useable points. Click to open the membership page."
 
 		"lottery_button_ability_reset"							"Reset"
 		"lottery_tooltip_ability_reset_enable"					"Remove the selected ability and reroll a new set of abilities"
@@ -3163,7 +3167,7 @@
 		"DOTA_Tooltip_modifier_item_magic_sword_debuff"									"Demonic Corruption"
 		"DOTA_Tooltip_modifier_item_magic_sword_debuff_Description"						"Armor reduced by %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS%, attack speed reduced by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%, movement speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%%, health regeneration reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%"
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset"								"Ability Reset Tome"
-		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Description"					"<h1>Use: Ability Reset</h1>Opens the ability draft interface, allowing you to remove selected abilities and learn new ones.<br>Skill points are refunded when removing abilities.<br><br>One tome can only be used to reset one ability.\n\n<h1>Dropped by Roshan</h1>Can be shared with teammates."
+		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Description"					"<h1>Use: Ability Reset</h1>Opens the ability draft interface, allowing you to remove selected abilities and learn new ones.<br>Skill points are refunded when removing abilities.<br><br>One tome can only be used to reset one ability.\n\nCan be shared with teammates."
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"Redesign your ability path."
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"Respec Tome"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -223,16 +223,20 @@
 		"lottery_active_ability_title"							"选择主动技能"
 		"lottery_passive_ability_title"							"选择被动技能"
 
-		"lottery_tooltip_ability_refresh"						"点击免费刷新技能"
+		"lottery_tooltip_ability_refresh"						"会员可以免费刷新一次技能"
 		"lottery_tooltip_ability_refresh_used"					"技能已刷新"
 		"lottery_tooltip_ability_refresh_picked"				"技能已选择"
 		"lottery_tooltip_ability_refresh_not_member"			"会员可刷新一次技能，点击开通会员"
-		"lottery_tooltip_ability_refresh_paid"					"消耗 <font color='#FFD700'>{cost}</font> 可用积分刷新技能（不降低会员等级）"
+		"lottery_tooltip_ability_refresh_paid"					"消耗 <font color='#FFD700'>{cost}</font> 可用积分刷新技能<br>剩余可用刷新次数：{remaining}<br>（不降低总会员积分及会员等级）"
+		"lottery_tooltip_ability_refresh_limit"					"可用刷新次数已用完<br>剩余可用刷新次数：0"
 		"lottery_tooltip_ability_refresh_insufficient"			"可用积分不足，点击前往会员页"
 
-		"lottery_tooltip_item_refresh"							"点击刷新物品"
+		"lottery_tooltip_item_refresh"							"会员可以免费刷新一次物品"
 		"lottery_tooltip_item_refresh_used"						"物品已刷新"
-		"lottery_tooltip_item_refresh_not_premium"				"高级会员可刷新一次物品，点击开通会员"
+		"lottery_tooltip_item_refresh_not_premium"				"高级会员可刷新物品，点击开通会员"
+		"lottery_tooltip_item_refresh_paid"						"消耗 <font color='#FFD700'>{cost}</font> 可用积分刷新物品<br>剩余可用刷新次数：{remaining}<br>（不降低总会员积分及会员等级）"
+		"lottery_tooltip_item_refresh_limit"					"可用刷新次数已用完<br>剩余可用刷新次数：0"
+		"lottery_tooltip_item_refresh_insufficient"				"可用积分不足，点击前往会员页"
 
 		"lottery_button_ability_reset"							"重置"
 		"lottery_tooltip_ability_reset_enable"					"移除已选择的技能，并重新抽选一组新技能"
@@ -3218,7 +3222,7 @@
 		"DOTA_Tooltip_modifier_item_magic_sword_debuff_Description"						"护甲降低 %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS%，攻击速度降低 %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%，移动速度降低 %dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%%，生命回复降低 %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%"
 
 		"DOTA_Tooltip_Ability_item_tome_of_ability_reset"								"能力重置书"
-		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Description"					"<h1>使用：能力重置</h1>打开能力重置界面，可以移除已学习的技能并学习新技能。<br>移除技能时会返还技能点。<br><br>一本书只能选择一个技能进行重置。\n\n<h1>击杀肉山时掉落</h1>可以分享给队友"
+		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Description"					"<h1>使用：能力重置</h1>打开能力重置界面，可以移除已学习的技能并学习新技能。<br>移除技能时会返还技能点。<br><br>一本书只能选择一个技能进行重置。\n\n可以分享给队友"
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。"
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"技能洗点书"

--- a/src/common/dto/lottery-status.d.ts
+++ b/src/common/dto/lottery-status.d.ts
@@ -14,7 +14,7 @@ export interface LotteryStatusDto {
   passiveAbilityLevel2?: number;
   isPassiveAbilityRefreshed2: boolean;
 
-  // 各槽位已付费刷新的次数，决定下次累进消耗；洗技能(reset)后归零
+  // 各槽位已使用会员积分刷新的次数，决定下次累进消耗；洗技能(reset)后归零
   activePaidRefreshCount: number;
   passivePaidRefreshCount: number;
   passivePaidRefreshCount2: number;

--- a/src/common/net_tables.d.ts
+++ b/src/common/net_tables.d.ts
@@ -71,7 +71,9 @@ declare global {
       [playerId: string]: {
         candidates: LotteryDto[];
         isRefreshed: boolean;
-        // 奖池档位（initial/default/premium）。命名为 poolType 而非 tier，避免与物品自身的 1~5 级 tier 混淆。
+        // 已使用会员积分刷新的次数；每个藏宝箱单独计算，新藏宝箱从 0 开始。
+        paidRefreshCount: number;
+        // 奖池档位（initial/default/premium/ultra）。命名为 poolType 而非 tier，避免与物品自身的 1~7 级 tier 混淆。
         poolType: string;
       };
     };

--- a/src/panorama/react/hud_lottery/ItemLottery.tsx
+++ b/src/panorama/react/hud_lottery/ItemLottery.tsx
@@ -1,6 +1,6 @@
 import 'panorama-polyfill-x/lib/console';
 import 'panorama-polyfill-x/lib/timers';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { LotteryDto } from '../../../common/dto/lottery';
 import { useNetTable } from '../shared/hooks/useNetTable';
 import { isPremiumMember } from '../shared/utils/member';
@@ -9,6 +9,8 @@ import { colors } from './colors';
 
 const EXPIRE_SECONDS = 12;
 const TICK_INTERVAL_MS = 100;
+const PAID_REFRESH_COSTS = [10, 20, 30, 50];
+const MAX_PAID_REFRESH_COUNT = 5;
 
 const containerStyle: Partial<VCSSStyleDeclaration> = {
   horizontalAlign: 'center',
@@ -80,10 +82,14 @@ const getTierGlow = (level: number): string => {
     3: colors.tier3,
     4: colors.tier4,
     5: colors.tier5,
-    6: colors.tier5, // T6 沿用 T5 颜色
+    6: colors.tier5,
+    7: colors.tier5,
   };
   return `0 0 2px 1px ${map[level] ?? colors.tier1}`;
 };
+
+const getPaidRefreshCost = (paidCount: number) =>
+  PAID_REFRESH_COSTS[Math.min(paidCount, PAID_REFRESH_COSTS.length - 1)];
 
 function pickItem(candidate: LotteryDto) {
   GameEvents.SendCustomGameEventToServer('lottery_pick_item', {
@@ -95,32 +101,64 @@ function pickItem(candidate: LotteryDto) {
 interface RefreshIconButtonProps {
   isPremium: boolean;
   isRefreshed: boolean;
+  paidRefreshCount: number;
+  useableMemberPoint: number;
 }
 
-function RefreshIconButton({ isPremium, isRefreshed }: RefreshIconButtonProps) {
-  const enabled = isPremium && !isRefreshed;
-  const imageSrc = enabled
+function RefreshIconButton({
+  isPremium,
+  isRefreshed,
+  paidRefreshCount,
+  useableMemberPoint,
+}: RefreshIconButtonProps) {
+  const remainingPaidRefreshCount = Math.max(0, MAX_PAID_REFRESH_COUNT - paidRefreshCount);
+  const isPaidRefreshLimitReached = isRefreshed && remainingPaidRefreshCount <= 0;
+  const nextCost = isRefreshed ? getPaidRefreshCost(paidRefreshCount) : 0;
+  const canAfford = useableMemberPoint >= nextCost;
+  const guideToMember = !isPremium || (isRefreshed && !isPaidRefreshLimitReached && !canAfford);
+  const canRefresh = isPremium && canAfford && !isPaidRefreshLimitReached;
+  const imageSrc = canRefresh
     ? 'file://{images}/custom_game/lottery/icon_rerolltoken.png'
     : 'file://{images}/custom_game/lottery/icon_rerolltoken_disabled.png';
 
-  const tooltipText = $.Localize(
-    !isPremium
-      ? '#lottery_tooltip_item_refresh_not_premium'
-      : isRefreshed
-        ? '#lottery_tooltip_item_refresh_used'
-        : '#lottery_tooltip_item_refresh',
-  );
+  const getTooltipText = () => {
+    if (!isPremium) {
+      return $.Localize('#lottery_tooltip_item_refresh_not_premium');
+    }
+    if (!isRefreshed) {
+      return $.Localize('#lottery_tooltip_item_refresh');
+    }
+    if (isPaidRefreshLimitReached) {
+      return $.Localize('#lottery_tooltip_item_refresh_limit');
+    }
+    if (!canAfford) {
+      return $.Localize('#lottery_tooltip_item_refresh_insufficient');
+    }
+    return $.Localize('#lottery_tooltip_item_refresh_paid')
+      .replace('{cost}', nextCost.toString())
+      .replace('{remaining}', remainingPaidRefreshCount.toString());
+  };
+
+  const tooltipText = getTooltipText();
+  const hoverPanelRef = useRef<Panel | null>(null);
+
+  useEffect(() => {
+    if (hoverPanelRef.current) {
+      $.DispatchEvent('DOTAShowTextTooltip', hoverPanelRef.current, tooltipText);
+    }
+  }, [tooltipText]);
 
   const handleClick = () => {
-    if (!isPremium) {
+    if (guideToMember) {
+      const param = isPremium && !canAfford ? 'member:points' : 'member';
       GameEvents.SendCustomGameEventToAllClients('hud_open_page', {
         page: 'profile',
-        param: 'member',
+        param,
         playerId: Game.GetLocalPlayerID(),
       });
       return;
     }
-    if (isRefreshed) {
+    if (isPaidRefreshLimitReached) {
       return;
     }
     GameEvents.SendCustomGameEventToServer('lottery_refresh_item', {});
@@ -130,8 +168,14 @@ function RefreshIconButton({ isPremium, isRefreshed }: RefreshIconButtonProps) {
     <Button
       onactivate={handleClick}
       style={refreshButtonStyle}
-      onmouseover={(panel) => $.DispatchEvent('DOTAShowTextTooltip', panel, tooltipText)}
-      onmouseout={() => $.DispatchEvent('DOTAHideTextTooltip')}
+      onmouseover={(panel) => {
+        hoverPanelRef.current = panel;
+        $.DispatchEvent('DOTAShowTextTooltip', panel, tooltipText);
+      }}
+      onmouseout={() => {
+        hoverPanelRef.current = null;
+        $.DispatchEvent('DOTAHideTextTooltip');
+      }}
     >
       <Image src={imageSrc} style={refreshImageStyle} />
     </Button>
@@ -150,8 +194,10 @@ function ItemLottery() {
     : [];
   // 引擎把 boolean 同步为 0/1
   const isRefreshed = Boolean(raw?.isRefreshed);
+  const paidRefreshCount = raw?.paidRefreshCount ?? 0;
 
   const isPremium = isPremiumMember(player?.member);
+  const useableMemberPoint = player?.useableMemberPoint ?? 0;
 
   const [remaining, setRemaining] = useState(EXPIRE_SECONDS);
 
@@ -198,7 +244,12 @@ function ItemLottery() {
             }}
           />
         ))}
-        <RefreshIconButton isPremium={isPremium} isRefreshed={isRefreshed} />
+        <RefreshIconButton
+          isPremium={isPremium}
+          isRefreshed={isRefreshed}
+          paidRefreshCount={paidRefreshCount}
+          useableMemberPoint={useableMemberPoint}
+        />
       </Panel>
       <Panel style={progressTrackStyle}>
         <Panel style={{ ...progressFillStyle, width: `${progressPct}%` }} />

--- a/src/panorama/react/hud_lottery/components/RefreshButton.tsx
+++ b/src/panorama/react/hud_lottery/components/RefreshButton.tsx
@@ -6,6 +6,7 @@ import { isMemberActive } from '../../shared/utils/member';
 
 // 与后端 ability-lottery.ts paidRefreshCosts 保持一致
 const PAID_REFRESH_COSTS = [10, 20, 30, 50];
+const MAX_PAID_REFRESH_COUNT = 5;
 
 interface RefreshButtonProps {
   type: AbilityItemType;
@@ -79,16 +80,18 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
   const isRefreshed = getIsRefreshed(type, lotteryStatus);
   const pickedName = getPickedName(type, lotteryStatus);
   const paidCount = getPaidCount(type, lotteryStatus);
+  const remainingPaidRefreshCount = Math.max(0, MAX_PAID_REFRESH_COUNT - paidCount);
+  const isPaidRefreshLimitReached = isRefreshed && remainingPaidRefreshCount <= 0;
 
-  // 付费阶段（免费已用过）下次消耗，免费阶段为 0
+  // 会员积分刷新阶段（免费已用过）下次消耗，免费阶段为 0
   const nextCost = isRefreshed ? getPaidRefreshCost(paidCount) : 0;
   const canAfford = useableMemberPoint >= nextCost;
 
-  // 引导态：非会员、或会员付费但积分不足，按钮可点但点击跳转会员/充值页
-  const guideToMember = !isMember || (isRefreshed && !canAfford);
+  // 引导态：非会员、或会员积分不足，按钮可点但点击跳转会员/充值页
+  const guideToMember = !isMember || (isRefreshed && !isPaidRefreshLimitReached && !canAfford);
 
   // 已选技能锁定该行，禁用；其余情况按钮都可点（引导态点击跳转）
-  const enabled = !pickedName;
+  const enabled = !pickedName && !isPaidRefreshLimitReached;
 
   // 仅可正常刷新时显示亮色 token，引导态/禁用态用灰显图标
   const imageSrc =
@@ -106,18 +109,20 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
     if (!isRefreshed) {
       return $.Localize('#lottery_tooltip_ability_refresh');
     }
+    if (isPaidRefreshLimitReached) {
+      return $.Localize('#lottery_tooltip_ability_refresh_limit');
+    }
     if (!canAfford) {
       return $.Localize('#lottery_tooltip_ability_refresh_insufficient');
     }
-    return $.Localize('#lottery_tooltip_ability_refresh_paid').replace(
-      '{cost}',
-      nextCost.toString(),
-    );
+    return $.Localize('#lottery_tooltip_ability_refresh_paid')
+      .replace('{cost}', nextCost.toString())
+      .replace('{remaining}', remainingPaidRefreshCount.toString());
   };
 
   const tooltipText = getTooltipText();
 
-  // DOTAShowTextTooltip 是快照式：悬停期间数据变化（点击付费刷新后 cost 进档、积分减少）
+  // DOTAShowTextTooltip 是快照式：悬停期间数据变化（点击会员积分刷新后 cost 进档、积分减少）
   // 不会自动更新已显示的文本，需在仍悬停时主动重新 dispatch。
   const hoverPanelRef = useRef<Panel | null>(null);
   useEffect(() => {
@@ -141,6 +146,10 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
 
     if (pickedName) {
       $.Msg('[RefreshButton] Already picked, ignoring click');
+      return;
+    }
+    if (isPaidRefreshLimitReached) {
+      $.Msg('[RefreshButton] Paid refresh limit reached, ignoring click');
       return;
     }
 

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.32';
+  public static readonly GAME_VERSION = 'v5.33';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数

--- a/src/vscripts/modules/event/event-entity-killed.ts
+++ b/src/vscripts/modules/event/event-entity-killed.ts
@@ -216,9 +216,6 @@ export class EventEntityKilled {
   private itemLightPartName = 'item_light_part';
   private itemDarkPartName = 'item_dark_part';
 
-  // 技能重置书
-  private itemTomeOfAbilityReset = 'item_tome_of_ability_reset';
-
   // 龙珠
   private dropItemListDragonBall: string[] = [
     'item_dragon_ball_1',
@@ -302,17 +299,12 @@ export class EventEntityKilled {
           true,
         );
 
-        // 技能重置书 / 融合符文 二选一掉落，两类等权（各 50%）
-        const roshanBonusPool =
-          RandomFloat(0, 1) < 0.5 ? [this.itemTomeOfAbilityReset] : this.dropItemListFusionMaterial;
-        this.dropItem(creep, roshanBonusPool, this.dropItemChanceRoshan);
-
-        // 击杀肉山：全体人类玩家各获得一次 PREMIUM 物品抽奖
+        // 击杀肉山：全体人类玩家各获得一次 ULTRA 物品抽奖
         PlayerHelper.ForEachPlayer((playerId) => {
           if (!PlayerHelper.IsHumanPlayerByPlayerId(playerId)) return;
           const hero = PlayerResource.GetSelectedHeroEntity(playerId);
           if (!hero) return;
-          GameRules.Lottery.Item.onTriggered(hero, ItemLotteryPool.PREMIUM);
+          GameRules.Lottery.Item.onTriggered(hero, ItemLotteryPool.ULTRA);
         });
       }
     } else if (creep.IsAncient()) {

--- a/src/vscripts/modules/lottery/ability/ability-lottery.ts
+++ b/src/vscripts/modules/lottery/ability/ability-lottery.ts
@@ -15,8 +15,9 @@ export class AbilityLottery {
   readonly randomCountBase = 6;
   readonly randomCountExtra = 2;
 
-  // 付费刷新累进消耗：首次免费后，第 n 次付费(n 从 0)取此表，封顶 50
+  // 会员积分刷新累进消耗：首次免费后，第 n 次积分刷新(n 从 0)取此表，封顶 50
   readonly paidRefreshCosts = [10, 20, 30, 50];
+  readonly maxPaidRefreshCount = 5;
 
   constructor() {
     // 启动物品抽奖
@@ -273,13 +274,17 @@ export class AbilityLottery {
       return;
     }
 
-    // 付费刷新仅限官方服务器
+    // 会员积分刷新仅限官方服务器
     if (ApiClient.IsLocalhost()) {
       print('非官方服务器不能付费刷新');
       return;
     }
 
     const paidCount = this.getSlotPaidCount(lotteryStatus, abilityType);
+    if (paidCount >= this.maxPaidRefreshCount) {
+      print('付费刷新次数已用完');
+      return;
+    }
     const cost = this.getPaidRefreshCost(paidCount);
 
     // 乐观更新：不等 API 回包，直接重抽并本地预扣积分；回包再以服务端真实积分纠正
@@ -296,7 +301,7 @@ export class AbilityLottery {
     CustomNetTables.SetTableValue('lottery_status', steamAccountID, lotteryStatus);
   }
 
-  /** 第 paidCount 次付费(从 0 起)的积分消耗，封顶为表内最后一档 */
+  /** 第 paidCount 次会员积分刷新(从 0 起)的积分消耗，封顶为表内最后一档 */
   private getPaidRefreshCost(paidCount: number): number {
     const index = Math.min(paidCount, this.paidRefreshCosts.length - 1);
     return this.paidRefreshCosts[index];
@@ -425,7 +430,7 @@ export class AbilityLottery {
       );
     }
 
-    // 清除对应的技能名称和等级，付费刷新计数一并归零（消耗梯度回到第一档）
+    // 清除对应的技能名称和等级，会员积分刷新计数一并归零（消耗梯度回到第一档）
     if (abilityType === AbilityItemTypes.Active) {
       lotteryStatus.activeAbilityName = undefined;
       lotteryStatus.activeAbilityLevel = undefined;

--- a/src/vscripts/modules/lottery/item/item-lottery-helper.ts
+++ b/src/vscripts/modules/lottery/item/item-lottery-helper.ts
@@ -3,16 +3,18 @@ import { pickRandomTierByRate } from '../shared/random-tier';
 import { itemTiers } from './lottery-items';
 
 export enum ItemLotteryPool {
-  INITIAL = 'initial', // 开局点位：屏蔽 T5/T4，避开引擎全价卖出窗口
+  INITIAL = 'initial', // 开局点位：屏蔽 T7~T4，避开引擎全价卖出窗口
   DEFAULT = 'default', // 普通藏宝箱
   PREMIUM = 'premium', // 后期 / 肉山 / 会员：高 tier 加权
+  ULTRA = 'ultra', // 大后期：保底 T3，高 tier 明显加权
 }
 
 const POOL_RATES: Record<ItemLotteryPool, number[]> = {
-  // 累计阈值 [T6, T5, T4, T3, T2, T1]
-  [ItemLotteryPool.INITIAL]: [0, 0, 0, 10, 50, 100],
-  [ItemLotteryPool.DEFAULT]: [1, 2, 7, 25, 60, 100],
-  [ItemLotteryPool.PREMIUM]: [2, 7, 25, 60, 100, 100],
+  // 累计阈值 [T7, T6, T5, T4, T3, T2, T1]
+  [ItemLotteryPool.INITIAL]: [0, 0, 0, 0, 10, 50, 100],
+  [ItemLotteryPool.DEFAULT]: [1, 2, 3, 7, 25, 60, 100],
+  [ItemLotteryPool.PREMIUM]: [2, 4, 8, 30, 65, 100, 100],
+  [ItemLotteryPool.ULTRA]: [3, 6, 16, 40, 100, 100, 100],
 };
 
 export class ItemLotteryHelper {

--- a/src/vscripts/modules/lottery/item/item-lottery.test.ts
+++ b/src/vscripts/modules/lottery/item/item-lottery.test.ts
@@ -52,10 +52,30 @@ jest.mock('../../../api/analytics/ga4/ga4-pick-item-tracker', () => ({
 }));
 
 const mockGetMemberLevel = jest.fn((_steamId: number) => 1); // 默认 NORMAL
+const mockGetUseableMemberPoint = jest.fn((_steamId: number) => 0);
+const mockDeductUseableMemberPoint = jest.fn();
 jest.mock('../../../api/player', () => ({
   MemberLevel: { NORMAL: 1, PREMIUM: 2 },
   Player: {
     GetMemberLevel: (steamId: number) => mockGetMemberLevel(steamId),
+    GetUseableMemberPoint: (steamId: number) => mockGetUseableMemberPoint(steamId),
+    DeductUseableMemberPoint: (steamId: number, point: number) =>
+      mockDeductUseableMemberPoint(steamId, point),
+  },
+}));
+
+const mockIsLocalhost = jest.fn(() => true);
+jest.mock('../../../api/api-client', () => ({
+  ApiClient: {
+    IsLocalhost: () => mockIsLocalhost(),
+  },
+}));
+
+const mockUseMemberPoint = jest.fn();
+jest.mock('../../../api/player-member-point', () => ({
+  PlayerMemberPointApi: {
+    UseMemberPoint: (steamId: number, memberPoint: number, reason: string) =>
+      mockUseMemberPoint(steamId, memberPoint, reason),
   },
 }));
 
@@ -70,16 +90,21 @@ describe('ItemLottery', () => {
     for (const k of Object.keys(netTable)) delete netTable[k];
     mockHero.AddItem.mockClear();
     mockGetMemberLevel.mockReturnValue(1); // 默认 NORMAL
+    mockGetUseableMemberPoint.mockReturnValue(0);
+    mockDeductUseableMemberPoint.mockClear();
+    mockIsLocalhost.mockReturnValue(true);
+    mockUseMemberPoint.mockClear();
     global.RandomInt = jest.fn((min: number, _max: number) => min);
     lottery = new ItemLottery();
   });
 
   describe('onTriggered', () => {
-    it('人类玩家触发时写入 { candidates, isRefreshed, poolType } 到 net table', () => {
+    it('人类玩家触发时写入 { candidates, isRefreshed, paidRefreshCount, poolType } 到 net table', () => {
       lottery.onTriggered(humanOpener);
       const entry = netTable['lottery_item']?.['3'];
       expect(entry).toBeDefined();
       expect(entry.isRefreshed).toBe(false);
+      expect(entry.paidRefreshCount).toBe(0);
       expect(entry.poolType).toBeDefined();
       expect(entry.candidates).toHaveLength(ItemLottery.CANDIDATE_COUNT);
       expect(entry.candidates[0]).toMatchObject({
@@ -128,6 +153,7 @@ describe('ItemLottery', () => {
       // 选完后写空 candidates 清行
       expect(netTable['lottery_item']['3'].candidates).toEqual([]);
       expect(netTable['lottery_item']['3'].isRefreshed).toBe(false);
+      expect(netTable['lottery_item']['3'].paidRefreshCount).toBe(0);
     });
 
     it('无 pending 抽奖时 noop', () => {
@@ -179,6 +205,7 @@ describe('ItemLottery', () => {
 
       const after = netTable['lottery_item']['3'];
       expect(after.isRefreshed).toBe(true);
+      expect(after.paidRefreshCount).toBe(0);
       expect(after.candidates).toHaveLength(ItemLottery.CANDIDATE_COUNT);
     });
 
@@ -189,7 +216,7 @@ describe('ItemLottery', () => {
       expect(netTable['lottery_item']['3'].isRefreshed).toBe(false);
     });
 
-    it('已刷新过则二次刷新被拒绝', () => {
+    it('localhost 中已免费刷新过则二次刷新被拒绝', () => {
       mockGetMemberLevel.mockReturnValue(2);
       lottery.onTriggered(humanOpener);
       lottery.refreshItem(3 as PlayerID);
@@ -197,6 +224,70 @@ describe('ItemLottery', () => {
       lottery.refreshItem(3 as PlayerID);
       // 候选未再次替换（引用相同的 candidates）
       expect(netTable['lottery_item']['3'].candidates).toBe(afterFirst);
+    });
+
+    it('官方服务器中已免费刷新过可消耗会员积分继续刷新', () => {
+      mockGetMemberLevel.mockReturnValue(2);
+      mockIsLocalhost.mockReturnValue(false);
+      mockGetUseableMemberPoint.mockReturnValue(10);
+      lottery.onTriggered(humanOpener);
+      lottery.refreshItem(3 as PlayerID);
+      const afterFirst = netTable['lottery_item']['3'].candidates;
+
+      lottery.refreshItem(3 as PlayerID);
+
+      expect(netTable['lottery_item']['3'].candidates).not.toBe(afterFirst);
+      expect(netTable['lottery_item']['3'].paidRefreshCount).toBe(1);
+      expect(mockDeductUseableMemberPoint).toHaveBeenCalledWith(12345, 10);
+      expect(mockUseMemberPoint).toHaveBeenCalledWith(12345, 10, 'lottery_refresh_item');
+    });
+
+    it('付费刷新积分不足时拒绝刷新', () => {
+      mockGetMemberLevel.mockReturnValue(2);
+      mockIsLocalhost.mockReturnValue(false);
+      mockGetUseableMemberPoint.mockReturnValue(9);
+      lottery.onTriggered(humanOpener);
+      lottery.refreshItem(3 as PlayerID);
+      const afterFirst = netTable['lottery_item']['3'].candidates;
+
+      lottery.refreshItem(3 as PlayerID);
+
+      expect(netTable['lottery_item']['3'].candidates).toBe(afterFirst);
+      expect(netTable['lottery_item']['3'].paidRefreshCount).toBe(0);
+      expect(mockDeductUseableMemberPoint).not.toHaveBeenCalled();
+      expect(mockUseMemberPoint).not.toHaveBeenCalled();
+    });
+
+    it('付费刷新达到 5 次上限后拒绝刷新', () => {
+      mockGetMemberLevel.mockReturnValue(2);
+      mockIsLocalhost.mockReturnValue(false);
+      mockGetUseableMemberPoint.mockReturnValue(999);
+      lottery.onTriggered(humanOpener);
+      lottery.refreshItem(3 as PlayerID);
+      netTable['lottery_item']['3'].paidRefreshCount = 5;
+      const afterFirst = netTable['lottery_item']['3'].candidates;
+
+      lottery.refreshItem(3 as PlayerID);
+
+      expect(netTable['lottery_item']['3'].candidates).toBe(afterFirst);
+      expect(netTable['lottery_item']['3'].paidRefreshCount).toBe(5);
+      expect(mockDeductUseableMemberPoint).not.toHaveBeenCalled();
+      expect(mockUseMemberPoint).not.toHaveBeenCalled();
+    });
+
+    it('新藏宝箱会重置已付费刷新次数', () => {
+      mockGetMemberLevel.mockReturnValue(2);
+      mockIsLocalhost.mockReturnValue(false);
+      mockGetUseableMemberPoint.mockReturnValue(10);
+      lottery.onTriggered(humanOpener);
+      lottery.refreshItem(3 as PlayerID);
+      lottery.refreshItem(3 as PlayerID);
+      expect(netTable['lottery_item']['3'].paidRefreshCount).toBe(1);
+
+      lottery.onTriggered(humanOpener);
+
+      expect(netTable['lottery_item']['3'].isRefreshed).toBe(false);
+      expect(netTable['lottery_item']['3'].paidRefreshCount).toBe(0);
     });
 
     it('已 pick 完（candidates 空）则刷新被拒绝', () => {

--- a/src/vscripts/modules/lottery/item/item-lottery.ts
+++ b/src/vscripts/modules/lottery/item/item-lottery.ts
@@ -1,5 +1,7 @@
 import { LotteryDto } from '../../../../common/dto/lottery';
+import { ApiClient } from '../../../api/api-client';
 import { GA4PickItemTracker } from '../../../api/analytics/ga4/ga4-pick-item-tracker';
+import { PlayerMemberPointApi } from '../../../api/player-member-point';
 import { MemberLevel, Player } from '../../../api/player';
 import { reloadable } from '../../../utils/tstl-utils';
 import { PlayerHelper } from '../../helper/player-helper';
@@ -12,6 +14,8 @@ import { ItemLotteryHelper, ItemLotteryPool } from './item-lottery-helper';
 @reloadable
 export class ItemLottery {
   static readonly CANDIDATE_COUNT = 4;
+  readonly paidRefreshCosts = [10, 20, 30, 50];
+  readonly maxPaidRefreshCount = 5;
 
   constructor() {
     CustomGameEventManager.RegisterListener('lottery_pick_item', (_userId, event) => {
@@ -39,6 +43,7 @@ export class ItemLottery {
     CustomNetTables.SetTableValue('lottery_item', playerId.toString(), {
       candidates,
       isRefreshed: false,
+      paidRefreshCount: 0,
       poolType: pool,
     });
   }
@@ -76,6 +81,7 @@ export class ItemLottery {
     CustomNetTables.SetTableValue('lottery_item', playerId.toString(), {
       candidates: [],
       isRefreshed: false,
+      paidRefreshCount: 0,
       poolType: ItemLotteryPool.DEFAULT,
     });
 
@@ -95,14 +101,30 @@ export class ItemLottery {
     }
     // 同 lottery_status：boolean 写入后引擎可能同步为 0/1，宽松匹配两种值
     const refreshed = raw.isRefreshed as unknown as boolean | number;
-    if (refreshed === true || refreshed === 1) {
-      print('[ItemLottery] refresh denied, already refreshed, player ' + playerId);
-      return;
-    }
     const currentCandidates = Object.values(raw.candidates ?? {}) as unknown as LotteryDto[];
     if (currentCandidates.length === 0) {
       print('[ItemLottery] refresh denied, already picked or empty, player ' + playerId);
       return;
+    }
+
+    if (refreshed === true || refreshed === 1) {
+      if (ApiClient.IsLocalhost()) {
+        print('[ItemLottery] paid refresh denied on localhost, player ' + playerId);
+        return;
+      }
+
+      const paidRefreshCount = raw.paidRefreshCount ?? 0;
+      if (paidRefreshCount >= this.maxPaidRefreshCount) {
+        print('[ItemLottery] paid refresh denied, refresh limit reached, player ' + playerId);
+        return;
+      }
+      const cost = this.getPaidRefreshCost(paidRefreshCount);
+      if (Player.GetUseableMemberPoint(steamAccountID) < cost) {
+        print('[ItemLottery] paid refresh denied, insufficient member points, player ' + playerId);
+        return;
+      }
+      Player.DeductUseableMemberPoint(steamAccountID, cost);
+      PlayerMemberPointApi.UseMemberPoint(steamAccountID, cost, 'lottery_refresh_item');
     }
 
     const pool = (raw.poolType as ItemLotteryPool) ?? ItemLotteryPool.DEFAULT;
@@ -110,8 +132,14 @@ export class ItemLottery {
     CustomNetTables.SetTableValue('lottery_item', playerId.toString(), {
       candidates,
       isRefreshed: true,
+      paidRefreshCount: refreshed === true || refreshed === 1 ? (raw.paidRefreshCount ?? 0) + 1 : 0,
       poolType: pool,
     });
     print('[ItemLottery] refreshed for player ' + playerId);
+  }
+
+  private getPaidRefreshCost(paidCount: number): number {
+    const index = Math.min(paidCount, this.paidRefreshCosts.length - 1);
+    return this.paidRefreshCosts[index];
   }
 }

--- a/src/vscripts/modules/lottery/item/lottery-items.ts
+++ b/src/vscripts/modules/lottery/item/lottery-items.ts
@@ -1,13 +1,21 @@
 import { Tier } from '../shared/tier';
 
 /**
- * 物品抽奖池，Tier 6-1。配合 POOL_RATES 累计阈值使用（见 item-lottery-helper）。
+ * 物品抽奖池，Tier 7-1。配合 POOL_RATES 累计阈值使用（见 item-lottery-helper）。
  */
 export const itemTiers: Tier[] = [
   {
-    level: 6,
+    level: 7,
     names: [
       'item_awaken_stone', // 觉醒石
+    ],
+  },
+  // 超高价值成长/通用资源
+  {
+    level: 6,
+    names: [
+      'item_tome_of_luoshu', // 洛书
+      'item_universal_rune', // 通用符文
     ],
   },
   // 终极物品
@@ -22,8 +30,6 @@ export const itemTiers: Tier[] = [
       'item_fusion_shadow', // 暗影符文
       'item_fusion_magic', // 魔化符文
       'item_fusion_agile', // 灵动符文
-      'item_universal_rune', // 通用符文
-      'item_tome_of_luoshu', // 洛书
     ],
   },
   // 特殊物品

--- a/src/vscripts/modules/treasure/treasure.test.ts
+++ b/src/vscripts/modules/treasure/treasure.test.ts
@@ -73,6 +73,7 @@ global.GameRules = {
 };
 
 import { Treasure } from './treasure';
+import { ItemLotteryPool } from '../lottery/item/item-lottery-helper';
 
 describe('Treasure', () => {
   let treasure: Treasure;
@@ -166,6 +167,26 @@ describe('Treasure', () => {
         ...Treasure.SPAWN_POINTS_RADIANT_HARD,
       ];
       expect(merged).toContain(point);
+    });
+  });
+
+  describe('物品抽奖池映射', () => {
+    it('第 1 个藏宝箱使用 INITIAL 池', () => {
+      expect(Treasure.mapToLotteryPool(1)).toBe(ItemLotteryPool.INITIAL);
+    });
+
+    it('第 2-5 个藏宝箱使用 DEFAULT 池', () => {
+      expect(Treasure.mapToLotteryPool(2)).toBe(ItemLotteryPool.DEFAULT);
+      expect(Treasure.mapToLotteryPool(5)).toBe(ItemLotteryPool.DEFAULT);
+    });
+
+    it('第 6-9 个藏宝箱使用 PREMIUM 池', () => {
+      expect(Treasure.mapToLotteryPool(6)).toBe(ItemLotteryPool.PREMIUM);
+      expect(Treasure.mapToLotteryPool(9)).toBe(ItemLotteryPool.PREMIUM);
+    });
+
+    it('第 10 个起使用 ULTRA 池', () => {
+      expect(Treasure.mapToLotteryPool(10)).toBe(ItemLotteryPool.ULTRA);
     });
   });
 

--- a/src/vscripts/modules/treasure/treasure.ts
+++ b/src/vscripts/modules/treasure/treasure.ts
@@ -229,6 +229,7 @@ export class Treasure {
 
   static mapToLotteryPool(openCount: number): ItemLotteryPool {
     if (openCount <= 1) return ItemLotteryPool.INITIAL;
+    if (openCount >= 10) return ItemLotteryPool.ULTRA;
     if (openCount >= 6) return ItemLotteryPool.PREMIUM;
     return ItemLotteryPool.DEFAULT;
   }


### PR DESCRIPTION
## Issue

- [x] fix #2114

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.33[/b]

- 击杀肉山时，物品抽奖有更高概率出现高级物品。
- 高级会员现在可以消耗会员积分刷新藏宝箱物品抽奖，每个藏宝箱最多额外刷新 5 次，技能抽选同样。
```

```
[b]Gameplay update v5.33[/b]

- When Roshan is killed, item lotteries have a higher chance to offer high-tier items.
- Premium members can now spend member points to reroll treasure chest item lotteries up to 5 extra times per chest; ability lotteries follow the same limit.
```