### PR TITLE
为 RN 贡献的道具/技能添加 Lore 署名

### DIFF
--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -910,7 +910,7 @@
 		// 狙击手 暗杀-觉醒
 		"DOTA_Tooltip_ability_sniper_assassinate_upgrade"							"<font color='#d000ff'>暗杀 觉醒</font>"
 		"DOTA_Tooltip_ability_sniper_assassinate_upgrade_Description"				"狙击手锁定区域内的敌方英雄，发射毁灭性的子弹，在远距离造成一次必定暴击的攻击，并附带额外物理伤害。<br><br>普通攻击有一定概率触发该技能。"
-		"DOTA_Tooltip_ability_sniper_assassinate_upgrade_Lore"						"扣下扳机的那一刻，整片战场都为之屏息。"
+		"DOTA_Tooltip_ability_sniper_assassinate_upgrade_Lore"						"扣下扳机的那一刻，整片战场都为之屏息。 — by RN"
 		"DOTA_Tooltip_ability_sniper_assassinate_upgrade_Note0"						"准星效果只对友军可见。"
 		"DOTA_Tooltip_ability_sniper_assassinate_upgrade_Note1"						"隐身不会使弹道偏移。"
 		"DOTA_Tooltip_ability_sniper_assassinate_upgrade_Note2"						"打断引导法术，包括对魔法免疫单位。"
@@ -971,6 +971,7 @@
 		"DOTA_Tooltip_ability_rubick_might_and_magus2_aoe_bonus"				"作用范围加成："
 		"DOTA_Tooltip_ability_rubick_might_and_magus2_magic_resist_bonus"		"%魔法抗性加成："
 		"DOTA_Tooltip_ability_rubick_might_and_magus2_aoe_bonus_duration"		"额外持续时间："
+		"DOTA_Tooltip_ability_rubick_might_and_magus2_Lore"						"RN: 如果魔法不能打动你，贫僧也略通一些拳脚"
 		"DOTA_Tooltip_modifier_rubick_might_and_magus2"							"力量与魔法"
 		"DOTA_Tooltip_modifier_rubick_might_and_magus2_Description"				"技能作用范围提升%dMODIFIER_PROPERTY_AOE_BONUS_CONSTANT_STACKING%，魔法抗性提升%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%。"
 
@@ -1082,6 +1083,7 @@
 "DOTA_Tooltip_ability_pudge_meat_hook_lua_hook_base_distance"					"基础施法距离："
 		"DOTA_Tooltip_ability_pudge_meat_hook_lua_shard_description"					"肉钩击中敌人时，根据钩中时的距离造成额外纯粹伤害。"
 		"DOTA_Tooltip_ability_pudge_meat_hook_lua_distance_to_damage"					"%行进距离伤害："
+		"DOTA_Tooltip_ability_pudge_meat_hook_lua_Lore"						"RN: 这下总不用吵架了吧，真是踏马操碎了心"
 
 		// 剑圣 剑刃风暴-觉醒
 		"DOTA_Tooltip_ability_juggernaut_blade_fury_custom"								"<font color='#d000ff'>剑刃风暴 觉醒</font>"
@@ -1096,7 +1098,7 @@
 		// 斧王 无情铁手-觉醒
 		"DOTA_Tooltip_ability_axe_auto_culling_blade"									"<font color='#d000ff'>无情铁手 觉醒</font>"
 		"DOTA_Tooltip_ability_axe_auto_culling_blade_Description"						"<font color='#FF0000'>自动施放：自动斩杀</font><br>开启自动施法后，斧王会自动检测施法范围内血量低于斩杀线的敌方英雄并立即施放；触发后的持续时间内持续自动斩杀。<br><br>斩杀线 = 淘汰之刃阈值 + 斧王收获的额外护甲<br><br>斩杀时会突进到敌人身边。"
