### PR TITLE
Bot auto-enables toggle/autocast lottery abilities

### DIFF
--- a/.claude/skills/bot-ability-usage/SKILL.md
+++ b/.claude/skills/bot-ability-usage/SKILL.md
@@ -68,7 +68,7 @@ Glob pattern: src/vscripts/ai/ability/specs/<abilityName>.ts
 2. **目标数量条件**：群体技能要求"周围至少 N 个敌人才出手"`target.count.gte: 3`。
 3. **施法者条件**：例如"蓝量够才用"`self.unitCondition.manaPercent.gte: 50`，或"血量低才用某保命技能"。
 4. **技能等级 / 充能条件**：`ability.level.gte: 3`、`ability.charges.gte: 1`。
-5. **避免重复施法**：`target.unitCondition.noModifier: 'modifier_xxx'`，常用于持续 debuff/buff。Modifier 名从 `abilities_schinese.txt`（或英文版）中搜 `DOTA_Tooltip_modifier_<name>` 取 `<name>`。例：寒霜魔盾 = `modifier_lich_frost_shield`。
+5. **避免重复施法**：`target.unitCondition.noModifier: 'modifier_xxx'`，常用于持续 debuff/buff。Modifier 名查 `DOTA_Tooltip_modifier_<name>` 取 `<name>`：**优先查项目 `game/resource/addon_schinese.txt`**（自定义/克隆/override 技能以项目本地化为准）；项目搜不到再查 reference 最新版本 `docs/reference/<version>/abilities_schinese.txt`（原版技能兜底）。例：寒霜魔盾 = `modifier_lich_frost_shield`；`lich_frost_armor` 是项目把奥术法师寒冰盔甲克隆给巫妖，原版 lich 无此技能，modifier 名 = `modifier_lich_frost_armor`，仅在项目本地化有定义。
 6. **跳过已被控目标**：`target.unitCondition.notActionable: true`，目标处于眩晕/变羊/噩梦/虚空大等硬控状态则跳过，对已被控的目标使用控制技能通常是浪费。
 7. **附近无敌方英雄才施法**：`self.noEnemyHeroInRange: 900`（距离可自定义），常用于对小兵或建筑施法前确认安全。此字段在 dispatcher `tryCast` 层检查，**不是** `self.unitCondition` 的子字段，直接挂在 `self` 下。
 8. **附近需要足够友方小兵**：`self.friendlyCreepNearby: { count: { gte: 3 } }`，常用于推塔场景（对 `EnemyBuilding` 施法时确认有推线波）。`range` 不填默认 900。此字段也直接挂在 `self` 下，dispatcher inline `FindUnitsInRadius` 检查。

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -13,6 +13,7 @@
 	"lich_frost_armor"
 	{
 		"MaxLevel"						"5"
+		"AbilityDuration"				"60.0"		// 40.0
 		"AbilityValues"
 		{
 			"armor_bonus"			"8 12 16 20 24"	// x2

--- a/src/vscripts/ai/ability/ability-cast.test.ts
+++ b/src/vscripts/ai/ability/ability-cast.test.ts
@@ -1,0 +1,61 @@
+import { ApplyAbilityAction } from './ability-cast';
+
+/**
+ * ApplyAbilityAction 只负责"目标状态与当前状态不一致才切换并返回 true"的分支逻辑，
+ * 保证 bot 主动开关只在第一次切换那一 tick 占用 dispatcher，之后放行其他技能。
+ * Dota 引擎 API（ToggleAbility / ToggleAutoCast）仅 mock 占位防崩，不断言其调用参数。
+ */
+function fakeAbility(state: { toggle?: boolean; autoCast?: boolean }): CDOTABaseAbility {
+  return {
+    GetName: () => 'fake_ability',
+    GetToggleState: () => state.toggle ?? false,
+    GetAutoCastState: () => state.autoCast ?? false,
+    ToggleAbility: () => {
+      state.toggle = !state.toggle;
+    },
+    ToggleAutoCast: () => {
+      state.autoCast = !state.autoCast;
+    },
+  } as unknown as CDOTABaseAbility;
+}
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).print = () => {
+    // 占位，避免 dota 全局 print 未定义
+  };
+});
+
+describe('ApplyAbilityAction', () => {
+  it('toggleOn switches an off ability on, returns true once', () => {
+    const state = { toggle: false };
+    const ability = fakeAbility(state);
+
+    expect(ApplyAbilityAction(ability, { toggleOn: true })).toBe(true);
+    expect(state.toggle).toBe(true);
+    // 已开启后不再重复触发，放行其他技能
+    expect(ApplyAbilityAction(ability, { toggleOn: true })).toBe(false);
+  });
+
+  it('toggleOff switches an on ability off, returns true once', () => {
+    const state = { toggle: true };
+    const ability = fakeAbility(state);
+
+    expect(ApplyAbilityAction(ability, { toggleOff: true })).toBe(true);
+    expect(state.toggle).toBe(false);
+    expect(ApplyAbilityAction(ability, { toggleOff: true })).toBe(false);
+  });
+
+  it('autoCastOn enables autocast, returns true once', () => {
+    const state = { autoCast: false };
+    const ability = fakeAbility(state);
+
+    expect(ApplyAbilityAction(ability, { autoCastOn: true })).toBe(true);
+    expect(state.autoCast).toBe(true);
+    expect(ApplyAbilityAction(ability, { autoCastOn: true })).toBe(false);
+  });
+
+  it('returns false when no action flag is set', () => {
+    const ability = fakeAbility({});
+    expect(ApplyAbilityAction(ability, {})).toBe(false);
+  });
+});

