### PR TITLE
Property page usable/total points and awaken auto-cast channel fix

### DIFF
--- a/content/panorama/layout/custom_game/battlepass.xml
+++ b/content/panorama/layout/custom_game/battlepass.xml
@@ -76,13 +76,11 @@
 			<!-- 顶部积分 -->
 			<Panel id="PlayerPointStats">
 				<Panel id="SeasonPointContainer" class="pointParent">
-					<Image id="SeasonPointImage" class="pointIcon" src="s2r://panorama/images/custom_game/battlepass/pts_earned_png.vtex"
-						onmouseover="UIShowTextTooltipStyled( #data_panel_season_point_total, ShortTextTooltip )" onmouseout="UIHideTextTooltip()"/>
+					<Image id="SeasonPointImage" class="pointIcon" src="s2r://panorama/images/custom_game/battlepass/pts_earned_png.vtex"/>
 					<Label id="SeasonPoint" class="pointNumber" text="18888" />
 				</Panel>
 				<Panel id="MemberPointContainer" class="pointParent">
-					<Image id="MemberPointImage" class="pointIcon" src="s2r://panorama/images/custom_game/battlepass/charge_point_png.vtex"
-						onmouseover="UIShowTextTooltipStyled( #data_panel_member_point_total, ShortTextTooltip )" onmouseout="UIHideTextTooltip()"/>
+					<Image id="MemberPointImage" class="pointIcon" src="s2r://panorama/images/custom_game/battlepass/charge_point_png.vtex"/>
 					<Label id="MemberPoint" class="pointNumber" text="18888" />
 				</Panel>
 				<Panel id="PropertyPointContainer" class="pointParent">
@@ -165,10 +163,10 @@
 					<Panel id="PropertyListContainer" class="SubContainer" />
 					<Panel id="PropertyResetContainer" class="SubContainer">
 						<Button id="ResetUseSeasonPoint" class="LinkButton">
-							<Label id="ResetUseSeasonPointText" class="ButtonText" text="#reset_property_use_season_point" />
+							<Label id="ResetUseSeasonPointText" class="ButtonText" html="true" text="#reset_property_use_season_point" />
 						</Button>
 						<Button id="ResetUseMemberPoint" class="LinkButton">
-							<Label id="ResetUseMemberPointText" class="ButtonText" text="#reset_property_use_member_point" />
+							<Label id="ResetUseMemberPointText" class="ButtonText" html="true" text="#reset_property_use_member_point" />
 						</Button>
 					</Panel>
 				</Panel>

--- a/content/panorama/scripts/custom_game/battlepass.js
+++ b/content/panorama/scripts/custom_game/battlepass.js
@@ -130,6 +130,33 @@ function SetTopStatus(player) {
   $('#MemberPoint').text = player.memberPointTotal;
   $('#SeasonPoint').text = player.seasonPointTotal;
   $('#PropertyPoint').text = `${player.useableLevel} / ${player.totalLevel}`;
+
+  // 顶部 pill 只显总额，可用积分放进 hover tooltip
+  SetPointTooltip(
+    '#SeasonPointContainer',
+    '#data_panel_season_point_tooltip',
+    player.useableSeasonPoint,
+    player.seasonPointTotal,
+  );
+  SetPointTooltip(
+    '#MemberPointContainer',
+    '#data_panel_member_point_tooltip',
+    player.useableMemberPoint,
+    player.memberPointTotal,
+  );
+}
+
+function SetPointTooltip(panelId, locKey, useable, total) {
+  const panel = $(panelId);
+  const text = $.Localize(locKey)
+    .replace('{useable}', useable)
+    .replace('{total}', total);
+  panel.SetPanelEvent('onmouseover', () => {
+    $.DispatchEvent('DOTAShowTextTooltip', panel, text);
+  });
+  panel.SetPanelEvent('onmouseout', () => {
+    $.DispatchEvent('DOTAHideTextTooltip');
+  });
 }
 
 // 属性