-		"DOTA_Tooltip_ability_axe_auto_culling_blade_Lore"								"利刃所向，皆为收割。"
+		"DOTA_Tooltip_ability_axe_auto_culling_blade_Lore"								"利刃所向，皆为收割。 — by RN"
 		"DOTA_Tooltip_ability_axe_auto_culling_blade_duration"							"持续时间："
 		"DOTA_Tooltip_ability_axe_auto_culling_blade_check_interval"						"斩杀间隔："
 		"DOTA_Tooltip_ability_axe_auto_culling_blade_increase_damage_per_kill"			"每次斩杀提升伤害："
@@ -1108,6 +1110,7 @@
 		"DOTA_Tooltip_ability_break_speed_limit_Description"							"当攻速达到上限后，每击杀一名英雄提高攻速上限%speed_limit_per_stack%点，持续%duration%秒。"
 		"DOTA_Tooltip_ability_break_speed_limit_speed_limit_per_stack"					"每次击杀突破攻速上限："
 		"DOTA_Tooltip_ability_break_speed_limit_duration"								"持续时间："
+		"DOTA_Tooltip_ability_break_speed_limit_Lore"						"-RN: 刮的越快，就刮得越快"
 		"DOTA_Tooltip_modifier_break_speed_limit_stacks"								"刮痧之王"
 		"DOTA_Tooltip_modifier_break_speed_limit_stacks_Description"					"每层提高攻速上限50点。"
 
@@ -1120,11 +1123,13 @@
 		"DOTA_Tooltip_ability_necrolyte_heartstopper_aura_datadriven_aura_damage"		"%每秒最大生命值伤害："
 		"DOTA_Tooltip_ability_necrolyte_heartstopper_aura_datadriven_heal_reduction_pct"	"治疗降低："
 		"DOTA_Tooltip_ability_necrolyte_heartstopper_aura_datadriven_heal_regen_to_damage"	"%生命恢复转化为伤害（神杖）："
+		"DOTA_Tooltip_ability_necrolyte_heartstopper_aura_datadriven_Lore"						"RN: 竭心感染有救了"
 
 		// 卓尔游侠 数箭连发-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>数箭连发 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"向单个敌人连续发射多支箭矢，每箭造成一次普通攻击。<br><br>与数箭齐发共享冷却、同步升级。"
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_shots"			"箭矢数："
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Lore"						"RN: 诸葛连弩"
 
 		// 宙斯 神王-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_zuus_upgrade"							"<font color='#d000ff'>神王 觉醒</font>"
@@ -1135,6 +1140,7 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_Description"	"幻影刺客闪烁到一个目标单位身旁，获得短暂的攻击速度加成和<font color='#FFCC66'>魔法免疫</font>，并自动发起攻击。<br><br>窒碍短匕弹道速度提升。施放窒碍短匕后获得短暂<font color='#FFCC66'>魔法免疫</font>。"
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_bonus_attack_speed"	"攻击速度加成："
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_untargetable_duration"	"持续时间："
+		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_Lore"						"RN: 这下敢B上去了吧"
 
 		// 巫医 神语-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_upgrade"					"<font color='#d000ff'>神语 觉醒</font>"
@@ -2968,7 +2974,7 @@
 		// 鹰眼炮台
 		"DOTA_Tooltip_Ability_item_hawkeye_turret"										"鹰眼炮台"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_Description"							"<h1><font color='#FFFF00'>主动：人形炮台（仅限远程）</font></h1>化身炮台，变为飞行单位，获得高空视野。持续%active_duration%秒，禁锢无法移动，获得额外攻击距离%active_attack_range%，视野范围为攻击距离 + %active_bonus_vision%。<br><br><font color='#FF6B6B'>近战英雄使用没有效果。</font>\n<h1>被动：霰弹（仅限远程）</h1>对攻击目标周围%attack_radius%范围内的敌人造成%attack_percent%%%溅射伤害。<br/>霰弹特效无法叠加，拥有%internal_cooldown%秒内置冷却。\n<h1>被动：绝对腐蚀</h1>物理攻击将降低目标%corruption_armor%点护甲，持续%corruption_duration%秒。<br><br>每次有英雄死于毁蚀效果下就会+%bonus_damage_per_kill%点攻击力，最多获得%max_damage%点。"