--- a/src/vscripts/ai/ability/ability-cast.ts
+++ b/src/vscripts/ai/ability/ability-cast.ts
@@ -1,4 +1,4 @@
-import { IsAbilityBehavior } from '../action/cast-condition';
+import { CastCoindition, IsAbilityBehavior } from '../action/cast-condition';
 
 /**
  * 技能的有效施法距离 = KV 中 AbilityCastRange + 施法者的施法距离加成。
@@ -52,5 +52,37 @@ export function CastAbilityOnTargetByBehavior(
   }
 
   print(`[AI] ERROR CastByBehavior ${abilityName} behavior not supported`);
+  return false;
+}
+
+/**
+ * 执行 spec 中声明的开关动作（toggle / autocast）。仅切换状态，不走正常施法派发。
+ *
+ * 用于 bot 主动开启抽奖抽到的法球/开关类被动技能（默认关闭，不开启永不生效）：
+ *  - toggleOn / toggleOff：切换 TOGGLE 技能开关（如分裂箭、严寒烧灼有 A 杖时）
+ *  - autoCastOn：开启自动施法（毒性攻击、霜冻之箭等攻击型法球）
+ *
+ * 仅当目标状态与当前状态不一致时才切换并返回 true（命中本 tick），避免反复点击。
+ * dispatcher 与老链路 ActionAbility.doAction 共用。
+ */
+export function ApplyAbilityAction(
+  ability: CDOTABaseAbility,
+  action: NonNullable<CastCoindition['action']>,
+): boolean {
+  if (action.toggleOn && !ability.GetToggleState()) {
+    print(`[AI] toggleOn ${ability.GetName()}`);
+    ability.ToggleAbility();
+    return true;
+  }
+  if (action.toggleOff && ability.GetToggleState()) {
+    print(`[AI] toggleOff ${ability.GetName()}`);
+    ability.ToggleAbility();
+    return true;
+  }
+  if (action.autoCastOn && !ability.GetAutoCastState()) {
+    print(`[AI] autoCastOn ${ability.GetName()}`);
+    ability.ToggleAutoCast();
+    return true;
+  }
   return false;
 }

--- a/src/vscripts/ai/ability/ability-dispatcher.ts
+++ b/src/vscripts/ai/ability/ability-dispatcher.ts
@@ -8,7 +8,11 @@ import {
   NumberRange,
 } from '../action/cast-condition';
 import type { BotBaseAIModifier } from '../hero/bot-base';
-import { CastAbilityOnTargetByBehavior, GetFullCastRange } from './ability-cast';
+import {
+  ApplyAbilityAction,
+  CastAbilityOnTargetByBehavior,
+  GetFullCastRange,
+} from './ability-cast';
 import { AbilityRegistry } from './ability-registry';
 import { AbilitySpec, TargetSide } from './ability-spec';
 
