### PR TITLE
Add Drow Ranger awakened Splinter Shot

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -279,6 +279,7 @@ GameEvents.SendCustomGameEventToAllClients('hud_open_page', { page: 'home', play
 - **新建 Net Table 必须双注册**: 在 `src/common/net_tables.d.ts` 的 `CustomNetTableDeclarations` 加类型只是 TS 契约，引擎运行时还要在 `game/scripts/custom_net_tables.txt` 注册表名，否则服务端 `SetTableValue` 会报 `Unknown custom nettable` 且客户端永远收不到。改完后必须**重启 Dota Tools**（script_reload 不重读 KV）
 - **Net Table 清行不能传 nil**: `CustomNetTables.SetTableValue(table, key, nil)` 在 Dota 引擎下是 **noop**，不会删除或同步空值给客户端。如需清行，传**空 table**（数组类用 `[]`、对象类用 `{}`），客户端 `Object.values(value).length === 0` 即可识别为空
 - **React Panorama 条件返回不同 panel 结构会渲染失败**: 在 React 组件中根据状态返回**完全不同的 JSX 结构**（例如 `if (empty) return <Panel collapse />; return <Panel>...复杂子树...</Panel>;`）会导致 panel 在 Panorama DOM 中始终缺失。改为**始终渲染同一 panel 树**，用 `style={{ visibility: cond ? 'visible' : 'collapse' }}` 切换显隐
+- **不吃技能增强须显式标 flag，不靠物理类型**: 自定义技能用 `ApplyDamage` 造成物理伤害时，**不要**依赖「物理类型隐式不吃 spell amp」这条经验来确保不被技能增强放大。引擎判定是否吃技能增强的真正开关是伤害标志位，要明确排除时显式加 `damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION`（本项目技能增强是自定义属性 `property_spell_amplify_percentage` 实现，更不应靠隐式行为）
 
 ### 图片资源管理
 

--- a/.claude/skills/awaken-ability/SKILL.md
+++ b/.claude/skills/awaken-ability/SKILL.md
@@ -58,14 +58,14 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
   "special_bonus_unique_xxx_upgrade"
   {
       "BaseClass"             "ability_lua"
-      "ScriptFile"            "abilities/special_bonus_unique_xxx_upgrade"
+      "ScriptFile"            "abilities/ts_abilities/special_bonus_unique_xxx_upgrade"
       "AbilityTextureName"    "xxx_some_icon"
       "MaxLevel"              "5"
       "AbilityValues" { ... }
   }
   ```
 
-- **`ScriptFile` 实现** → 纯 Lua 放 `game/scripts/vscripts/abilities/<name>.lua`（`class({})` + `LinkLuaModifier`，不经 TSTL）；TSTL 写法放 `src/vscripts/abilities/`。被动觉醒标准写法：`GetIntrinsicModifierName()` 返回一个隐藏内置 modifier，无需学习即生效，所有可调值从 KV `AbilityValues` 读取。
+- **`ScriptFile` 实现选型** → 与 `custom-ability` skill 同一优先级：① 含被动属性加成（攻速/护甲/移速/属性…）走 **DataDriven**（KV `Modifiers`→`Properties`，引擎原生求值最省，允许其中 `RunScript` 调少量 Lua 补动态值）→ ② 逻辑技能走 **TS（TSTL）**，源码放 `src/vscripts/abilities/`，KV `ScriptFile` 指向编译产物 `abilities/ts_abilities/<name>`（`@registerAbility`/`@registerModifier`，参考斧王 `axe_auto_culling_blade`、宙斯 `special_bonus_unique_zuus_upgrade`）→ ③ **纯 Lua 仅用于维护已有技能，不从零新写**。被动觉醒标准写法：`GetIntrinsicModifierName()` 返回一个隐藏内置 modifier，无需学习即生效，所有可调值从 KV `AbilityValues` 读取。
 
 - **图标** → 引用 Dota2 原版技能名则不放 png；自定义图标才复制同名 png 到 `game/resource/flash3/images/spellicons/<name>.png`。`AbilityTextureName` 也可直接填**至宝/变体 texture 路径**（如 `necrolyte/apostle_of_decay_icons/necrolyte_heartstopper_aura`、`drow_ranger/immortal/drow_ranger_wave_of_silence`、`zuus_static_field_alt1`），引擎直接引用，同样无需放 png。
 

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1140,6 +1140,11 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>Requiem of Souls Guard Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade_Description"		"During Requiem of Souls' cast animation, Shadow Fiend gains <font color='#FFCC66'>magic immunity</font>, preventing his cast from being interrupted by disables.<br><br>Necromastery grants 10 souls per hero kill and 3 souls per unit kill."
 
+		// Drow Ranger Splinter Shot
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>Splinter Shot Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"Attacks have a chance to splinter into arrows that fly at up to %splinter_targets% enemies around the primary target, each dealing %splinter_damage_pct%%% of the attack's damage as physical damage and applying Frost Arrows' slow."
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_splinter_chance"	"%Proc Chance:"
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1138,6 +1138,11 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>魂之挽歌护体 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade_Description"		"释放魂之挽歌的施法前摇期间，影魔获得<font color='#FFCC66'>魔法免疫</font>，避免被控制打断。<br><br>支配死灵击杀英雄获得10个灵魂，击杀小兵获得3个灵魂。"
 
+		// 卓尔游侠 裂影箭
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>裂影箭 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"普攻有概率分裂出箭矢，射向主目标周围最多%splinter_targets%名敌人，每支造成本次攻击伤害%splinter_damage_pct%%%的物理伤害，并附带霜冻之箭的减速效果。"
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_splinter_chance"	"%触发概率："
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能
@@ -2507,7 +2512,7 @@
 
 		// 觉醒石
 		"DOTA_Tooltip_ability_item_awaken_stone"						"觉醒石"
-		"DOTA_Tooltip_ability_item_awaken_stone_Description"			"<h1>使用: 觉醒</h1> 唤醒英雄沉睡的力量，将一个技能蜕变为觉醒形态。\n<h1>支持的英雄</h1>屠夫、剑圣、狙击手、斧王、死灵法师、宙斯、幻影刺客、巫医、影魔\n可以分享给队友\n不可购买出售，藏宝箱有概率出现"
+		"DOTA_Tooltip_ability_item_awaken_stone_Description"			"<h1>使用: 觉醒</h1> 唤醒英雄沉睡的力量，将一个技能蜕变为觉醒形态。\n<h1>支持的英雄</h1>屠夫、剑圣、狙击手、斧王、死灵法师、宙斯、幻影刺客、巫医、影魔、卓尔游侠\n可以分享给队友\n不可购买出售，藏宝箱有概率出现"
 		"DOTA_Tooltip_ability_item_awaken_stone_Lore"					"一块能唤醒沉睡之力的石头。"
 
 		// 被动技能书

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -398,4 +398,40 @@
 			"invulnerability_duration"	"1.67"
 		}
 	}
+
+	// 卓尔游侠 裂影箭-觉醒
+	// 新增被动：普攻有概率分裂出数支箭射向主目标周围的敌人，造成本次攻击伤害的百分比并附带霜冻箭减速
+	// 技能名同时作 special_bonus key 挂回 marksmanship，使精准箭触发概率提升（见 override 联动）
+	"special_bonus_unique_drow_ranger_upgrade"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"					"ABILITY_TYPE_ULTIMATE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_NO"
+		"AbilityTextureName"			"drow_ranger_multishot_arcana"
+		"MaxLevel"						"4"
+		"LinkedAbility"					"drow_ranger_marksmanship"	// 与大招射手天赋双向联动同步升级
+
+		"precache"
+		{
+			"particle"		"particles/units/heroes/hero_drow/drow_marksmanship_attack.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_drow.vsndevts"
+		}
+
+		"AbilityValues"
+		{
+			"splinter_chance"
+			{
+				"value"										"30 35 40 45"	// 与射手天赋同概率
+				"special_bonus_unique_drow_ranger_3"		"+13"			// 同吃射手天赋的概率天赋
+			}
+			"splinter_targets"			"2"
+			"splinter_radius"			"500"
+			"splinter_damage_pct"		"40"
+			"slow_duration"				"1.5"
+			"projectile_speed"			"1250"
+		}
+	}
 }

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -5100,6 +5100,7 @@
 	"drow_ranger_marksmanship"
 	{
 		"MaxLevel" "4"
+		"LinkedAbility"	"special_bonus_unique_drow_ranger_upgrade"	// 与觉醒裂影箭双向联动同步升级
 		"AbilityValues"
 		{
 			"chance"

--- a/src/vscripts/abilities/ts_abilities/axe_auto_culling_blade.ts
+++ b/src/vscripts/abilities/ts_abilities/axe_auto_culling_blade.ts
@@ -9,9 +9,23 @@ import {
 /** 斧王 自动淘汰之刃-觉醒：autocast 开启、淘汰之刃就绪时，自动斩杀血量低于阈值的敌方英雄（施放原版淘汰之刃，击杀/收获护甲交给原版）。 */
 @registerAbility('axe_auto_culling_blade')
 export class AxeAutoCullingBlade extends AutoCastAbility {
+  // 上一 tick 斩杀的目标，下一 tick 校验是否漏斩
+  private pendingTarget?: CDOTA_BaseNPC;
+
   OnAutoCastThink(caster: CDOTA_BaseNPC_Hero): void {
     const culling = caster.FindAbilityByName('axe_culling_blade');
-    if (!culling || !culling.IsFullyCastable()) return;
+    if (!culling) return;
+
+    // 漏斩兜底：上次斩杀的目标若仍存活（前摇窗口内血量回升等），强制清 CD 重施一次补刀
+    const pending = this.pendingTarget;
+    this.pendingTarget = undefined;
+    if (pending && !pending.IsNull() && pending.IsAlive()) {
+      culling.EndCooldown();
+      castImmediatelyOnTarget(caster, culling, pending);
+      return;
+    }
+
+    if (!culling.IsFullyCastable()) return;
 
     // 淘汰之刃可对魔免单位施放
     const enemies = findEnemiesInRange(
@@ -27,6 +41,7 @@ export class AxeAutoCullingBlade extends AutoCastAbility {
     for (const enemy of enemies) {
       if (!enemy.IsNull() && enemy.IsAlive() && enemy.GetHealth() <= threshold) {
         castImmediatelyOnTarget(caster, culling, enemy);
+        this.pendingTarget = enemy;
         return;
       }
     }

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade.ts
@@ -59,16 +59,14 @@ export class modifier_special_bonus_unique_drow_ranger_upgrade extends BaseModif
     if (damage <= 0) return;
 
     const maxTargets = ability.GetSpecialValueFor('splinter_targets');
-    const radius = ability.GetSpecialValueFor('splinter_radius');
     const projectileSpeed = ability.GetSpecialValueFor('projectile_speed');
     const slowDuration = ability.GetSpecialValueFor('slow_duration');
     const frostArrows = parent.FindAbilityByName('drow_ranger_frost_arrows');
-
     const enemies = FindUnitsInRadius(
       parent.GetTeamNumber(),
       target.GetAbsOrigin(),
       undefined,
-      radius,
+      ability.GetSpecialValueFor('splinter_radius'),
       UnitTargetTeam.ENEMY,
       UnitTargetType.HERO + UnitTargetType.BASIC,
       UnitTargetFlags.NONE,
@@ -79,34 +77,44 @@ export class modifier_special_bonus_unique_drow_ranger_upgrade extends BaseModif
     let hit = 0;
     for (const enemy of enemies) {
       if (enemy === target || enemy.IsNull() || !enemy.IsAlive()) continue;
-
-      ProjectileManager.CreateTrackingProjectile({
-        Target: enemy,
-        Source: parent,
-        Ability: ability,
-        EffectName: 'particles/units/heroes/hero_drow/drow_marksmanship_attack.vpcf',
-        iMoveSpeed: projectileSpeed,
-        bDodgeable: false,
-      });
-
-      ApplyDamage({
-        victim: enemy,
-        attacker: parent,
-        damage,
-        damage_type: DamageTypes.PHYSICAL,
-        damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION,
-        ability,
-      });
-
-      // 复用霜冻箭减速，随其等级强弱
-      if (frostArrows && frostArrows.GetLevel() > 0) {
-        enemy.AddNewModifier(parent, frostArrows, 'modifier_drow_ranger_frost_arrows_slow', {
-          duration: slowDuration,
-        });
-      }
-
+      this.fireSplinter(parent, ability, enemy, damage, projectileSpeed, slowDuration, frostArrows);
       hit += 1;
       if (hit >= maxTargets) break;
+    }
+  }
+
+  // 对单个敌人射出一支分裂箭：弹道 + 物理伤害（不吃技能增强）+ 霜冻减速
+  private fireSplinter(
+    parent: CDOTA_BaseNPC,
+    ability: CDOTABaseAbility,
+    enemy: CDOTA_BaseNPC,
+    damage: number,
+    projectileSpeed: number,
+    slowDuration: number,
+    frostArrows?: CDOTABaseAbility,
+  ): void {
+    ProjectileManager.CreateTrackingProjectile({
+      Target: enemy,
+      Source: parent,
+      Ability: ability,
+      EffectName: 'particles/units/heroes/hero_drow/drow_marksmanship_attack.vpcf',
+      iMoveSpeed: projectileSpeed,
+      bDodgeable: false,
+    });
+
+    ApplyDamage({
+      victim: enemy,
+      attacker: parent,
+      damage,
+      damage_type: DamageTypes.PHYSICAL,
+      damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION,
+      ability,
+    });
+
+    if (frostArrows && frostArrows.GetLevel() > 0) {
+      enemy.AddNewModifier(parent, frostArrows, 'modifier_drow_ranger_frost_arrows_slow', {
+        duration: slowDuration,
+      });
     }
   }
 }

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade.ts
@@ -1,0 +1,112 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+/**
+ * 卓尔游侠 裂影箭-觉醒：普攻有概率分裂出箭矢射向主目标周围的敌人，
+ * 各造成本次攻击伤害的百分比并附带霜冻之箭减速。还原老版精准箭分裂手感。
+ */
+@registerAbility('special_bonus_unique_drow_ranger_upgrade')
+export class SpecialBonusUniqueDrowRangerUpgrade extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return 'modifier_special_bonus_unique_drow_ranger_upgrade';
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_drow_ranger_upgrade extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_ATTACK];
+  }
+
+  // 抬手射出即触发（不等主箭命中），分裂箭与主箭同时飞出
+  OnAttack(event: ModifierAttackEvent): void {
+    if (!IsServer()) return;
+    const parent = this.GetParent();
+    if (event.attacker !== parent || parent.IsIllusion()) return;
+
+    const target = event.target;
+    if (!target || target.IsNull() || !target.IsAlive()) return;
+    if (target.GetTeamNumber() === parent.GetTeamNumber()) return;
+
+    const ability = this.GetAbility();
+    if (!ability || ability.GetLevel() <= 0) return;
+    if (!RollPseudoRandomPercentage(ability.GetSpecialValueFor('splinter_chance'), 0, parent)) {
+      return;
+    }
+
+    // 抬手时本次攻击伤害尚未结算，用对该目标的平均攻击力作基数
+    const damage =
+      parent.GetAverageTrueAttackDamage(target) *
+      ability.GetSpecialValueFor('splinter_damage_pct') *
+      0.01;
+    if (damage <= 0) return;
+
+    const maxTargets = ability.GetSpecialValueFor('splinter_targets');
+    const radius = ability.GetSpecialValueFor('splinter_radius');
+    const projectileSpeed = ability.GetSpecialValueFor('projectile_speed');
+    const slowDuration = ability.GetSpecialValueFor('slow_duration');
+    const frostArrows = parent.FindAbilityByName('drow_ranger_frost_arrows');
+
+    const enemies = FindUnitsInRadius(
+      parent.GetTeamNumber(),
+      target.GetAbsOrigin(),
+      undefined,
+      radius,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO + UnitTargetType.BASIC,
+      UnitTargetFlags.NONE,
+      FindOrder.CLOSEST,
+      false,
+    );
+
+    let hit = 0;
+    for (const enemy of enemies) {
+      if (enemy === target || enemy.IsNull() || !enemy.IsAlive()) continue;
+
+      ProjectileManager.CreateTrackingProjectile({
+        Target: enemy,
+        Source: parent,
+        Ability: ability,
+        EffectName: 'particles/units/heroes/hero_drow/drow_marksmanship_attack.vpcf',
+        iMoveSpeed: projectileSpeed,
+        bDodgeable: false,
+      });
+
+      ApplyDamage({
+        victim: enemy,
+        attacker: parent,
+        damage,
+        damage_type: DamageTypes.PHYSICAL,
+        damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION,
+        ability,
+      });
+
+      // 复用霜冻箭减速，随其等级强弱
+      if (frostArrows && frostArrows.GetLevel() > 0) {
+        enemy.AddNewModifier(parent, frostArrows, 'modifier_drow_ranger_frost_arrows_slow', {
+          duration: slowDuration,
+        });
+      }
+
+      hit += 1;
+      if (hit >= maxTargets) break;
+    }
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -74,4 +74,11 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
     newAbility: 'special_bonus_unique_nevermore_upgrade',
     newLevel: 1,
   },
+  // 卓尔游侠 裂影箭（新增被动，与大招射手天赋 LinkedAbility 同步升级，初始等级继承大招）
+  {
+    heroName: 'npc_dota_hero_drow_ranger',
+    newAbility: 'special_bonus_unique_drow_ranger_upgrade',
+    newLevel: 0,
+    inheritLevelFrom: 'drow_ranger_marksmanship',
+  },
 ];


### PR DESCRIPTION
## Issue

- [ ] N/A

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.35a[/b]

- 新增卓尔游侠觉醒技能「裂影箭」，普通攻击有概率分裂出箭矢射向周围敌人，并附带霜冻减速
- 修正觉醒自动施法打断TP等BUG。
```

```
[b]Gameplay update v5.35a[/b]

- Added Drow Ranger awakened ability "Splinter Shot": attacks have a chance to splinter arrows at nearby enemies with a frost slow
- Fixed awaken auto-cast interrupting channeling abilities.
```