-		"DOTA_Tooltip_ability_item_hawkeye_turret_Lore"									"化身为固定炮台，以强大的火力压制敌人。"
+		"DOTA_Tooltip_ability_item_hawkeye_turret_Lore"									"化身为固定炮台，以强大的火力压制敌人。 — by RN"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_Note0"								"护甲降低效果对建筑有效。"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_bonus_damage"							"+$damage"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_bonus_attack_speed"					"+$attack"
@@ -2980,7 +2986,7 @@
 		// 鹰眼战机
 		"DOTA_Tooltip_Ability_item_hawkeye_fighter"										"鹰眼战机"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_Description"							"<h1><font color='#FFFF00'>主动: 人形战斗机</font></h1>激活战机模式，获得高空视野和极高的机动性。持续%active_duration%秒内，获得%active_movement_speed_pct%%%移速加成，变为飞行单位，无视地形移动，无视单位碰撞，无视移速上限，并施加弱驱散效果。<br><br>冷却时间：%AbilityCooldown%秒<br><br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>"
-		"DOTA_Tooltip_ability_item_hawkeye_fighter_Lore"								"化身战机,翱翔天际,无人能及。"
+		"DOTA_Tooltip_ability_item_hawkeye_fighter_Lore"								"化身战机,翱翔天际,无人能及。 — by RN"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_bonus_all_stats"						"+$all"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_bonus_movement_speed"				"+$move_speed"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_bonus_movement_speed_pct"			"%+$move_speed"
@@ -2992,7 +2998,7 @@
 		// 禁忌法锤 Forbidden Staff
 		"DOTA_Tooltip_Ability_item_forbidden_staff"										"<font color='#8B008B'>禁忌法锤</font>"
 		"DOTA_Tooltip_ability_item_forbidden_staff_Description"							"<h1><font color='#8B008B'>主动：禁忌领域</font></h1>在目标区域施放禁忌领域,对范围内所有敌人施放死灵冲击，闪电风暴和变羊术。<br><br>死灵冲击：降低敌人 %blast_magic_resist%%% 点的魔法抗性（固定值），造成%necrolyte_att_multiplier%x[你的全属性]点魔法伤害,并将目标变成小动物%sheep_duration%秒<br><br>闪电风暴：造成%lightning_damage%点魔法伤害<br><br>额外效果：清除范围内敌方的侦查守卫和岗哨守卫<br><br>作用范围：%radius_tooltip%"
-		"DOTA_Tooltip_ability_item_forbidden_staff_Lore"								"禁忌的力量,不可轻易触碰。"
+		"DOTA_Tooltip_ability_item_forbidden_staff_Lore"								"禁忌的力量,不可轻易触碰。 — by RN"
 		"DOTA_Tooltip_ability_item_forbidden_staff_Note0"								"死灵冲击会将目标变成无害的小动物,无法攻击，施法或使用物品。"
 		"DOTA_Tooltip_ability_item_forbidden_staff_bonus_aoe"							"+$aoe_bonus"
 		"DOTA_Tooltip_ability_item_forbidden_staff_bonus_hp"							"+$health"
@@ -3008,7 +3014,7 @@
 		// 禁忌战刃
 		"DOTA_Tooltip_Ability_item_forbidden_blade"										"<font color='#8B008B'>禁忌战刃</font>"
 		"DOTA_Tooltip_ability_item_forbidden_blade_Description"							"<h1><font color='#8B008B'>主动：忌炼杀狱</font></h1>在目标区域施放忌炼杀狱,对%radius%范围内所有敌人施放一闪，闪电风暴和毁灭终曲。<br><br>一闪眩晕时间：%stun_duration%秒<br>一闪伤害：%active_damage_base%+%active_damage_multi%x[你的主属性](纯粹伤害)<br>闪电风暴伤害：%lightning_damage%<br>毁灭终曲持续时间：%mute_duration%秒<br><br>作用范围：%radius%"