@@ -124,6 +128,11 @@ export class AbilityDispatcher {
 
     if (condition?.debug) {
       print(`[AI] Dispatcher hit ${ability.GetName()} side=${spec.targetSide}`);
+    }
+
+    // 开关/法球类：找到目标（= 满足开启条件）后只切换状态，不走正常施法派发。
+    if (condition?.action) {
+      return ApplyAbilityAction(ability, condition.action);
     }
 
     const castPosition = this.resolveCastPosition(hero, ability, target, condition);

--- a/src/vscripts/ai/ability/specs/ancient_apparition_chilling_touch.ts
+++ b/src/vscripts/ai/ability/specs/ancient_apparition_chilling_touch.ts
@@ -1,0 +1,17 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 极寒之触：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * 每次攻击耗蓝法球，升到 2 级再开启，避免低级时持续耗蓝。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'ancient_apparition_chilling_touch',
+    targetSide: TargetSide.Self,
+    condition: {
+      ability: { level: { gte: 2 } },
+      action: { autoCastOn: true },
+    },
+  },
+];

--- a/src/vscripts/ai/ability/specs/doom_bringer_infernal_blade.ts
+++ b/src/vscripts/ai/ability/specs/doom_bringer_infernal_blade.ts
@@ -1,0 +1,14 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 阎刃：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * CD 制法球（触发后才耗蓝），常开无害，bot 抽到即开启自动施法。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'doom_bringer_infernal_blade',
+    targetSide: TargetSide.Self,
+    condition: { action: { autoCastOn: true } },
+  },
+];

--- a/src/vscripts/ai/ability/specs/drow_ranger_frost_arrows.ts
+++ b/src/vscripts/ai/ability/specs/drow_ranger_frost_arrows.ts
@@ -1,0 +1,17 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 霜冻之箭：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * 项目里每箭耗蓝 9-13（AbilityValues 嵌套 manacost），升到 2 级再开启，避免低级时持续耗蓝。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'drow_ranger_frost_arrows',
+    targetSide: TargetSide.Self,
+    condition: {
+      ability: { level: { gte: 2 } },
+      action: { autoCastOn: true },
+    },
+  },
+];

--- a/src/vscripts/ai/ability/specs/enchantress_impetus.ts
+++ b/src/vscripts/ai/ability/specs/enchantress_impetus.ts
@@ -1,0 +1,17 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 推进：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * 高蓝耗法球（40-60/攻击），升到 2 级再开启，避免低级时持续耗蓝。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'enchantress_impetus',
+    targetSide: TargetSide.Self,
+    condition: {
+      ability: { level: { gte: 2 } },
+      action: { autoCastOn: true },
+    },
+  },
+];

--- a/src/vscripts/ai/ability/specs/index.ts
+++ b/src/vscripts/ai/ability/specs/index.ts
@@ -1,17 +1,24 @@
 import { AbilityRegistry } from '../ability-registry';
+import { SPECS as ancientApparitionChillingTouch } from './ancient_apparition_chilling_touch';
 import { SPECS as axeBattleHunger } from './axe_battle_hunger';
 import { SPECS as axeBerserkerSCall } from './axe_berserkers_call';
 import { SPECS as axeCullingBlade } from './axe_culling_blade';
+import { SPECS as doomBringerInfernalBlade } from './doom_bringer_infernal_blade';
 import { SPECS as dragonKnightBreatheFire } from './dragon_knight_breathe_fire';
 import { SPECS as dragonKnightDragonTail } from './dragon_knight_dragon_tail';
 import { SPECS as dragonKnightFireball } from './dragon_knight_fireball';
+import { SPECS as drowRangerFrostArrows } from './drow_ranger_frost_arrows';
+import { SPECS as enchantressImpetus } from './enchantress_impetus';
 import { SPECS as jakiroDualBreath } from './jakiro_dual_breath';
+import { SPECS as lichFrostArmor } from './lich_frost_armor';
 import { SPECS as lichFrostNova } from './lich_frost_nova';
 import { SPECS as lichFrostShield } from './lich_frost_shield';
 import { SPECS as lionFingerOfDeath } from './lion_finger_of_death';
 import { SPECS as lionImpale } from './lion_impale';
 import { SPECS as lionManaDrain } from './lion_mana_drain';
 import { SPECS as lionVoodoo } from './lion_voodoo';
