### PR TITLE
Order payment platforms by interface language

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -344,6 +344,7 @@
 		"member_platform_subscribe_month"		"/Month"
 		"member_shop_divider"					"Already a member? Buy Experience to level up faster"
 		"member_shop_title"						"Buy Member Points"
+		"member_other_payment"					"Other Payment Methods"
 		"member_activate"						"Manual Activate"
 		"member_activate_tooltip"				"Only needed if you forgot to enter your Friend ID or entered it incorrectly. Once activated, your account is saved and future subscriptions activate automatically."
 		"member_refresh"						"Refresh Membership & Points"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -344,6 +344,7 @@
 		"member_platform_subscribe_month"		"/月"
 		"member_shop_divider"			"已有会员？购买会员积分快速升级"
 		"member_shop_title"				"购买会员积分"
+		"member_other_payment"			"其他支付方式"
 		"member_activate"				"手动激活"
 		"member_activate_tooltip"		"若订阅时忘记填写好友ID或填写有误，可在此手动激活。激活成功后系统将记录您的账号，之后订阅无需再次填写。"
 		"member_refresh"				"刷新会员状态和积分"

--- a/src/panorama/react/hud_main/pages/profile/layout.less
+++ b/src/panorama/react/hud_main/pages/profile/layout.less
@@ -3,8 +3,8 @@
 
 /* ========== 个人中心外框 ========== */
 .profile-modal {
-  width: 65%;
-  height: 65%;
+  width: 70%;
+  height: 70%;
   margin-bottom: 60px;
   background-color: gradient(
     linear,

--- a/src/panorama/react/hud_main/pages/profile/layout.less
+++ b/src/panorama/react/hud_main/pages/profile/layout.less
@@ -82,6 +82,6 @@
   width: 100%;
   height: fit-children;
   min-height: 480px;
-  padding: 20px;
+  padding: 14px;
   flow-children: down;
 }

--- a/src/panorama/react/hud_main/pages/profile/tabs/member/PointsPage.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/member/PointsPage.tsx
@@ -1,5 +1,11 @@
-import React from 'react';
-import { GetLocalPlayerSteamAccountID, GetAfdianPointsUrl, KOFI_POINTS_URLS } from '@utils/utils';
+import React, { useState } from 'react';
+import {
+  GetLocalPlayerSteamAccountID,
+  GetAfdianPointsUrl,
+  GetPaymentPlatformOrder,
+  PaymentPlatform,
+  KOFI_POINTS_URLS,
+} from '@utils/utils';
 import { AlipaySubscribeCard, AlipayCardItem } from './alipay';
 import { MEMBER_POINTS_ICONS } from './alipay/constants';
 import { ExternalPointsCard } from './ExternalPointsCard';
@@ -24,6 +30,8 @@ const POINTS_AMOUNTS = [3500, 11000, 28000];
 
 export function PointsPage({ refreshing, onRefresh }: PointsPageProps) {
   const steamId = GetLocalPlayerSteamAccountID();
+  const order = GetPaymentPlatformOrder();
+  const [expanded, setExpanded] = useState(false);
 
   const alipayItems: AlipayCardItem[] = ALIPAY_POINTS_TIERS.map((tier, i) => ({
     productCode: tier.productCode,
@@ -40,6 +48,46 @@ export function PointsPage({ refreshing, onRefresh }: PointsPageProps) {
 
   const pointsLabel = (i: number) =>
     $.Localize('#member_points_amount_fmt').replace('{n}', String(POINTS_AMOUNTS[i]));
+
+  const cards: Record<PaymentPlatform, React.ReactNode> = {
+    alipay: (
+      <AlipaySubscribeCard
+        items={alipayItems}
+        nameKey="#member_platform_alipay"
+        descKey="#member_platform_alipay_desc"
+      />
+    ),
+    afdian: (
+      <ExternalPointsCard
+        variantClassName="member-platform-card-afdian"
+        descClassName="member-platform-desc-cn"
+        logoSrc={AFDIAN_ICON}
+        name={$.Localize('#member_platform_afdian')}
+        desc={$.Localize('#member_platform_afdian_desc')}
+        buttons={POINTS_AMOUNTS.map((_, i) => ({
+          label: pointsLabel(i),
+          price: `¥${AFDIAN_POINTS_PRICES[i]}`,
+          onClick: openUrl(GetAfdianPointsUrl(i)),
+        }))}
+        activateUrl={AFDIAN_ACTIVATE_URL}
+      />
+    ),
+    kofi: (
+      <ExternalPointsCard
+        variantClassName="member-platform-card-kofi"
+        descClassName="member-platform-desc-intl"
+        logoSrc={KOFI_LOGO}
+        name={$.Localize('#member_platform_kofi')}
+        desc={$.Localize('#member_platform_kofi_desc')}
+        buttons={POINTS_AMOUNTS.map((_, i) => ({
+          label: pointsLabel(i),
+          price: `$${KOFI_POINTS_PRICES[i]}`,
+          onClick: openUrl(KOFI_POINTS_URLS[i]),
+        }))}
+        activateUrl={KOFI_ACTIVATE_URL}
+      />
+    ),
+  };
 
   return (
     <Panel className="member-subpage member-points-page">
@@ -77,39 +125,27 @@ export function PointsPage({ refreshing, onRefresh }: PointsPageProps) {
       </Panel>
 
       <Panel className="member-platform-cards">
-        <AlipaySubscribeCard
-          items={alipayItems}
-          nameKey="#member_platform_alipay"
-          descKey="#member_platform_alipay_desc"
-        />
+        {order.map((key, i) => (
+          <Panel
+            key={key}
+            className="member-platform-slot"
+            style={{ visibility: i < 2 || expanded ? 'visible' : 'collapse' }}
+          >
+            {cards[key]}
+          </Panel>
+        ))}
+      </Panel>
 
-        <ExternalPointsCard
-          variantClassName="member-platform-card-afdian"
-          descClassName="member-platform-desc-cn"
-          logoSrc={AFDIAN_ICON}
-          name={$.Localize('#member_platform_afdian')}
-          desc={$.Localize('#member_platform_afdian_desc')}
-          buttons={POINTS_AMOUNTS.map((_, i) => ({
-            label: pointsLabel(i),
-            price: `¥${AFDIAN_POINTS_PRICES[i]}`,
-            onClick: openUrl(GetAfdianPointsUrl(i)),
-          }))}
-          activateUrl={AFDIAN_ACTIVATE_URL}
-        />
-
-        <ExternalPointsCard
-          variantClassName="member-platform-card-kofi"
-          descClassName="member-platform-desc-intl"
-          logoSrc={KOFI_LOGO}
-          name={$.Localize('#member_platform_kofi')}
-          desc={$.Localize('#member_platform_kofi_desc')}
-          buttons={POINTS_AMOUNTS.map((_, i) => ({
-            label: pointsLabel(i),
-            price: `$${KOFI_POINTS_PRICES[i]}`,
-            onClick: openUrl(KOFI_POINTS_URLS[i]),
-          }))}
-          activateUrl={KOFI_ACTIVATE_URL}
-        />
+      <Panel
+        className="member-other-payment-row"
+        style={{ visibility: expanded ? 'collapse' : 'visible' }}
+      >
+        <Button className="member-other-payment-btn" onactivate={() => setExpanded(true)}>
+          <Label
+            className="member-other-payment-label"
+            text={$.Localize('#member_other_payment')}
+          />
+        </Button>
       </Panel>
     </Panel>
   );

--- a/src/panorama/react/hud_main/pages/profile/tabs/member/SubscribePage.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/member/SubscribePage.tsx
@@ -1,5 +1,9 @@
-import React from 'react';
-import { GetLocalPlayerSteamAccountID } from '@utils/utils';
+import React, { useState } from 'react';
+import {
+  GetLocalPlayerSteamAccountID,
+  GetPaymentPlatformOrder,
+  PaymentPlatform,
+} from '@utils/utils';
 import { AlipayCardItem, AlipaySubscribeCard } from './alipay';
 import {
   AFDIAN_ACTIVATE_URL,
@@ -26,6 +30,8 @@ const defaultTier = (platform: MembershipPlatform) => MEMBERSHIP_PLATFORMS[platf
 
 export function SubscribePage({ isNormalOnly, refreshing, onRefresh }: SubscribePageProps) {
   const steamId = GetLocalPlayerSteamAccountID();
+  const order = GetPaymentPlatformOrder();
+  const [expanded, setExpanded] = useState(false);
 
   const alipayItems: AlipayCardItem[] = MEMBERSHIP_PLATFORMS.alipay.tiers.map((tier) => ({
     productCode: MEMBERSHIP_PLATFORMS.alipay.productCode!,
@@ -42,6 +48,44 @@ export function SubscribePage({ isNormalOnly, refreshing, onRefresh }: Subscribe
         : undefined,
     successIconSrc: CROWN_GOLD,
   }));
+
+  const cards: Record<PaymentPlatform, React.ReactNode> = {
+    alipay: (
+      <AlipaySubscribeCard
+        items={alipayItems}
+        nameKey="#member_platform_alipay"
+        descKey="#member_platform_alipay_desc"
+      />
+    ),
+    afdian: (
+      <ExternalPlatformCard
+        variantClassName="member-platform-card-afdian"
+        descClassName="member-platform-desc-cn"
+        logoSrc={AFDIAN_ICON}
+        name={$.Localize('#member_platform_afdian')}
+        desc={$.Localize('#member_platform_afdian_desc')}
+        subscribeUrl={GetAfdianSubscribeUrl()}
+        subscribePrice={`¥${defaultTier('afdian').price}`}
+        subscribeUnitText={$.Localize('#member_platform_subscribe_month')}
+        shopUrl={AFDIAN_SHOP_URL}
+        activateUrl={AFDIAN_ACTIVATE_URL}
+      />
+    ),
+    kofi: (
+      <ExternalPlatformCard
+        variantClassName="member-platform-card-kofi"
+        descClassName="member-platform-desc-intl"
+        logoSrc={KOFI_LOGO}
+        name={$.Localize('#member_platform_kofi')}
+        desc={$.Localize('#member_platform_kofi_desc')}
+        subscribeUrl={KOFI_SUBSCRIBE_URL}
+        subscribePrice={`$${defaultTier('kofi').price}`}
+        subscribeUnitText={$.Localize('#member_platform_subscribe_month')}
+        shopUrl={KOFI_SHOP_URL}
+        activateUrl={KOFI_ACTIVATE_URL}
+      />
+    ),
+  };
 
   return (
     <Panel className="member-subpage member-subscribe-page">
@@ -87,42 +131,30 @@ export function SubscribePage({ isNormalOnly, refreshing, onRefresh }: Subscribe
         </Button>
       </Panel>
 
-      {/* 三平台并排 */}
+      {/* 按语言顺序渲染三张卡，第 3 张默认折叠 */}
       <Panel className="member-platform-cards">
-        {/* 支付宝 */}
-        <AlipaySubscribeCard
-          items={alipayItems}
-          nameKey="#member_platform_alipay"
-          descKey="#member_platform_alipay_desc"
-        />
+        {order.map((key, i) => (
+          <Panel
+            key={key}
+            className="member-platform-slot"
+            style={{ visibility: i < 2 || expanded ? 'visible' : 'collapse' }}
+          >
+            {cards[key]}
+          </Panel>
+        ))}
+      </Panel>
 
-        {/* 爱发电 */}
-        <ExternalPlatformCard
-          variantClassName="member-platform-card-afdian"
-          descClassName="member-platform-desc-cn"
-          logoSrc={AFDIAN_ICON}
-          name={$.Localize('#member_platform_afdian')}
-          desc={$.Localize('#member_platform_afdian_desc')}
-          subscribeUrl={GetAfdianSubscribeUrl()}
-          subscribePrice={`¥${defaultTier('afdian').price}`}
-          subscribeUnitText={$.Localize('#member_platform_subscribe_month')}
-          shopUrl={AFDIAN_SHOP_URL}
-          activateUrl={AFDIAN_ACTIVATE_URL}
-        />
-
-        {/* Ko-fi */}
-        <ExternalPlatformCard
-          variantClassName="member-platform-card-kofi"
-          descClassName="member-platform-desc-intl"
-          logoSrc={KOFI_LOGO}
-          name={$.Localize('#member_platform_kofi')}
-          desc={$.Localize('#member_platform_kofi_desc')}
-          subscribeUrl={KOFI_SUBSCRIBE_URL}
-          subscribePrice={`$${defaultTier('kofi').price}`}
-          subscribeUnitText={$.Localize('#member_platform_subscribe_month')}
-          shopUrl={KOFI_SHOP_URL}
-          activateUrl={KOFI_ACTIVATE_URL}
-        />
+      {/* 其他支付方式：展开第 3 张，展开后按钮消失 */}
+      <Panel
+        className="member-other-payment-row"
+        style={{ visibility: expanded ? 'collapse' : 'visible' }}
+      >
+        <Button className="member-other-payment-btn" onactivate={() => setExpanded(true)}>
+          <Label
+            className="member-other-payment-label"
+            text={$.Localize('#member_other_payment')}
+          />
+        </Button>
       </Panel>
     </Panel>
   );

--- a/src/panorama/react/hud_main/pages/profile/tabs/member/styles.less
+++ b/src/panorama/react/hud_main/pages/profile/tabs/member/styles.less
@@ -286,19 +286,55 @@
   height: fit-children;
 }
 
+/* 卡片外层 slot：承载 fill-parent-flow 均分与右边距，
+   collapse 时脱流让剩余两张各占一半 */
+.member-platform-slot {
+  width: fill-parent-flow(1);
+  height: fit-children;
+  flow-children: down;
+  margin-right: 10px;
+  &:last-child {
+    margin-right: 0px;
+  }
+}
+
 /* 单个平台 card */
 .member-platform-card {
   .stats-card;
-  width: fill-parent-flow(1);
+  width: 100%;
   height: fit-children;
   min-height: 60%;
   flow-children: down;
   padding: 16px 14px;
   horizontal-align: center;
-  margin-right: 10px;
-  &:last-child {
-    margin-right: 0px;
-  }
+}
+
+/* 「其他支付方式」按钮：卡片容器下方独立一行，右对齐 */
+.member-other-payment-row {
+  width: 100%;
+  height: fit-children;
+  margin-top: 10px;
+}
+
+.member-other-payment-btn {
+  horizontal-align: right;
+  height: 32px;
+  padding: 0 16px;
+  border: 1px solid #ffffff40;
+  border-radius: @radius-md;
+  flow-children: right;
+  vertical-align: center;
+}
+
+.member-other-payment-btn:hover {
+  border-color: #ffffff80;
+  background-color: #ffffff10;
+}
+
+.member-other-payment-label {
+  vertical-align: center;
+  color: #ffffffcc;
+  font-size: 16px;
 }
 
 .member-platform-card-afdian {

--- a/src/panorama/utils/utils.ts
+++ b/src/panorama/utils/utils.ts
@@ -55,6 +55,19 @@ export const KOFI_SUBSCRIBE_URL = 'https://ko-fi.com/post/Membership-Z8Z01CDJLU'
 export const AFDIAN_SHOP_URL = 'https://ifdian.net/a/windy10v10ai?tab=shop';
 export const KOFI_SHOP_URL = 'https://ko-fi.com/windy10v10ai/shop';
 
+export type PaymentPlatform = 'alipay' | 'afdian' | 'kofi';
+
+/**
+ * 支付方式展示顺序：简体中文玩家优先支付宝（折扣最大且仅限国内），
+ * 其他语言优先 Ko-fi。数组首两项默认展示，第 3 项折叠。
+ */
+export function GetPaymentPlatformOrder(): PaymentPlatform[] {
+  if ($.Language() === 'schinese') {
+    return ['alipay', 'afdian', 'kofi'];
+  }
+  return ['kofi', 'afdian', 'alipay'];
+}
+
 /**
  * 添加自定义键位绑定
  * @param keyName 键位名称


### PR DESCRIPTION
## Issue

- 无关联 Issue

## Checklist

- [x] I have tested the changes works well.

## Summary

会员订阅 / 积分页此前固定三卡并排（支付宝 / 爱发电 / Ko-fi），玩家感到混乱，。

本次按界面语言区分默认展示：

- 简体中文（`schinese`）：默认显示 **支付宝 + 爱发电**，Ko-fi 折叠
- 其他语言：默认显示 **Ko-fi + 爱发电**，支付宝折叠
- 底部「其他支付方式」按钮：点击后把折叠的第 3 张追加到旁边，按钮消失；切换 tab 重进后重置

实现要点：

- 新增 `GetPaymentPlatformOrder()`（读 `$.Language()` 返回有序平台数组）
- 两个页面按顺序数组渲染三张卡，组件内 `useState` 控制第 3 张与按钮的 `visibility`
- 卡片外包一层 `.member-platform-slot` 承载 `fill-parent-flow` 均分，折叠的 slot 脱流让剩余两张自动各占一半
- 顺带缩小 profile `.content-area` 内边距（20px → 14px）

## Release Note

```
[b]游戏性更新 v5.33[/b]

- 会员与积分页面根据游戏语言优化支付方式展示：中文玩家优先显示支付宝与爱发电，其他语言优先显示 Ko-fi 与爱发电，其余支付方式可点击「其他支付方式」展开。
```

```
[b]Gameplay update v5.33[/b]

- Membership and points pages now adapt payment options to your game language: Chinese players see Alipay and Afdian first, others see Ko-fi and Afdian first, with remaining methods available via the "Other Payment Methods" button.
```