-		"DOTA_Tooltip_ability_item_forbidden_blade_Lore"								"禁忌之刃,斩断一切。"
+		"DOTA_Tooltip_ability_item_forbidden_blade_Lore"								"禁忌之刃,斩断一切。 — by RN"
 		"DOTA_Tooltip_ability_item_forbidden_blade_Note0"								"一闪效果造成纯粹伤害,无视魔法免疫。"
 		"DOTA_Tooltip_ability_item_forbidden_blade_bonus_strength"						"+$str"
 		"DOTA_Tooltip_ability_item_forbidden_blade_bonus_agility"						"+$agi"
@@ -3030,14 +3036,14 @@
 		"DOTA_Tooltip_ability_item_switchable_crit_blade_bonus_damage_percent"			"%+基础伤害"
 		"DOTA_Tooltip_ability_item_switchable_crit_blade_Note0"							"克敌机先: 攻击无视闪避"
 		"DOTA_Tooltip_ability_item_switchable_crit_blade_Note1"							"继承黄金大核荣耀的基础暴击效果"
-		"DOTA_Tooltip_ability_item_switchable_crit_blade_Lore"							"破浪：潮初起时刃轻扬<br>断流：潮横断处月凝霜<br>归海：潮归瀚海刀义藏"
+		"DOTA_Tooltip_ability_item_switchable_crit_blade_Lore"							"破浪：潮初起时刃轻扬<br>断流：潮横断处月凝霜<br>归海：潮归瀚海刀义藏 — by RN"
 		"DOTA_Tooltip_modifier_item_switchable_crit_blade"								"刀势"
 		"DOTA_Tooltip_modifier_item_switchable_crit_blade_Description"					"1=初式·破浪 2=二式·断流 3=终式·归海"
 
 		// 魔龙狂舞
 		"DOTA_Tooltip_Ability_item_magic_crit_blade"									"<font color='#A74ABD'>魔龙狂舞</font>"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_Description"						"<h1><font color='#FF0000'>被动：神圣斧</font></h1>使下次攻击具有克敌机先效果，并且会施加毒素，持续%slow_duration%秒，减缓%slow%%%移动速度，并且每秒造成%int_damage_multiplier%倍智力值的伤害。<br><br>攻击会降低敌人%active_mres_reduction%%%魔法抗性，持续%passive_cooldown%秒。<br><br>所有攻击都具有克敌机先效果。\n<h1><font color='#A74ABD'>主动：龙息爆发</font></h1>使用后%active_duration%秒内，获得%spell_amp_multiplier%倍被智力法术增强。<br><br>冷却时间：%active_cooldown%秒<br>魔法消耗：%AbilityManaCost%\n<h1><font color='#0096FF'>被动：幻影暴击</font></h1>每次攻击有%crit_chance%%%几率造成额外的魔法伤害，数值为攻击伤害的%crit_multiplier%%%。"
-		"DOTA_Tooltip_ability_item_magic_crit_blade_Lore"								"魔龙狂舞，焚天灭地。魔焰龙息席卷万物，法术爆发摧枯拉朽。"
+		"DOTA_Tooltip_ability_item_magic_crit_blade_Lore"								"魔龙狂舞，焚天灭地。魔焰龙息席卷万物，法术爆发摧枯拉朽。 — by RN"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_bonus_intellect"					"+$int"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_bonus_damage"						"+$damage"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_spell_amp_per_int"					"%+每点智力法术增强"
@@ -3050,7 +3056,7 @@
 		// 枯木逢春/生命之心
 		"DOTA_Tooltip_Ability_item_withered_spring"										"<font color='#90EE90'>生命之心</font>"
 		"DOTA_Tooltip_ability_item_withered_spring_Description"							"<h1><font color='#90EE90'>枯木逢春</font></h1>立即恢复%instant_heal%生命值,驱散所有负面效果,并在%active_duration%秒内获得:<br>+%bonus_armor_active%护甲<br>+%bonus_regen_active%生命回复<br>+%status_resistance_active%%%状态抗性<br>+%damage_reduction%%%减伤<br>生命值低于%hp_threshold%%%时自动触发。<br><br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n"
