### PR TITLE
Add ward slot keybind and quick-cast settings

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3238,6 +3238,7 @@
 		"dota_hud_error_awaken_stone_unsupported"										"This hero has no ability to awaken"
 		"dota_hud_error_awaken_stone_awakened"											"This hero has already awakened"
 		"dota_hud_error_passive_skill_tome_max_usage"									"Passive Skill Tome usage limit reached"
+		"dota_hud_error_ward_no_cast_zone"												"Cannot place wards near Roshan's pit"
 
 		"DOTA_Tooltip_ability_trigger_learned_skills_Note0"    "Does not trigger the following types of skills:"
 		"DOTA_Tooltip_ability_trigger_learned_skills_Note1"    "• Map functionality skills (teleport, point of control, etc.)"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3300,6 +3300,7 @@
 		"dota_hud_error_awaken_stone_unsupported"										"该英雄暂未拥有可觉醒的技能"
 		"dota_hud_error_awaken_stone_awakened"											"该英雄已经觉醒过了"
 		"dota_hud_error_passive_skill_tome_max_usage"									"被动技能书使用次数已达上限"
+		"dota_hud_error_ward_no_cast_zone"												"肉山坑附近不能放置守卫"
 
 		// 藏宝箱
 		"npc_treasure_chest"															"藏宝箱"

--- a/src/common/events.d.ts
+++ b/src/common/events.d.ts
@@ -135,5 +135,9 @@ interface SaveBindAbilityKeyEventData {
   activeAbilityQuickCast: boolean;
   passiveAbilityQuickCast: boolean;
   passiveAbilityQuickCast2?: boolean;
+  wardObserverKey?: string;
+  wardObserverQuickCast?: boolean;
+  wardSentryKey?: string;
+  wardSentryQuickCast?: boolean;
 }
 

--- a/src/panorama/react/hud_lottery/KeyBind.tsx
+++ b/src/panorama/react/hud_lottery/KeyBind.tsx
@@ -37,7 +37,9 @@ function KeyBind() {
     if (
       playerSetting.activeAbilityKey ||
       playerSetting.passiveAbilityKey ||
-      playerSetting.passiveAbilityKey2
+      playerSetting.passiveAbilityKey2 ||
+      playerSetting.wardObserverKey ||
+      playerSetting.wardSentryKey
     ) {
       setIsCollapsed(true);
     }
@@ -45,6 +47,8 @@ function KeyBind() {
     playerSetting.activeAbilityKey,
     playerSetting.passiveAbilityKey,
     playerSetting.passiveAbilityKey2,
+    playerSetting.wardObserverKey,
+    playerSetting.wardSentryKey,
   ]);
 
   // 获取玩家steamId，如果获取失败，则为观战，不显示