@@ -154,7 +181,7 @@ function SetResetPropertyButton(player) {
   const resetUseSeasonPointButton = $('#ResetUseSeasonPoint');
   const text = $.Localize(`#reset_property_use_season_point`);
   $('#ResetUseSeasonPointText').text = text.replace('{seasonPoint}', player.seasonNextLevelPoint);
-  if (player.seasonPointTotal >= player.seasonNextLevelPoint) {
+  if (player.useableSeasonPoint >= player.seasonNextLevelPoint) {
     resetUseSeasonPointButton.SetHasClass('deactivated', false);
     resetUseSeasonPointButton.SetHasClass('activated', true);
     resetUseSeasonPointButton.SetPanelEvent('onactivate', () => {
@@ -168,7 +195,7 @@ function SetResetPropertyButton(player) {
 
   // 会员积分重置
   const resetUseMemberPointButton = $('#ResetUseMemberPoint');
-  if (player.memberPointTotal >= 1000) {
+  if (player.useableMemberPoint >= 1000) {
     resetUseMemberPointButton.SetHasClass('deactivated', false);
     resetUseMemberPointButton.SetHasClass('activated-gold', true);
     resetUseMemberPointButton.SetPanelEvent('onactivate', () => {

--- a/content/panorama/styles/custom_game/battlepass.css
+++ b/content/panorama/styles/custom_game/battlepass.css
@@ -340,12 +340,13 @@ TextEntry.MonoFont {
 }
 
 .LinkButton {
-  width: 60%;
-  height: 40px;
+  width: 65%;
+  height: fit-children;
+  padding: 6px 10px;
   vertical-align: center;
   horizontal-align: center;
-  margin: 20px;
-  /* 文字自动换行 */
+  margin: 10px;
+  /* 文字自动换行，按钮高度随行数自适应 */
   white-space: normal;
 }
 
@@ -499,6 +500,7 @@ TextEntry.MonoFont {
 }
 
 .ButtonText {
+  width: 100%;
   color: white;
   vertical-align: center;
   horizontal-align: center;
@@ -507,6 +509,7 @@ TextEntry.MonoFont {
   letter-spacing: 0px;
   font-size: 16px;
   text-shadow: 1px 1px 3px 3 black;
+  white-space: normal;
 }
 
 #BpPropertiesButtons {

--- a/content/panorama/styles/custom_game/battlepass.css
+++ b/content/panorama/styles/custom_game/battlepass.css
@@ -340,7 +340,7 @@ TextEntry.MonoFont {
 }
 
 .LinkButton {
-  width: 65%;
+  width: 78%;
   height: fit-children;
   padding: 6px 10px;
   vertical-align: center;

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -156,6 +156,8 @@
 		"data_panel_member_point"		"Member Points (Usable/Total)"
 		"data_panel_season_point"		"Battle Points (Usable/Total)"
 		"data_panel_property_point"		"Attribute Points (Usable/Total)"
+		"data_panel_season_point_tooltip"	"Battle Points (Usable/Total: {useable}/{total})"
+		"data_panel_member_point_tooltip"	"Member Points (Usable/Total: {useable}/{total})"
 
 		"data_panel_data_button"		"Data"
 		"data_panel_property_button"	"Attributes"
@@ -170,8 +172,8 @@
 		"data_panel_link_rule"			"Points and Attribute Rule"
 		"data_panel_member_point_rule_url"		"https://ko-fi.com/post/Points-and-Attribute-Rules-S6S01CTP83"
 
-		"reset_property_use_season_point"		"Reset Attribute Points for {seasonPoint} Battle Points"
-		"reset_property_use_member_point"		"Reset Attribute Points for 1000 Member Points"
+		"reset_property_use_season_point"		"Reset Attribute Points for {seasonPoint} usable Battle Points<br>(level unaffected)"
+		"reset_property_use_member_point"		"Reset Attribute Points for 1000 usable Member Points<br>(level unaffected)"
 
 		"data_panel_player_property_label"		"Spend Attribute Points to upgrade your hero. Upgrades are permanent and persist between games."
 		"data_panel_player_property_label_2"		"Points cannot be spent on locally hosted games. Please play on a dedicated server to spend points."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -172,8 +172,8 @@
 		"data_panel_link_rule"			"Points and Attribute Rule"
 		"data_panel_member_point_rule_url"		"https://ko-fi.com/post/Points-and-Attribute-Rules-S6S01CTP83"
 
-		"reset_property_use_season_point"		"Reset Attribute Points for {seasonPoint} usable Battle Points<br>(level unaffected)"
-		"reset_property_use_member_point"		"Reset Attribute Points for 1000 usable Member Points<br>(level unaffected)"
+		"reset_property_use_season_point"		"Reset for {seasonPoint} usable Battle Points<br>(level unaffected)"
+		"reset_property_use_member_point"		"Reset for 1000 usable Member Points<br>(level unaffected)"
 
 		"data_panel_player_property_label"		"Spend Attribute Points to upgrade your hero. Upgrades are permanent and persist between games."
 		"data_panel_player_property_label_2"		"Points cannot be spent on locally hosted games. Please play on a dedicated server to spend points."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -114,6 +114,8 @@
 		///////////////////////////////////////////////////
 		"data_panel_button"				"Меню"
 		"data_panel_property_point"		"Attribute Points (Доступно/Всего)"
+		"data_panel_season_point_tooltip"	"Battle Experience (Доступно/Всего: {useable}/{total})"
+		"data_panel_member_point_tooltip"	"Member Experience (Доступно/Всего: {useable}/{total})"
 
 		"data_panel_data_button"		"Инфо"
 		"data_panel_property_button"	"Атрибуты"
@@ -127,8 +129,8 @@
 		"data_panel_level_progress"		"Уровень"
 		"data_panel_link_rule"			"Правила опыта и атрибутов"
 
-		"reset_property_use_season_point"		"Сбросить Attribute Points за {seasonPoint} Battle Experience"
-		"reset_property_use_member_point"		"Сбросить Attribute Points за 1000 Member Experience"
+		"reset_property_use_season_point"		"Сбросить Attribute Points за {seasonPoint} Battle Experience<br>(уровень не снизится)"
+		"reset_property_use_member_point"		"Сбросить Attribute Points за 1000 Member Experience<br>(уровень не снизится)"
 
 		"data_panel_player_property_label"		"Тратьте Attribute Points для улучшения героя — улучшения постоянные и сохраняются из игры в игру."
 		"data_panel_player_property_label_2"		"Очки нельзя тратить на локальном сервере — играйте на выделенном сервере от Valve, чтобы использовать и получать бонусы от улучшений."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -129,8 +129,8 @@
 		"data_panel_level_progress"		"Уровень"
 		"data_panel_link_rule"			"Правила опыта и атрибутов"
 
-		"reset_property_use_season_point"		"Сбросить Attribute Points за {seasonPoint} Battle Experience<br>(уровень не снизится)"
-		"reset_property_use_member_point"		"Сбросить Attribute Points за 1000 Member Experience<br>(уровень не снизится)"
+		"reset_property_use_season_point"		"Сбросить за {seasonPoint} Battle Experience<br>(уровень не снизится)"
+		"reset_property_use_member_point"		"Сбросить за 1000 Member Experience<br>(уровень не снизится)"
 
 		"data_panel_player_property_label"		"Тратьте Attribute Points для улучшения героя — улучшения постоянные и сохраняются из игры в игру."
 		"data_panel_player_property_label_2"		"Очки нельзя тратить на локальном сервере — играйте на выделенном сервере от Valve, чтобы использовать и получать бонусы от улучшений."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -156,6 +156,8 @@
 		"data_panel_member_point"		"会员积分 (可用/总数)"
 		"data_panel_season_point"		"勇士积分 (可用/总数)"
 		"data_panel_property_point"		"属性点 (可用/总数)"
+		"data_panel_season_point_tooltip"	"勇士积分（可用/总分：{useable}/{total}）"
+		"data_panel_member_point_tooltip"	"会员积分（可用/总分：{useable}/{total}）"
 
 		"data_panel_data_button"		"数据"
 		"data_panel_property_button"	"属性"
@@ -170,8 +172,8 @@
 		"data_panel_link_rule"			"经验属性规则说明"
 		"data_panel_member_point_rule_url"		"https://ifdian.net/p/24140a48680511ed9d3852540025c377"
 
-		"reset_property_use_season_point"		"消耗{seasonPoint}勇士积分重置"
-		"reset_property_use_member_point"		"消耗1000会员积分重置"
+		"reset_property_use_season_point"		"消耗{seasonPoint}可用勇士积分重置<br>(不会降低等级)"
+		"reset_property_use_member_point"		"消耗1000可用会员积分重置<br>(不会降低等级)"
 
 		"data_panel_player_property_label"		"使用属性点增强英雄，升级后属性及时生效。"
 		"data_panel_player_property_label_2"		"本地主机无法加点，请使用服务器主机进行游戏。"

--- a/src/vscripts/abilities/ts_abilities/shared/auto-cast-ability.ts
+++ b/src/vscripts/abilities/ts_abilities/shared/auto-cast-ability.ts
@@ -41,6 +41,8 @@ export class modifier_autocast_think extends BaseModifier {
     if (!IsServer()) return;
     const caster = this.GetParent();
     if (!caster.IsAlive()) return;
+    // 玩家正在持续释放（TP 等）时不抢操作，避免打断
+    if (caster.IsChanneling()) return;
     const ability = this.GetAbility() as unknown as AutoCastAbility;
     if (!ability.GetAutoCastState()) return;
     ability.OnAutoCastThink(caster as CDOTA_BaseNPC_Hero);


### PR DESCRIPTION
## Issue

- [x] fix #2149

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.35a[/b]

- 修正宙斯、斧王觉醒自动施法会打断传送等引导技能的问题。
- 属性页面积分悬停显示可用/总积分，重置属性改为消耗可用积分且不会降低等级。
```

```
[b]Gameplay update v5.35a[/b]

- Fixed Zeus and Axe awakened auto-cast interrupting channeling abilities like Teleport.
- Property page now shows usable/total points on hover, and attribute reset spends usable points without lowering your level.
```