-		"DOTA_Tooltip_ability_item_withered_spring_Lore"								"饱含生命之力的树甲，枯木逢春,绝处逢生。"
+		"DOTA_Tooltip_ability_item_withered_spring_Lore"								"饱含生命之力的树甲，枯木逢春,绝处逢生。 — by RN"
 		"DOTA_Tooltip_ability_item_withered_spring_bonus_strength"						"+$str"
 		"DOTA_Tooltip_ability_item_withered_spring_bonus_health"						"+$health"
 		"DOTA_Tooltip_ability_item_withered_spring_bonus_health_regen"					"+$hp_regen"
@@ -3068,7 +3074,7 @@
 		// 德古拉面罩/生命之盔
 		"DOTA_Tooltip_Ability_item_dracula_mask"										"<font color='#8B0000'>生命之盔</font>"
 		"DOTA_Tooltip_ability_item_dracula_mask_Description"							"<h1><font color='#90EE90'>主动：吸血盛宴</h1>驱散所有负面效果,并在%active_duration%秒内获得:<br>%lifesteal_active%%%物理吸血<br>%spell_lifesteal_active%%%法术吸血<br>+%bonus_attack_speed_active%攻击速度<br>+%bonus_movement_speed_active%%%移动速度<br>%damage_reduction%%%减伤<br>免疫减速<br><br>生命值低于%hp_threshold%%%时自动触发。<br><br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>\n<h1>"
-		"DOTA_Tooltip_ability_item_dracula_mask_Lore"									"饱含生命之力的头盔,赋予佩戴者永恒的生命力。"
+		"DOTA_Tooltip_ability_item_dracula_mask_Lore"									"饱含生命之力的头盔,赋予佩戴者永恒的生命力。 — by RN"
 		"DOTA_Tooltip_ability_item_dracula_mask_bonus_strength"							"+$str"
 		"DOTA_Tooltip_ability_item_dracula_mask_bonus_health"							"+$health"
 		"DOTA_Tooltip_ability_item_dracula_mask_bonus_damage"							"+$damage"
@@ -3086,7 +3092,7 @@
 		// 暗影裁决
 		"DOTA_Tooltip_Ability_item_shadow_judgment"										"<font color='#8A2BE2'>暗影裁决</font>"
 		"DOTA_Tooltip_ability_item_shadow_judgment_Description"							"<h1>主动：暗影审判</h1>对目标施加暗影审判，融合一闪，苍蓝幻想和变态辣的所有debuff效果。<br><br>一闪：瞬移到目标身后，眩晕%stun_duration%秒，造成%active_damage_base%+%active_damage_multi%x[主属性]点纯粹伤害<br>苍蓝幻想：持续驱散增益，%mute_duration%秒禁用装备和被动，减速%slow_pct%%%，攻击速度减少%attack_slow%，每秒造成%max_hp_dmg_pct%%%最大生命值的纯粹伤害，降低%hp_regen_reduction%%%生命恢复<br>变态辣：沉默%silence_duration%秒，结束时造成期间受到伤害的%silence_damage_percent%%%作为额外魔法伤害<br><br>施法距离：%abilitycastrange%"
-		"DOTA_Tooltip_ability_item_shadow_judgment_Lore"								"暗影的裁决，无人可逃。"
+		"DOTA_Tooltip_ability_item_shadow_judgment_Lore"								"暗影的裁决，无人可逃。 — by RN"
 		"DOTA_Tooltip_ability_item_shadow_judgment_bonus_strength"						"+$str"
 		"DOTA_Tooltip_ability_item_shadow_judgment_bonus_agility"						"+$agi"
 		"DOTA_Tooltip_ability_item_shadow_judgment_bonus_intellect"						"+$int"