+import { SPECS as medusaSplitShot } from './medusa_split_shot';
+import { SPECS as omniknightHammerOfPurity } from './omniknight_hammer_of_purity';
 import { SPECS as omniknightPurification } from './omniknight_purification';
 import { SPECS as sandkingBurrowstrike } from './sandking_burrowstrike';
 import { SPECS as sandkingScorpionStrike } from './sandking_scorpion_strike';
@@ -21,10 +28,15 @@ import { SPECS as shadowShamanMassSerpentWard } from './shadow_shaman_mass_serpe
 import { SPECS as shadowShamanShackles } from './shadow_shaman_shackles';
 import { SPECS as shadowShamanUrnaconda } from './shadow_shaman_urnaconda';
 import { SPECS as shadowShamanVoodoo } from './shadow_shaman_voodoo';
+import { SPECS as silencerGlaivesOfWisdom } from './silencer_glaives_of_wisdom';
+import { SPECS as slarkSaltwaterShiv } from './slark_saltwater_shiv';
 import { SPECS as tinkerDeployTurrets } from './tinker_deploy_turrets';
 import { SPECS as tinkerLaser } from './tinker_laser';
 import { SPECS as tinkerMarchOfTheMachines } from './tinker_march_of_the_machines';
 import { SPECS as tinkerWarpGrenade } from './tinker_warp_grenade';
