### PR TITLE
新增属性 减速免疫

### DIFF
--- a/content/panorama/scripts/custom_game/battlepass.js
+++ b/content/panorama/scripts/custom_game/battlepass.js
@@ -231,7 +231,8 @@ function AddPlayerProperty(player, property) {
     property.name === 'property_skill_points_bonus' ||
     property.name === 'property_ignore_movespeed_limit' ||
     property.name === 'property_cannot_miss' ||
-    property.name === 'property_flying'
+    property.name === 'property_flying' ||
+    property.name === 'property_slow_immune'
   ) {
     levelupText = $.Localize(`#data_panel_player_property_level_up_X`).replace(
       'X',
@@ -380,6 +381,7 @@ const Player_Propertys_Show_Tooltip_1 = [
   'property_ignore_movespeed_limit',
   'property_cannot_miss',
   'property_flying',
+  'property_slow_immune',
 ];
 
 const Player_Propertys_Show_Tooltip_2 = ['property_skill_points_bonus'];
@@ -563,6 +565,14 @@ const Player_Property_List = [
     name: 'property_flying',
     level: 0,
     imageSrc: 's2r://panorama/images/cavern/icon_cc_wings_png.vtex',
+    valuePerLevel: 0.125,
+    pointCostPerLevel: 8,
+    enableMaxLevelUpgrade: false,
+  },
+  {
+    name: 'property_slow_immune',
+    level: 0,
+    imageSrc: 's2r://panorama/images/cavern/icon_winged_boots_png.vtex',
     valuePerLevel: 0.125,
     pointCostPerLevel: 8,
     enableMaxLevelUpgrade: false,

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -200,6 +200,7 @@
 		"data_panel_player_property_ignore_movespeed_limit"		"Unlimited Movement Speed"
 		"data_panel_player_property_cannot_miss"				"True Strike"
 		"data_panel_player_property_flying"						"Flying Status"
+		"data_panel_player_property_slow_immune"				"Slow Immunity"
 		"data_panel_player_property_skill_points_bonus"			"Bonus Skill Points"
 		"data_panel_player_property_bonus_vision"				"Bonus Vision"
 

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -200,6 +200,7 @@
 		"data_panel_player_property_ignore_movespeed_limit"		"无视移速上限"
 		"data_panel_player_property_cannot_miss"				"克敌机先"
 		"data_panel_player_property_flying"						"飞行状态"
+		"data_panel_player_property_slow_immune"				"减速免疫"
 		"data_panel_player_property_skill_points_bonus"			"额外技能点"
 		"data_panel_player_property_bonus_vision"				"额外视野"
 

--- a/src/vscripts/modifiers/property/property_declare.ts
+++ b/src/vscripts/modifiers/property/property_declare.ts
@@ -240,6 +240,15 @@ export class property_cannot_miss extends PropertyBaseModifier {
 }
 
 @registerModifier('modifiers/property/property_declare')
+export class property_slow_immune extends PropertyBaseModifier {
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.UNSLOWABLE]: true,
+    };
+  }
+}
+
+@registerModifier('modifiers/property/property_declare')
 export class property_flying extends PropertyBaseModifier {
   CheckState(): Partial<Record<ModifierState, boolean>> {
     return {

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.34';
+  public static readonly GAME_VERSION = 'v5.35';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数

--- a/src/vscripts/modules/property/property_controller.ts
+++ b/src/vscripts/modules/property/property_controller.ts
@@ -17,6 +17,7 @@ import {
   property_movespeed_bonus_constant,
   property_physical_armor_bonus,
   property_preattack_bonus_damage,
+  property_slow_immune,
   property_spell_amplify_percentage,
   property_spell_lifesteal,
   property_stats_agility_bonus,
@@ -63,6 +64,7 @@ export class PropertyController {
     PropertyController.propertyLuaModiferMap.set(property_health_regen_percentage.name, 0.3);
     PropertyController.propertyLuaModiferMap.set(property_mana_regen_total_percentage.name, 0.3);
     PropertyController.propertyLuaModiferMap.set(property_ignore_movespeed_limit.name, 0.125);
+    PropertyController.propertyLuaModiferMap.set(property_slow_immune.name, 0.125);
 
     // data driven modifier
     // 多档属性名须以 '_level_' 结尾；单档则为完整 modifier 名


### PR DESCRIPTION
## Issue

Closes #1786

## Changes

新增玩家属性「减速免疫」(`property_slow_immune`)，采用 Lua `CheckState` → `MODIFIER_STATE_UNSLOWABLE` 实现(同圣女白莲)
，单档二值，8 属性点激活。

- VScripts: 新增 `property_slow_immune` modifier 类 + controller 注册
- Panorama: battlepass.js 新增属性条目(icon_winged_boots, pointCostPerLevel=8)
- 本地化: 中英文标签同步

## Backend

需协同合并 windy10v10ai/firebase#949 (PROPERTY_NAME_LIST 加白名单)

## Release Note

```
- 新增属性:减速免疫
- New property: Slow Immunity
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