@@ -3109,7 +3115,7 @@
 		// 暗影咒灭
 		"DOTA_Tooltip_Ability_item_shadow_impact"										"<font color='#C77DFF'>暗影咒灭</font>"
 		"DOTA_Tooltip_ability_item_shadow_impact_Description"							"<h1>主动：暗影湮灭</h1>对目标施放暗影湮灭。<br><br>纯粹伤害：%absolute_damage%点<br>魔法伤害：%dagon_damage%点<br>虚灵冲击：造成%blast_damage_base%+%blast_agility_multiplier%x[主属性]点魔法伤害,并使目标进入虚灵状态%ethereal_duration%秒,减速%blast_movement_slow%%%<br>死灵冲击：降低敌人 %blast_magic_resist%%% 点的魔法抗性（固定值），造成%necrolyte_att_multiplier%x[全属性]点魔法伤害,并变羊%sheep_duration%秒<br><br>施法距离：%abilitycastrange%"
-		"DOTA_Tooltip_ability_item_shadow_impact_Lore"									"暗影的冲击,毁灭一切。"
+		"DOTA_Tooltip_ability_item_shadow_impact_Lore"									"暗影的冲击,毁灭一切。 — by RN"
 		"DOTA_Tooltip_ability_item_shadow_impact_bonus_intellect"						"+$int"
 		"DOTA_Tooltip_ability_item_shadow_impact_bonus_strength"						"+$str"
 		"DOTA_Tooltip_ability_item_shadow_impact_bonus_agility"							"+$agi"
@@ -3128,7 +3134,7 @@
 
 		"DOTA_Tooltip_Ability_item_swift_glove"											"无限手套"
 		"DOTA_Tooltip_ability_item_swift_glove_Description"								"<h1><font color='#FFFF00'>被动：极速</font></h1>提升攻击速度，移动速度和攻击距离，并减少%bat_reduction_pct%%%基础攻击间隔。"
-		"DOTA_Tooltip_ability_item_swift_glove_Lore"									"传说中的手套，能让佩戴者的速度快到看不见。"
+		"DOTA_Tooltip_ability_item_swift_glove_Lore"									"传说中的手套，能让佩戴者的速度快到看不见。 — by RN"
 		"DOTA_Tooltip_ability_item_swift_glove_Note0"									"基础攻击间隔减少效果无法叠加。"
 		"DOTA_Tooltip_ability_item_swift_glove_bonus_strength"							"+$str"
 		"DOTA_Tooltip_ability_item_swift_glove_bonus_agility"							"+$agi"
@@ -3140,7 +3146,7 @@
 
 		"DOTA_Tooltip_Ability_item_ten_thousand_swords"									"万剑归宗"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_Description"						"<h1><font color='#FFFF00'>被动：剑之极致</font></h1>集四把神器对剑之力于一身，大幅提升全属性，状态抗性，攻击速度，移动速度，生命恢复，魔法恢复和技能增强。攻击附带魔法伤害。"
-		"DOTA_Tooltip_ability_item_ten_thousand_swords_Lore"							"万剑归宗，天下无敌。四把神器对剑的力量汇聚于此，铸就无上神兵。"
+		"DOTA_Tooltip_ability_item_ten_thousand_swords_Lore"							"万剑归宗，天下无敌。四把神器对剑的力量汇聚于此，铸就无上神兵。 — by RN"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_bonus_strength"					"+$str"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_bonus_agility"					"+$agi"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_bonus_intellect"					"+$int"
@@ -3154,7 +3160,7 @@
 
 		"DOTA_Tooltip_Ability_item_time_gem"											"时间宝石"
 		"DOTA_Tooltip_ability_item_time_gem_Description"								"<h1><font color='#FFFF00'>主动：时间重置</font></h1>重置所有物品和技能的冷却时间。<br><br>冷却时间：%AbilityCooldown%秒\n<h1>被动：时间加速</h1>降低所有技能和物品%bonus_cooldown%%%的冷却时间。"