+import { SPECS as tuskWalrusPunch } from './tusk_walrus_punch';
+import { SPECS as viperPoisonAttack } from './viper_poison_attack';
+import { SPECS as winterWyvernArcticBurn } from './winter_wyvern_arctic_burn';
 
 /**
  * 技能 AI spec 聚合注册入口。
@@ -81,4 +93,22 @@ export function registerAbilitySpecs(): void {
   AbilityRegistry.registerAll(tinkerMarchOfTheMachines);
   AbilityRegistry.registerAll(tinkerWarpGrenade);
   AbilityRegistry.registerAll(tinkerDeployTurrets);
+
+  // 抽奖法球 / 开关类：bot 抽到后主动开启自动施法 / 切换开关，否则永不生效。
+  // CD 制 / 0 蓝法球常开（Self autoCastOn）
+  AbilityRegistry.registerAll(tuskWalrusPunch);
+  AbilityRegistry.registerAll(doomBringerInfernalBlade);
+  AbilityRegistry.registerAll(slarkSaltwaterShiv);
+  AbilityRegistry.registerAll(omniknightHammerOfPurity);
+  // 每攻击耗蓝法球，升到 2 级再开（Self autoCastOn + level.gte 2）
+  AbilityRegistry.registerAll(viperPoisonAttack);
+  AbilityRegistry.registerAll(silencerGlaivesOfWisdom);
+  AbilityRegistry.registerAll(drowRangerFrostArrows);
+  AbilityRegistry.registerAll(ancientApparitionChillingTouch);
+  AbilityRegistry.registerAll(enchantressImpetus);
+  // TOGGLE 类：分裂箭按敌人数量开关；严寒烧灼有 A 杖时按敌情飞行开关（持续耗蓝，无敌则关）
+  AbilityRegistry.registerAll(medusaSplitShot);
+  AbilityRegistry.registerAll(winterWyvernArcticBurn);
+  // 友方护甲（主动释放，noModifier 防重复）
+  AbilityRegistry.registerAll(lichFrostArmor);
 }

--- a/src/vscripts/ai/ability/specs/lich_frost_armor.ts
+++ b/src/vscripts/ai/ability/specs/lich_frost_armor.ts
@@ -1,0 +1,19 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 霜冻护甲：UNIT_TARGET | FRIENDLY。给友军（含自己）上护甲并减速攻击者。
+ *
+ * 项目把奥术法师寒冰盔甲克隆给巫妖，走正常主动释放（非 autocast），
+ * noModifier 防止持续期内重复刷新。modifier 名见项目本地化 addon_schinese.txt。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'lich_frost_armor',
+    targetSide: TargetSide.FriendlyHero,
+    condition: {
+      target: {
+        unitCondition: { noModifier: 'modifier_lich_frost_armor' },
+      },
+    },
+  },
+];

--- a/src/vscripts/ai/ability/specs/medusa_split_shot.ts
+++ b/src/vscripts/ai/ability/specs/medusa_split_shot.ts
@@ -3,9 +3,9 @@ import { AbilitySpec, TargetSide } from '../ability-spec';
 /**
  * 分裂箭：NO_TARGET | TOGGLE。开启后攻击分裂打多目标，但降低单体伤害。
  *
- * 900 内 ≥2 敌方英雄/小兵时开启群战/清线，≤1 且等级未满（lvl≤3，伤害惩罚相对高）时关闭。
- * count 区间留缓冲带避免边界横跳。自 hero-medusa.ts 迁移而来。
- * 对小兵 dispatcher 自动套 creep 默认条件（附近无敌英雄才触发，避免与对英雄逻辑打架）。
+ * 900 内敌方英雄 ≥2 / 小兵 ≥3 时开启群战/清线，≤1 时关闭。count 区间留缓冲带避免边界横跳。
+ * 对小兵 dispatcher 默认套 level≥3 门槛（为主动施法设计），开关只看数量，故显式写 level.gte:1 覆盖掉。
+ * 自 hero-medusa.ts 迁移而来。
  */
 export const SPECS: AbilitySpec[] = [
   {
@@ -13,6 +13,7 @@ export const SPECS: AbilitySpec[] = [
     targetSide: TargetSide.EnemyHero,
     condition: {
       target: { count: { gte: 2 }, range: { lte: 900 } },
+      ability: { level: { gte: 2 } },
       action: { toggleOn: true },
     },
   },
@@ -21,7 +22,7 @@ export const SPECS: AbilitySpec[] = [
     targetSide: TargetSide.EnemyHero,
     condition: {
       target: { count: { lte: 1 }, range: { lte: 900 } },
-      ability: { level: { lte: 3 } },
+      ability: { level: { gte: 1, lte: 3 } },
       action: { toggleOff: true },
     },
   },
@@ -29,7 +30,8 @@ export const SPECS: AbilitySpec[] = [
     abilityName: 'medusa_split_shot',
     targetSide: TargetSide.EnemyCreep,
     condition: {
-      target: { count: { gte: 2 }, range: { lte: 900 } },
+      target: { count: { gte: 3 }, range: { lte: 900 } },
+      ability: { level: { gte: 2 } },
       action: { toggleOn: true },
     },
   },
@@ -38,7 +40,7 @@ export const SPECS: AbilitySpec[] = [
     targetSide: TargetSide.EnemyCreep,
     condition: {
       target: { count: { lte: 1 }, range: { lte: 900 } },
-      ability: { level: { lte: 3 } },
+      ability: { level: { gte: 1, lte: 3 } },
       action: { toggleOff: true },
     },
   },

--- a/src/vscripts/ai/ability/specs/medusa_split_shot.ts
+++ b/src/vscripts/ai/ability/specs/medusa_split_shot.ts
@@ -1,0 +1,45 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 分裂箭：NO_TARGET | TOGGLE。开启后攻击分裂打多目标，但降低单体伤害。
+ *
+ * 900 内 ≥2 敌方英雄/小兵时开启群战/清线，≤1 且等级未满（lvl≤3，伤害惩罚相对高）时关闭。
+ * count 区间留缓冲带避免边界横跳。自 hero-medusa.ts 迁移而来。
+ * 对小兵 dispatcher 自动套 creep 默认条件（附近无敌英雄才触发，避免与对英雄逻辑打架）。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'medusa_split_shot',
+    targetSide: TargetSide.EnemyHero,
+    condition: {
+      target: { count: { gte: 2 }, range: { lte: 900 } },
+      action: { toggleOn: true },
+    },
+  },
+  {
+    abilityName: 'medusa_split_shot',
+    targetSide: TargetSide.EnemyHero,
+    condition: {
+      target: { count: { lte: 1 }, range: { lte: 900 } },
+      ability: { level: { lte: 3 } },
+      action: { toggleOff: true },
+    },
+  },
+  {
+    abilityName: 'medusa_split_shot',
+    targetSide: TargetSide.EnemyCreep,
+    condition: {
+      target: { count: { gte: 2 }, range: { lte: 900 } },
+      action: { toggleOn: true },
+    },
+  },
+  {
+    abilityName: 'medusa_split_shot',
+    targetSide: TargetSide.EnemyCreep,
+    condition: {
+      target: { count: { lte: 1 }, range: { lte: 900 } },
+      ability: { level: { lte: 3 } },
+      action: { toggleOff: true },
+    },
+  },
+];