--- a/src/panorama/react/hud_lottery/WardSlot.tsx
+++ b/src/panorama/react/hud_lottery/WardSlot.tsx
@@ -32,6 +32,7 @@ const containerStyle: Partial<VCSSStyleDeclaration> = {
   flowChildren: 'down',
   marginBottom: '8px',
   transform: 'translateX(-55px)',
+  zIndex: 100,
 };
 
 const slotStyle: Partial<VCSSStyleDeclaration> = {

--- a/src/panorama/react/hud_lottery/WardSlot.tsx
+++ b/src/panorama/react/hud_lottery/WardSlot.tsx
@@ -1,7 +1,9 @@
 import 'panorama-polyfill-x/lib/console';
 import 'panorama-polyfill-x/lib/timers';
 import React, { useEffect, useRef, useState } from 'react';
-import { AddKeyBind, FindDotaHudElement } from '@utils/utils';
+import { FindDotaHudElement, GetLocalPlayerSteamAccountID } from '@utils/utils';
+import { useNetTable } from '../shared/hooks/useNetTable';
+import { PlayerSetting } from '../../../vscripts/api/player';
 
 const POLL_INTERVAL_MS = 200;
 const RIGHT_FLARE_WIDTH = '125px';
@@ -15,14 +17,14 @@ const SLOTS = [
   {
     ability: 'ability_ward_observer_slot',
     item: 'item_ward_observer',
-    keybind: DOTAKeybindCommand_t.DOTA_KEYBIND_CONTROL_GROUP5,
+    settingKey: 'wardObserverKey',
   },
   {
     ability: 'ability_ward_sentry_slot',
     item: 'item_ward_sentry',
-    keybind: DOTAKeybindCommand_t.DOTA_KEYBIND_CONTROL_GROUP6,
+    settingKey: 'wardSentryKey',
   },
-] as const;
+] as const satisfies readonly { ability: string; item: string; settingKey: keyof PlayerSetting }[];
 
 const containerStyle: Partial<VCSSStyleDeclaration> = {
   horizontalAlign: 'right',
@@ -73,11 +75,6 @@ const hotkeyStyle: Partial<VCSSStyleDeclaration> = {
   zIndex: 1,
 };
 
-interface SlotState {
-  charges: number;
-  hotkey: string;
-}
-
 function getHeroSlotAbility(abilityName: string): AbilityEntityIndex | -1 {
   const heroId = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
   if (heroId === -1) {
@@ -100,9 +97,10 @@ function placeWard(abilityName: string) {
 
 function WardSlot() {
   const containerRef = useRef<Panel | null>(null);
-  const [states, setStates] = useState<SlotState[]>(() =>
-    SLOTS.map(({ keybind }) => ({ charges: 0, hotkey: Game.GetKeybindForCommand(keybind) })),
-  );
+  const [charges, setCharges] = useState<number[]>(() => SLOTS.map(() => 0));
+  const steamAccountId = GetLocalPlayerSteamAccountID();
+  const player = useNetTable('player_table', steamAccountId);
+  const playerSetting = player?.playerSetting;
 
   useEffect(() => {
     const centerWithStats = FindDotaHudElement('center_with_stats');
@@ -135,27 +133,11 @@ function WardSlot() {
   }, []);
 
   useEffect(() => {
-    for (const { ability, keybind } of SLOTS) {
-      const keyName = Game.GetKeybindForCommand(keybind);
-      if (keyName !== '') {
-        AddKeyBind(
-          keyName,
-          () => placeWard(ability),
-          () => {},
-        );
-      }
-    }
-  }, []);
-
-  useEffect(() => {
     const id = setInterval(() => {
-      setStates(
-        SLOTS.map(({ ability, keybind }) => {
+      setCharges(
+        SLOTS.map(({ ability }) => {
           const abilityId = getHeroSlotAbility(ability);
-          return {
-            charges: abilityId === -1 ? 0 : Abilities.GetCurrentAbilityCharges(abilityId),
-            hotkey: Game.GetKeybindForCommand(keybind),
-          };
+          return abilityId === -1 ? 0 : Abilities.GetCurrentAbilityCharges(abilityId);
         }),
       );
     }, POLL_INTERVAL_MS);
@@ -164,8 +146,9 @@ function WardSlot() {
 
   return (
     <Panel hittest={false} ref={containerRef} style={containerStyle}>
-      {SLOTS.map(({ ability, item }, i) => {
-        const charges = states[i].charges;
+      {SLOTS.map(({ ability, item, settingKey }, i) => {
+        const chargeCount = charges[i];
+        const hotkey = playerSetting?.[settingKey] ?? '';
         return (
           <Panel
             key={ability}
@@ -176,10 +159,10 @@ function WardSlot() {
             <DOTAItemImage
               itemname={item}
               showtooltip={true}
-              style={{ ...iconBaseStyle, opacity: charges > 0 ? '1' : '0.4' }}
+              style={{ ...iconBaseStyle, opacity: chargeCount > 0 ? '1' : '0.4' }}
             />
-            {states[i].hotkey !== '' && <Label style={hotkeyStyle} text={states[i].hotkey} />}
-            <Label style={chargeStyle} text={charges.toString()} />
+            {hotkey !== '' && <Label style={hotkeyStyle} text={hotkey} />}
+            <Label style={chargeStyle} text={chargeCount.toString()} />
           </Panel>
         );
       })}

--- a/src/panorama/react/hud_lottery/components/KeyBindContainer.tsx
+++ b/src/panorama/react/hud_lottery/components/KeyBindContainer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import KeySettingButton from './KeySettingButton';
+import WardKeySettingButton from './WardKeySettingButton';
 import KeyBindRemember from './KeyBindRemember';
 import { GetLotteryStatus, SubscribeLotteryStatus } from '@utils/net-table';
 import { GetLocalPlayerSteamAccountID } from '@utils/utils';
@@ -38,6 +39,14 @@ const KeyBindContainer: React.FC<KeyBindContainerProps> = ({ isCollapsed, player
   const [isRememberAbilityKey, setIsRememberAbilityKey] = useState(
     playerSetting.isRememberAbilityKey,
   );
+  const [wardObserverKey, setWardObserverKey] = useState(playerSetting.wardObserverKey ?? '');
+  const [wardObserverQuickCast, setWardObserverQuickCast] = useState(
+    playerSetting.wardObserverQuickCast ?? false,
+  );
+  const [wardSentryKey, setWardSentryKey] = useState(playerSetting.wardSentryKey ?? '');
+  const [wardSentryQuickCast, setWardSentryQuickCast] = useState(
+    playerSetting.wardSentryQuickCast ?? false,
+  );
   const isFirstRender = useRef(true);
 
   // 监听nettable数据变化
@@ -64,6 +73,10 @@ const KeyBindContainer: React.FC<KeyBindContainerProps> = ({ isCollapsed, player
       activeAbilityQuickCast,
       passiveAbilityQuickCast,
       passiveAbilityQuickCast2,
+      wardObserverKey,
+      wardObserverQuickCast,
+      wardSentryKey,
+      wardSentryQuickCast,
     });
   }, [
     isRememberAbilityKey,
@@ -73,6 +86,10 @@ const KeyBindContainer: React.FC<KeyBindContainerProps> = ({ isCollapsed, player
     activeAbilityQuickCast,
     passiveAbilityQuickCast,
     passiveAbilityQuickCast2,
+    wardObserverKey,
+    wardObserverQuickCast,
+    wardSentryKey,
+    wardSentryQuickCast,
   ]);
 
   useEffect(() => {
@@ -123,6 +140,24 @@ const KeyBindContainer: React.FC<KeyBindContainerProps> = ({ isCollapsed, player
           setBindKeyText={setPassiveAbilityKey2}
           quickCast={passiveAbilityQuickCast2}
           setQuickCast={setPassiveAbilityQuickCast2}
+        />
+      </Panel>
+      <Panel style={{ flowChildren: 'right' }}>
+        <WardKeySettingButton
+          itemname="item_ward_observer"
+          abilityname="ability_ward_observer_slot"
+          bindKeyText={wardObserverKey}
+          setBindKeyText={setWardObserverKey}
+          quickCast={wardObserverQuickCast}
+          setQuickCast={setWardObserverQuickCast}
+        />
+        <WardKeySettingButton
+          itemname="item_ward_sentry"
+          abilityname="ability_ward_sentry_slot"
+          bindKeyText={wardSentryKey}
+          setBindKeyText={setWardSentryKey}
+          quickCast={wardSentryQuickCast}
+          setQuickCast={setWardSentryQuickCast}
         />
       </Panel>
       <KeyBindRemember

--- a/src/panorama/react/hud_lottery/components/KeyCaptureBox.tsx
+++ b/src/panorama/react/hud_lottery/components/KeyCaptureBox.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+
+// 移除A,S（Dota默认占用）
+export const VALID_BIND_KEYS = " BCDEFGHIJKLMNOPQRTUVWXYZ0123456789`-=[]\\;',./";
+
+interface KeyCaptureBoxProps {
+  bindKeyText: string;
+  setBindKeyText: (key: string) => void;
+  className?: string;
+  style?: Partial<VCSSStyleDeclaration>;
+  textStyle?: Partial<VCSSStyleDeclaration>;
+}
+
+/**
+ * 点击激活单字符按键输入，校验通过后回写 bindKeyText。
+ * 供 KeySettingButton（技能改键）与 WardKeySettingButton（Ward 改键）共用。
+ */
+const KeyCaptureBox = ({
+  bindKeyText,
+  setBindKeyText,
+  className = 'BindingContainer',
+  style,
+  textStyle,
+}: KeyCaptureBoxProps): React.ReactElement => {
+  const [isActive, setIsActive] = useState(false);
+
+  const activeKeySetting = (e: Panel) => {
+    $.DispatchEvent('DOTAHideTextTooltip');
+    if (isActive) {
+      return;
+    }
+    setIsActive(true);
+
+    const textEntry = e.FindChildTraverse('keyBindTextEntry') as TextEntry | null;
+    if (textEntry) {
+      textEntry.text = '';
+      textEntry.SetFocus();
+    }
+  };
+
+  const onTextEntryChange = (textEntry: TextEntry) => {
+    const key = textEntry.text.toUpperCase();
+    if (key === '') {
+      return;
+    }
+    if (VALID_BIND_KEYS.indexOf(key) === -1) {
+      textEntry.text = '';
+      $.DispatchEvent('DOTAShowTextTooltip', textEntry, $.Localize('#key_bind_input_err'));
+      $.Schedule(2, () => {
+        $.DispatchEvent('DOTAHideTextTooltip');
+      });
+    } else {
+      setBindKeyText(key);
+      setIsActive(false);
+    }
+  };
+
+  return (
+    <Panel
+      className={className}
+      style={style}
+      onmouseactivate={activeKeySetting}
+      // on mouse over, show the tooltip
+      onmouseover={(e) => {
+        if (isActive) {
+          return;
+        }
+        $.DispatchEvent('DOTAShowTextTooltip', e, $.Localize('#key_bind_mouseover_tooltop'));
+      }}
+      // on mouse out, hide the tooltip
+      onmouseout={() => {
+        $.DispatchEvent('DOTAHideTextTooltip');
+      }}
+    >
+      <Label
+        style={{ visibility: isActive ? 'collapse' : 'visible', ...textStyle }}
+        className="BindingText"
+        text={bindKeyText}
+      />
+      <TextEntry
+        id="keyBindTextEntry"
+        style={{ visibility: isActive ? 'visible' : 'collapse' }}
+        className={`TextEntryArea ${isActive ? 'Actived' : ''}`}
+        placeholder={$.Localize('#key_bind_placeholder')}
+        maxchars={1}
+        ontextentrychange={onTextEntryChange}
+      />
+    </Panel>
+  );
+};
+
+export default KeyCaptureBox;

--- a/src/panorama/react/hud_lottery/components/KeySettingButton.tsx
+++ b/src/panorama/react/hud_lottery/components/KeySettingButton.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { bindAbilityKey } from '../hotkey';
+import KeyCaptureBox from './KeyCaptureBox';
 
 interface KeySettingButtonProps {
   abilityname?: string;
@@ -23,41 +24,6 @@ const KeySettingButton = ({
   quickCast,
   setQuickCast,
 }: KeySettingButtonProps): React.ReactElement => {
-  const [isActive, setIsActive] = useState(false);
-  // 移除A,S
-  const validKeys = " BCDEFGHIJKLMNOPQRTUVWXYZ0123456789`-=[]\\;',./";
-
-  const activeKeySetting = (e: Panel) => {
-    $.DispatchEvent('DOTAHideTextTooltip');
-    if (isActive) {
-      return;
-    }
-    setIsActive(true);
-
-    const textEntry = e.FindChildTraverse('keyBindTextEntry') as TextEntry | null;
-    if (textEntry) {
-      textEntry.text = '';
-      textEntry.SetFocus();
-    }
-  };
-
-  const onTextEntryChange = (textEntry: TextEntry) => {
-    const key = textEntry.text.toUpperCase();
-    if (key === '') {
-      return;
-    }
-    if (validKeys.indexOf(key) === -1) {
-      textEntry.text = '';
-      $.DispatchEvent('DOTAShowTextTooltip', textEntry, $.Localize('#key_bind_input_err'));
-      $.Schedule(2, () => {
-        $.DispatchEvent('DOTAHideTextTooltip');
-      });
-    } else {
-      setBindKeyText(key);
-      setIsActive(false);
-    }
-  };
-
   const onQuickCastChange = () => {
     const quickCastChanged = !quickCast;
     setQuickCast(quickCastChanged);
@@ -77,35 +43,7 @@ const KeySettingButton = ({
   return (
     <Panel style={rootPanelStyle} className="BindingRow">
       <DOTAAbilityImage abilityname={abilityname} showtooltip={true} />
-      <Panel
-        className="BindingContainer"
-        onmouseactivate={activeKeySetting}
-        // on mouse over, show the tooltip
-        onmouseover={(e) => {
-          if (isActive) {
-            return;
-          }
-          $.DispatchEvent('DOTAShowTextTooltip', e, $.Localize('#key_bind_mouseover_tooltop'));
-        }}
-        // on mouse out, hide the tooltip
-        onmouseout={() => {
-          $.DispatchEvent('DOTAHideTextTooltip');
-        }}
-      >
-        <Label
-          style={{ visibility: isActive ? 'collapse' : 'visible' }}
-          className="BindingText"
-          text={bindKeyText}
-        />
-        <TextEntry
-          id="keyBindTextEntry"
-          style={{ visibility: isActive ? 'visible' : 'collapse' }}
-          className={`TextEntryArea ${isActive ? 'Actived' : ''}`}
-          placeholder={$.Localize('#key_bind_placeholder')}
-          maxchars={1}
-          ontextentrychange={onTextEntryChange}
-        />
-      </Panel>
+      <KeyCaptureBox bindKeyText={bindKeyText} setBindKeyText={setBindKeyText} />
       <Panel
         style={{
           flowChildren: 'right',

--- a/src/panorama/react/hud_lottery/components/WardKeySettingButton.tsx
+++ b/src/panorama/react/hud_lottery/components/WardKeySettingButton.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from 'react';
+import { bindAbilityKey } from '../hotkey';
+import KeyCaptureBox from './KeyCaptureBox';
+
+interface WardKeySettingButtonProps {
+  itemname: string;
+  abilityname: string;
+  bindKeyText: string;
+  setBindKeyText: (key: string) => void;
+  quickCast: boolean;
+  setQuickCast: (value: boolean) => void;
+}
+
+const rootPanelStyle: Partial<VCSSStyleDeclaration> = {
+  width: '150px',
+  height: '32px',
+  padding: '4px 6px',
+  borderRadius: '3px',
+};
+
+const iconStyle: Partial<VCSSStyleDeclaration> = {
+  width: '28px',
+  height: '28px',
+  horizontalAlign: 'left',
+  verticalAlign: 'center',
+};
+
+const captureBoxStyle: Partial<VCSSStyleDeclaration> = {
+  width: '70px',
+  height: '28px',
+  marginTop: '0px',
+  marginLeft: '32px',
+  horizontalAlign: 'left',
+  verticalAlign: 'center',
+};
+
+const captureTextStyle: Partial<VCSSStyleDeclaration> = {
+  fontSize: '20px',
+  height: '28px',
+  padding: '0px',
+};
+
+const quickCastToggleStyle: Partial<VCSSStyleDeclaration> = {
+  horizontalAlign: 'right',
+  verticalAlign: 'center',
+};
+
+/**
+ * 真假眼额外槛位的改键设置，单行紧凑布局：图标 + 按键框 + 快速施法开关。
+ * ability_ward_observer_slot / ability_ward_sentry_slot 为 POINT 目标技能，
+ * bindAbilityKey 的 QuickCastAbility 已原生支持光标位置快速施法。
+ */
+const WardKeySettingButton = ({
+  itemname,
+  abilityname,
+  bindKeyText,
+  setBindKeyText,
+  quickCast,
+  setQuickCast,
+}: WardKeySettingButtonProps): React.ReactElement => {
+  useEffect(() => {
+    if (bindKeyText === '') {
+      return;
+    }
+    bindAbilityKey(abilityname, bindKeyText, quickCast);
+  }, [abilityname, bindKeyText, quickCast]);
+
+  return (
+    <Panel style={rootPanelStyle} className="BindingRow">
+      <DOTAItemImage itemname={itemname} showtooltip={true} style={iconStyle} />
+      <KeyCaptureBox
+        bindKeyText={bindKeyText}
+        setBindKeyText={setBindKeyText}
+        style={captureBoxStyle}
+        textStyle={captureTextStyle}
+      />
+      <Panel
+        style={quickCastToggleStyle}
+        onactivate={() => setQuickCast(!quickCast)}
+        onmouseover={(e) =>
+          $.DispatchEvent('DOTAShowTextTooltip', e, $.Localize('#key_bind_quick_cast'))
+        }
+        onmouseout={() => $.DispatchEvent('DOTAHideTextTooltip')}
+      >
+        <ToggleButton selected={quickCast} />
+      </Panel>
+    </Panel>
+  );
+};
+
+export default WardKeySettingButton;

--- a/src/panorama/react/hud_lottery/components/WardKeySettingButton.tsx
+++ b/src/panorama/react/hud_lottery/components/WardKeySettingButton.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { bindAbilityKey } from '../hotkey';
+import { bindWardSlotKey } from '../hotkey';
 import KeyCaptureBox from './KeyCaptureBox';
 
 interface WardKeySettingButtonProps {
@@ -48,7 +48,7 @@ const quickCastToggleStyle: Partial<VCSSStyleDeclaration> = {
 /**
  * 真假眼额外槛位的改键设置，单行紧凑布局：图标 + 按键框 + 快速施法开关。
  * ability_ward_observer_slot / ability_ward_sentry_slot 为 POINT 目标技能，
- * bindAbilityKey 的 QuickCastAbility 已原生支持光标位置快速施法。
+ * bindWardSlotKey 的 QuickCastAbility 已原生支持光标位置快速施法。
  */
 const WardKeySettingButton = ({
   itemname,
@@ -62,7 +62,7 @@ const WardKeySettingButton = ({
     if (bindKeyText === '') {
       return;
     }
-    bindAbilityKey(abilityname, bindKeyText, quickCast);
+    bindWardSlotKey(abilityname, bindKeyText, quickCast);
   }, [abilityname, bindKeyText, quickCast]);
 
   return (

--- a/src/panorama/react/hud_lottery/hotkey.ts
+++ b/src/panorama/react/hud_lottery/hotkey.ts
@@ -5,33 +5,57 @@ const notTargetAbilityNames = ['earthshaker_enchant_totem'];
 const unitTargetOnlyFriendlyAbilityNames = ['abyssal_underlord_firestorm'];
 
 export function bindAbilityKey(abilityname: string, key: string, isQuickCast: boolean) {
+  const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
+  const abilityID = Entities.GetAbilityByName(heroID, abilityname);
   // 绑定施法
   AddKeyBind(
     key,
+    () => executeAbilityCast(heroID, abilityID, isQuickCast),
+    () => {},
+  );
+}
+
+/**
+ * 真假眼额外槛位的改键：按键时重新获取 abilityID（绑定时技能可能尚未挂载到英雄身上，
+ * 如重新加载游戏后），且充能为 0 时表现为「物品没有反应」而非技能的「冷却中」提示。
+ */
+export function bindWardSlotKey(abilityname: string, key: string, isQuickCast: boolean) {
+  AddKeyBind(
+    key,
     () => {
-      // 每次按键时重新获取，避免绑定时技能尚未挂载到英雄身上导致 abilityID 失效（如重新加载游戏后）
       const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
       const abilityID = Entities.GetAbilityByName(heroID, abilityname);
-      if (GameUI.IsControlDown() === true) {
-        // ctrl升级
-        Abilities.AttemptToUpgrade(abilityID);
+      if (Abilities.GetCurrentAbilityCharges(abilityID) === 0) {
         return;
       }
-      if (GameUI.IsAltDown() === true) {
-        // alt切换自动施法
-        const castSuccess = castAbilityWhenAltDown(abilityID, Abilities.GetBehavior(abilityID));
-        if (castSuccess) {
-          return;
-        }
-      }
-      if (isQuickCast) {
-        QuickCastAbility(abilityID, Abilities.GetBehavior(abilityID));
-      } else {
-        Abilities.ExecuteAbility(abilityID, heroID, true);
-      }
+      executeAbilityCast(heroID, abilityID, isQuickCast);
     },
     () => {},
   );
+}
+
+function executeAbilityCast(
+  heroID: EntityIndex,
+  abilityID: AbilityEntityIndex,
+  isQuickCast: boolean,
+) {
+  if (GameUI.IsControlDown() === true) {
+    // ctrl升级
+    Abilities.AttemptToUpgrade(abilityID);
+    return;
+  }
+  if (GameUI.IsAltDown() === true) {
+    // alt切换自动施法
+    const castSuccess = castAbilityWhenAltDown(abilityID, Abilities.GetBehavior(abilityID));
+    if (castSuccess) {
+      return;
+    }
+  }
+  if (isQuickCast) {
+    QuickCastAbility(abilityID, Abilities.GetBehavior(abilityID));
+  } else {
+    Abilities.ExecuteAbility(abilityID, heroID, true);
+  }
 }
 
 function IsAbilityBehavior(behavior: DOTA_ABILITY_BEHAVIOR, judge: DOTA_ABILITY_BEHAVIOR) {

--- a/src/panorama/react/hud_lottery/hotkey.ts
+++ b/src/panorama/react/hud_lottery/hotkey.ts
@@ -5,12 +5,13 @@ const notTargetAbilityNames = ['earthshaker_enchant_totem'];
 const unitTargetOnlyFriendlyAbilityNames = ['abyssal_underlord_firestorm'];
 
 export function bindAbilityKey(abilityname: string, key: string, isQuickCast: boolean) {
-  const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
-  const abilityID = Entities.GetAbilityByName(heroID, abilityname);
   // 绑定施法
   AddKeyBind(
     key,
     () => {
+      // 每次按键时重新获取，避免绑定时技能尚未挂载到英雄身上导致 abilityID 失效（如重新加载游戏后）
+      const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
+      const abilityID = Entities.GetAbilityByName(heroID, abilityname);
       if (GameUI.IsControlDown() === true) {
         // ctrl升级
         Abilities.AttemptToUpgrade(abilityID);

--- a/src/panorama/react/hud_lottery/styles.less
+++ b/src/panorama/react/hud_lottery/styles.less
@@ -33,6 +33,7 @@
   letter-spacing: 1px;
   background-color: #141616;
   color: white;
+  border: 1px solid #3a3a3a;
   transition-property: background-color, color;
   transition-duration: 0.2s;
   transition-timing-function: ease-in-out;

--- a/src/panorama/utils/net-table-transform.ts
+++ b/src/panorama/utils/net-table-transform.ts
@@ -57,6 +57,8 @@ export const transformPlayer = createTransform<PlayerInfoDto>({
       activeAbilityQuickCast: { type: 'boolean' },
       passiveAbilityQuickCast: { type: 'boolean' },
       passiveAbilityQuickCast2: { type: 'boolean' },
+      wardObserverQuickCast: { type: 'boolean' },
+      wardSentryQuickCast: { type: 'boolean' },
     },
   },
   member: {

--- a/src/vscripts/abilities/ts_abilities/ward_slot/ability_ward_observer_slot.ts
+++ b/src/vscripts/abilities/ts_abilities/ward_slot/ability_ward_observer_slot.ts
@@ -1,10 +1,20 @@
 import { BaseAbility, registerAbility } from '../../../utils/dota_ts_adapter';
+import { isInWardNoCastZone } from './ward-no-cast-zone';
 
 /** 参考 1x6 abilities/ui/observer.lua */
 @registerAbility('ability_ward_observer_slot')
 export class AbilityWardObserverSlot extends BaseAbility {
   IsRefreshable(): boolean {
     return false;
+  }
+
+  // CastFilterResultLocation 返回 UF_FAIL_CUSTOM 时引擎才会取 GetCustomCastErrorLocation 飘字，两者须配套
+  CastFilterResultLocation(location: Vector): UnitFilterResult {
+    return isInWardNoCastZone(location) ? UnitFilterResult.FAIL_CUSTOM : UnitFilterResult.SUCCESS;
+  }
+
+  GetCustomCastErrorLocation(): string {
+    return '#dota_hud_error_ward_no_cast_zone';
   }
 
   OnSpellStart(): void {

--- a/src/vscripts/abilities/ts_abilities/ward_slot/ability_ward_sentry_slot.ts
+++ b/src/vscripts/abilities/ts_abilities/ward_slot/ability_ward_sentry_slot.ts
@@ -23,6 +23,9 @@ export class AbilityWardSentrySlot extends BaseAbility {
     );
     ward.SetControllableByPlayer(caster.GetPlayerOwnerID(), true);
     ward.SetOwner(caster);
+    // npc_dota_sentry_wards 与 observer 共用同一模型，靠 skin 1 区分外观；
+    // CreateUnitByName 不会自动应用 KV 中的 skin 字段，需手动设置
+    ward.SetSkin(1);
     ward.AddNewModifier(caster, undefined, 'modifier_item_buff_ward', { duration: lifetime });
     ward.AddNewModifier(caster, undefined, 'modifier_item_ward_true_sight', {
       duration: lifetime,

--- a/src/vscripts/abilities/ts_abilities/ward_slot/ability_ward_sentry_slot.ts
+++ b/src/vscripts/abilities/ts_abilities/ward_slot/ability_ward_sentry_slot.ts
@@ -1,10 +1,20 @@
 import { BaseAbility, registerAbility } from '../../../utils/dota_ts_adapter';
+import { isInWardNoCastZone } from './ward-no-cast-zone';
 
 /** 参考 1x6 abilities/ui/sentry.lua */
 @registerAbility('ability_ward_sentry_slot')
 export class AbilityWardSentrySlot extends BaseAbility {
   IsRefreshable(): boolean {
     return false;
+  }
+
+  // CastFilterResultLocation 返回 UF_FAIL_CUSTOM 时引擎才会取 GetCustomCastErrorLocation 飘字，两者须配套
+  CastFilterResultLocation(location: Vector): UnitFilterResult {
+    return isInWardNoCastZone(location) ? UnitFilterResult.FAIL_CUSTOM : UnitFilterResult.SUCCESS;
+  }
+
+  GetCustomCastErrorLocation(): string {
+    return '#dota_hud_error_ward_no_cast_zone';
   }
 
   OnSpellStart(): void {

--- a/src/vscripts/abilities/ts_abilities/ward_slot/ward-no-cast-zone.ts
+++ b/src/vscripts/abilities/ts_abilities/ward_slot/ward-no-cast-zone.ts
@@ -1,0 +1,9 @@
+// 上/下河道肉山坑位中心点，半径范围内禁止放置真假眼，避免肉山视野被无成本压制
+const NO_CAST_ZONE_RADIUS = 400;
+const NO_CAST_ZONE_CENTERS = [Vector(2787, -2722, 0), Vector(-3092, 2250, 0)];
+
+export function isInWardNoCastZone(location: Vector): boolean {
+  return NO_CAST_ZONE_CENTERS.some(
+    (center) => location.__sub(center).Length2D() <= NO_CAST_ZONE_RADIUS,
+  );
+}

--- a/src/vscripts/abilities/ts_abilities/ward_slot/ward-no-cast-zone.ts
+++ b/src/vscripts/abilities/ts_abilities/ward_slot/ward-no-cast-zone.ts
@@ -1,6 +1,6 @@
 // 上/下河道肉山坑位中心点，半径范围内禁止放置真假眼，避免肉山视野被无成本压制
-const NO_CAST_ZONE_RADIUS = 400;
-const NO_CAST_ZONE_CENTERS = [Vector(2787, -2722, 0), Vector(-3092, 2250, 0)];
+const NO_CAST_ZONE_RADIUS = 550;
+const NO_CAST_ZONE_CENTERS = [Vector(2756, -2708, 7), Vector(-3117, 2291, 7)];
 
 export function isInWardNoCastZone(location: Vector): boolean {
   return NO_CAST_ZONE_CENTERS.some(

--- a/src/vscripts/api/player-setting.ts
+++ b/src/vscripts/api/player-setting.ts
@@ -22,6 +22,10 @@ export class PlayerSettingApi {
       activeAbilityQuickCast: event.activeAbilityQuickCast === 1,
       passiveAbilityQuickCast: event.passiveAbilityQuickCast === 1,
       passiveAbilityQuickCast2: event.passiveAbilityQuickCast2 === 1,
+      wardObserverKey: event.wardObserverKey,
+      wardObserverQuickCast: event.wardObserverQuickCast === 1,
+      wardSentryKey: event.wardSentryKey,
+      wardSentryQuickCast: event.wardSentryQuickCast === 1,
     };
 
     ApiClient.sendWithRetry({

--- a/src/vscripts/api/player.ts
+++ b/src/vscripts/api/player.ts
@@ -22,6 +22,10 @@ export class PlayerSetting {
   activeAbilityQuickCast: boolean;
   passiveAbilityQuickCast: boolean;
   passiveAbilityQuickCast2?: boolean;
+  wardObserverKey?: string;
+  wardObserverQuickCast?: boolean;
+  wardSentryKey?: string;
+  wardSentryQuickCast?: boolean;
 }
 
 export class PlayerStatsLifetimeDto {

--- a/src/vscripts/modules/lottery/item/lottery-items.ts
+++ b/src/vscripts/modules/lottery/item/lottery-items.ts
@@ -44,6 +44,7 @@ export const itemTiers: Tier[] = [
       'item_light_part', // 圣光组件
       'item_dark_part', // 暗影组件
       'item_ultimate_scepter_2', // 真·阿哈利姆神杖
+      'item_hydras_breath', // 怪蛇之息
     ],
   },
   // 3~5k
@@ -76,6 +77,7 @@ export const itemTiers: Tier[] = [
       'item_essence_distiller', // 精之灵器
       'item_ancient_janggo', // 韧鼓
       'item_holy_locket', // 圣洁吊坠
+      'item_consecrated_wraps', // 圣化护服
     ],
   },
   // 1k


### PR DESCRIPTION
## Issue

- [x] fix #2141

## Release Note

```
[b]游戏性更新 v5.34b[/b]

- 重做真假眼位改键，支持快捷施法。并修复若干BUG。
```

```
[b]Gameplay update v5.34b[/b]

- Rework keybinds for the extra Ward Observer/Sentry slots support quick-cast. And fixed some bugs.
```