-		"DOTA_Tooltip_ability_item_time_gem_Lore"										"掌控时间的神秘宝石，能让使用者操纵时间的流速。"
+		"DOTA_Tooltip_ability_item_time_gem_Lore"										"掌控时间的神秘宝石，能让使用者操纵时间的流速。 — by RN"
 		"DOTA_Tooltip_ability_item_time_gem_Note0"										"时间重置不会刷新刷新球系列物品（刷新球，刷新核心，时间宝石）。"
 		"DOTA_Tooltip_ability_item_time_gem_Note1"										"与其他刷新球系列物品共享冷却时间。"
 		"DOTA_Tooltip_ability_item_time_gem_bonus_cooldown"								"%+$cooldown_reduction"
@@ -3172,7 +3178,7 @@
 		"DOTA_Tooltip_ability_item_beast_shield_Description"							"<h1>主动：人形肉盾</h1>获得减益免疫状态。进入防御姿态，所有被动属性加成提升%active_bonus_multiplier_tooltip%%%，移动速度固定为%active_movespeed%，持续%active_duration%秒。<br>提供%magic_resist%%%魔法抗性加成，并且免疫纯粹和反弹伤害。持续时间内敌方技能的负面效果不会生效。\n<h1>被动：游泳</h1>受到敌人的技能伤害在减免前的%mana_restore_pct%%%会转化为自身的魔法。\n<h1>被动：强袭光环</h1>为附近友军提供%aura_positive_armor%点护甲和%aura_attack_speed%点攻击速度。降低附近敌军%aura_negative_armor%点护甲。<br><br>作用范围：%aura_radius%"
 		"DOTA_Tooltip_modifier_item_beast_shield_resist_stack"							"潜水服"
 		"DOTA_Tooltip_modifier_item_beast_shield_resist_stack_Description"				"每层增加%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%魔法抗性。"
-		"DOTA_Tooltip_ability_item_beast_shield_Lore"									"融合了兽化符文力量的终极防御装备，能让使用者化身为不可摧毁的堡垒。"
+		"DOTA_Tooltip_ability_item_beast_shield_Lore"									"融合了兽化符文力量的终极防御装备，能让使用者化身为不可摧毁的堡垒。 — by RN"
 		"DOTA_Tooltip_ability_item_beast_shield_passive_bonus_strength"					"+$str"
 		"DOTA_Tooltip_ability_item_beast_shield_passive_bonus_health"					"+$health"
 		"DOTA_Tooltip_ability_item_beast_shield_passive_bonus_armor"					"+$armor"
@@ -3192,7 +3198,7 @@
 		// item_beast_armor 兽化甲
 		"DOTA_Tooltip_Ability_item_beast_armor"											"兽化甲"
 		"DOTA_Tooltip_ability_item_beast_armor_Description"								"<h1>主动：不粘锅</h1>发出极寒冲击波，对%blast_radius%范围内敌人造成%blast_damage%点魔法伤害，降低%movement_slow%%%移动速度和%attack_slow%攻击速度，降低%spell_resist_reduction%%%魔法抗性。<br>同时反弹%active_reflection_pct%%%所有伤害并反弹指向性技能，持续%active_duration%秒。\n<h1>被动：伤害反弹</h1>每次受到攻击时，反弹%passive_reflection_constant% + 所受攻击伤害的%passive_reflection_pct%%%。<br><br>每%block_cooldown%秒被动抵挡一次指向性法术。\n<h1>被动：辉耀灼烧</h1>每秒对%aura_radius%范围内敌军造成%aura_damage%点魔法伤害，并使其物理攻击有%blind_pct%%%几率不会命中。"
-		"DOTA_Tooltip_ability_item_beast_armor_Lore"									"集四大神器之力于一身的终极护甲，兽化符文赋予了它无与伦比的防御和反击能力。"
+		"DOTA_Tooltip_ability_item_beast_armor_Lore"									"集四大神器之力于一身的终极护甲，兽化符文赋予了它无与伦比的防御和反击能力。 — by RN"
 		"DOTA_Tooltip_ability_item_beast_armor_Note0"									"反弹的均为减免前的伤害。"
 		"DOTA_Tooltip_ability_item_beast_armor_Note1"									"伤害反弹不会反弹来自其他刃甲的伤害。"
 		"DOTA_Tooltip_ability_item_beast_armor_Note2"									"反弹伤害的类型与受到时相同。"