--- a/src/vscripts/ai/ability/specs/omniknight_hammer_of_purity.ts
+++ b/src/vscripts/ai/ability/specs/omniknight_hammer_of_purity.ts
@@ -1,0 +1,14 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 纯洁之锤：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * 0 蓝法球，常开无害，bot 抽到即开启自动施法。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'omniknight_hammer_of_purity',
+    targetSide: TargetSide.Self,
+    condition: { action: { autoCastOn: true } },
+  },
+];

--- a/src/vscripts/ai/ability/specs/silencer_glaives_of_wisdom.ts
+++ b/src/vscripts/ai/ability/specs/silencer_glaives_of_wisdom.ts
@@ -1,0 +1,17 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 智慧之刃：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * 每次攻击耗蓝法球，升到 2 级再开启，避免低级时持续耗蓝。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'silencer_glaives_of_wisdom',
+    targetSide: TargetSide.Self,
+    condition: {
+      ability: { level: { gte: 2 } },
+      action: { autoCastOn: true },
+    },
+  },
+];

--- a/src/vscripts/ai/ability/specs/slark_saltwater_shiv.ts
+++ b/src/vscripts/ai/ability/specs/slark_saltwater_shiv.ts
@@ -1,0 +1,14 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 海浪短刀：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * CD 制法球（CD 8-14s），常开消耗小，bot 抽到即开启自动施法。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'slark_saltwater_shiv',
+    targetSide: TargetSide.Self,
+    condition: { action: { autoCastOn: true } },
+  },
+];

--- a/src/vscripts/ai/ability/specs/tusk_walrus_punch.ts
+++ b/src/vscripts/ai/ability/specs/tusk_walrus_punch.ts
@@ -1,0 +1,14 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 海象神拳：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * CD 制法球（触发后才耗蓝），常开无害，bot 抽到即开启自动施法。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'tusk_walrus_punch',
+    targetSide: TargetSide.Self,
+    condition: { action: { autoCastOn: true } },
+  },
+];

--- a/src/vscripts/ai/ability/specs/viper_poison_attack.ts
+++ b/src/vscripts/ai/ability/specs/viper_poison_attack.ts
@@ -1,0 +1,17 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 毒性攻击：UNIT_TARGET | AUTOCAST | ATTACK。
+ *
+ * 每次攻击耗蓝法球，升到 2 级（跳过最低级、蓝耗占比高的 1 级）再开启，避免低级时持续耗蓝。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'viper_poison_attack',
+    targetSide: TargetSide.Self,
+    condition: {
+      ability: { level: { gte: 2 } },
+      action: { autoCastOn: true },
+    },
+  },
+];

--- a/src/vscripts/ai/ability/specs/winter_wyvern_arctic_burn.ts
+++ b/src/vscripts/ai/ability/specs/winter_wyvern_arctic_burn.ts
@@ -1,0 +1,28 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+/**
+ * 严寒烧灼：基础 NO_TARGET 主动；有 A 杖时变为开关型（持续飞行、每秒耗蓝）。
+ *
+ * 持续耗蓝，故按敌情开关：有 A 杖时，1800 内有敌方英雄 toggleOn 进入飞行形态，
+ * 1800 内无敌方英雄 toggleOff 退出省蓝（1800 = bot 预搜半径 aroundEnemyHeroes）。
+ * 无 A 杖时不是开关技能，spec 不触发。
+ */
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'winter_wyvern_arctic_burn',
+    targetSide: TargetSide.EnemyHero,
+    condition: {
+      self: { unitCondition: { hasScepter: true } },
+      target: { range: { lte: 1800 } },
+      action: { toggleOn: true },
+    },
+  },
+  {
+    abilityName: 'winter_wyvern_arctic_burn',
+    targetSide: TargetSide.Self,
+    condition: {
+      self: { unitCondition: { hasScepter: true }, noEnemyHeroInRange: 1800 },
+      action: { toggleOff: true },
+    },
+  },
+];

--- a/src/vscripts/ai/action/action-ability.ts
+++ b/src/vscripts/ai/action/action-ability.ts
@@ -1,4 +1,8 @@
-import { CastAbilityOnTargetByBehavior, GetFullCastRange } from '../ability/ability-cast';
+import {
+  ApplyAbilityAction,
+  CastAbilityOnTargetByBehavior,
+  GetFullCastRange,
+} from '../ability/ability-cast';
 import { BotBaseAIModifier } from '../hero/bot-base';
 import { ActionFind } from './action-find';
 import {
@@ -129,29 +133,9 @@ export class ActionAbility {
   }
 
   private static doAction(condition: CastCoindition, ability: CDOTABaseAbility): boolean {
-    if (condition?.action) {
-      if (condition?.action?.toggleOn) {
-        if (!ability.GetToggleState()) {
-          print(`[AI] toggleOn ${ability.GetName()}`);
-          ability.ToggleAbility();
-          return true;
-        }
-      }
-      if (condition?.action?.toggleOff) {
-        if (ability.GetToggleState()) {
-          print(`[AI] toggleOff ${ability.GetName()}`);
-          ability.ToggleAbility();
-          return true;
-        }
-      }
-      if (condition?.action?.autoCastOn) {
-        if (!ability.GetAutoCastState()) {
-          print(`[AI] autoCastOn ${ability.GetName()}`);
-          ability.ToggleAutoCast();
-          return true;
-        }
-      }
+    if (!condition.action) {
+      return false;
     }
-    return false;
+    return ApplyAbilityAction(ability, condition.action);
   }
 }

--- a/src/vscripts/ai/hero/hero-medusa.ts
+++ b/src/vscripts/ai/hero/hero-medusa.ts
@@ -24,25 +24,7 @@ export class MedusaAIModifier extends BotBaseAIModifier {
       return true;
     }
 
-    // 分裂箭 开启
-    if (
-      ActionAbility.CastAbilityOnFindEnemyHero(this, 'medusa_split_shot', {
-        target: { count: { gte: 2 }, range: { lte: 900 } },
-        action: { toggleOn: true },
-      })
-    ) {
-      return true;
-    }
-    // 分裂箭 关闭
-    if (
-      ActionAbility.CastAbilityOnFindEnemyHero(this, 'medusa_split_shot', {
-        target: { count: { lte: 1 }, range: { lte: 900 } },
-        ability: { level: { lte: 3 } },
-        action: { toggleOff: true },
-      })
-    ) {
-      return true;
-    }
+    // 分裂箭已迁移至 specs/medusa_split_shot.ts（dispatcher 自动处理）
 
     return false;
   }
@@ -61,26 +43,6 @@ export class MedusaAIModifier extends BotBaseAIModifier {
     if (
       ActionAbility.CastAbilityOnFindEnemyCreep(this, 'medusa_gorgon_grasp', {
         target: { count: { gte: 2 } },
-      })
-    ) {
-      return true;
-    }
-
-    // 分裂箭 开启
-    if (
-      ActionAbility.CastAbilityOnFindEnemyCreep(this, 'medusa_split_shot', {
-        target: { count: { gte: 2 }, range: { lte: 900 } },
-        action: { toggleOn: true },
-      })
-    ) {
-      return true;
-    }
-    // 分裂箭 关闭
-    if (
-      ActionAbility.CastAbilityOnFindEnemyCreep(this, 'medusa_split_shot', {
-        target: { count: { lte: 1 }, range: { lte: 900 } },
-        ability: { level: { lte: 3 } },
-        action: { toggleOff: true },
       })
     ) {
       return true;


### PR DESCRIPTION
## Issue

- [x] fix #2115

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.33a[/b]

- Bot 现在会主动开启法球类被动技能。
```

```
[b]Gameplay update v5.33a[/b]

- Bots now auto-enable orb-effect passive abilities.
```