@@ -3215,7 +3221,7 @@
 		// item_magic_sword 魔渊剑
 		"DOTA_Tooltip_Ability_item_magic_sword"											"魔渊剑"
 		"DOTA_Tooltip_Ability_item_magic_sword_Description"								"<h1>主动：<font color='#A74ABD'>一念成佛</font></h1>持续 %active_duration% 秒内，你造成的物理伤害的 %convert_pct%%% 会转化为额外纯粹伤害。\n<h1>被动：斩断世界线</h1>普通攻击时对目标周围最远 %cleave_distance% 距离的锥形区域内敌人造成 %cleave_damage_percent%%% 物理伤害。对非英雄单位造成 %cleave_damage_percent_creep%%% 物理伤害。（仅近战有效）\n<h1>被动：魔渊腐蚀</h1>攻击时对目标施加腐蚀效果，持续 %debuff_duration% 秒：<br>- 护甲降低 %corruption_armor%<br>- 攻击速度降低 %attack_slow%<br>- 移动速度降低 %slow_pct%%%<br>- 生命回复和治疗效果降低 %hp_regen_reduction_pct%%%"
-		"DOTA_Tooltip_Ability_item_magic_sword_Lore"									"佛曰：一念成佛，一念成魔。"
+		"DOTA_Tooltip_Ability_item_magic_sword_Lore"									"佛曰：一念成佛，一念成魔。 — by RN"
 		"DOTA_Tooltip_Ability_item_magic_sword_bonus_damage_passive"					"+$damage"
 		"DOTA_Tooltip_Ability_item_magic_sword_bonus_all_stats"							"+$all"
 		"DOTA_Tooltip_Ability_item_magic_sword_bonus_health_regen"						"+$hp_regen"
@@ -3229,11 +3235,11 @@
 
 		"DOTA_Tooltip_Ability_item_tome_of_ability_reset"								"能力重置书"
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Description"					"<h1>使用：能力重置</h1>打开能力重置界面，可以移除已学习的技能并学习新技能。<br>移除技能时会返还技能点。<br><br>一本书只能选择一个技能进行重置。\n\n可以分享给队友"
-		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。"
+		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。 — by RN"
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"技能洗点书"
 		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>重置英雄技能等级并返还已花费的技能点。主动技能清零，被动、攻击触发及开关型技能保留至1级。"
-		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。"
+		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。 — by RN"
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"最高等级只有1级的先天技能不受影响。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"被动、攻击触发及开关型技能会保留至1级（不清零），避免出现冷却异常等问题。"
 


### PR DESCRIPTION
## 说明

应贡献者 RN 的要求，在其曾提交的代码中补充署名。

### 关于代码文件中补版权声明

**没有必要。** 版权自代码写成之日起天然归属作者，与是否在文件中显式声明无关。主流开源项目（React、Linux kernel 等）均不逐文件标注贡献者版权，否则在多贡献者交织的文件中既不可维护、也易引发归属争议。本项目级 `LICENSE` 与 `LICENSE.EXCEPTIONS.md` 中的署名已覆盖全部贡献者。

### 本次改动

在以下道具/技能的 `_Lore` 风味文本中添加了 RN 署名

- `item_forbidden_blade` `item_time_gem` `item_beast_armor` 等 物品，在现有 Lore 末尾追加 `— by RN`
- `break_speed_limit` `pudge_meat_hook_lua` `rubick_might_and_magus2` 等 技能，新建 `_Lore` 条目

署名放在游戏内道具描述的**风味文本**中，既是 RN 创作痕迹的保留，也是出于情感价值尊重。

## Checklist

- [x] 仅本地化文本，无代码或玩法改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)