### PR TITLE
Disable creep lane invulnerable, add Roshan's Banner to shop

### DIFF
--- a/content/panorama/layout/custom_game/custom_loading_screen.xml
+++ b/content/panorama/layout/custom_game/custom_loading_screen.xml
@@ -133,20 +133,27 @@
 						<Label id="FixedAbilityTitle" class="GameOptionsLabel" text="#fixed_ability" />
 						<DropDown id="fixed_ability_dropdown" class="GameOptionsDropdown" oninputsubmit="SendGameOptionsToServer()">
 							<Label text="#fixed_ability_none" id="none"/>
+							<!-- 主动技能 -->
 							<Label text="#DOTA_Tooltip_ability_tidehunter_ravage" id="tidehunter_ravage" />
 							<Label text="#DOTA_Tooltip_ability_shadow_shaman_mass_serpent_ward" id="shadow_shaman_mass_serpent_ward" />
 							<Label text="#DOTA_Tooltip_ability_brewmaster_primal_split_lua" id="brewmaster_primal_split_lua" />
-							<Label text="#DOTA_Tooltip_ability_witch_doctor_death_ward" id="witch_doctor_death_ward" />
-							<Label text="#DOTA_Tooltip_ability_undying_flesh_golem" id="undying_flesh_golem" />
-							<Label text="#DOTA_Tooltip_ability_centaur_stampede" id="centaur_stampede" />
 							<Label text="#DOTA_Tooltip_ability_clinkz_burning_barrage2" id="clinkz_burning_barrage2" />
-							<Label text="#fixed_ability_ability_trigger_on_move_name" id="ability_trigger_on_move" />
+							<Label text="#DOTA_Tooltip_ability_slark_shadow_dance" id="slark_shadow_dance" />
+							<Label text="#DOTA_Tooltip_ability_life_stealer_rage" id="life_stealer_rage" />
+							<Label text="#DOTA_Tooltip_ability_faceless_void_chronosphere" id="faceless_void_chronosphere" />
+							<!-- 被动技能 -->
 							<Label text="#DOTA_Tooltip_ability_spectre_dispersion2" id="spectre_dispersion2" />
 							<Label text="#fixed_ability_ability_charge_damage_name" id="ability_charge_damage" />
-							<Label text="#DOTA_Tooltip_ability_riki_backstab" id="riki_backstab" />
-							<Label text="#DOTA_Tooltip_ability_medusa_split_shot" id="medusa_split_shot" />
-							<Label text="#DOTA_Tooltip_ability_black_drake_magic_amplification_aura" id="black_drake_magic_amplification_aura" />
-							<Label text="#DOTA_Tooltip_ability_kobold_taskmaster_speed_aura" id="kobold_taskmaster_speed_aura" />
+							<Label text="#DOTA_Tooltip_ability_pudge_innate_graft_flesh" id="pudge_innate_graft_flesh" />
+							<Label text="#DOTA_Tooltip_ability_death_prophet_witchcraft" id="death_prophet_witchcraft" />
+							<Label text="#DOTA_Tooltip_ability_rubick_arcane_supremacy" id="rubick_arcane_supremacy" />
+							<Label text="#DOTA_Tooltip_ability_primal_beast_colossal2" id="primal_beast_colossal2" />
+							<Label text="#DOTA_Tooltip_ability_tiny_grow" id="tiny_grow" />
+							<Label text="#DOTA_Tooltip_ability_tiny_insurmountable" id="tiny_insurmountable" />
+							<Label text="#DOTA_Tooltip_ability_slark_essence_shift" id="slark_essence_shift" />
+							<Label text="#fixed_ability_ability_trigger_on_spell_reflect_name" id="ability_trigger_on_spell_reflect" />
+							<Label text="#DOTA_Tooltip_ability_slardar_bash" id="slardar_bash" />
+							<Label text="#DOTA_Tooltip_ability_phantom_assassin_coup_de_grace" id="phantom_assassin_coup_de_grace" />
 						</DropDown>
 					</Panel>
 					<!-- 是否强制随机英雄 -->

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1156,7 +1156,7 @@
 
 		// Drow Ranger Splinter Shot
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>Splinter Shot Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"Attacks have a chance to splinter into arrows that fly at up to %splinter_targets% enemies around the primary target, each dealing %splinter_damage_pct%%% of the attack's damage as physical damage and applying Frost Arrows' slow.<br>Splinter arrows pierce through defenses, <font color='#FFFFFF'><b>ignoring their base armor</b></font>."
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"Attacks have a chance to splinter into arrows that fly at up to %splinter_targets% enemies around the primary target, each dealing %splinter_damage_pct%%% of the attack's damage as physical damage and applying Frost Arrows' slow.<br>Splinter arrows pierce through defenses, ignoring their <font color='#FFFFFF'><b>base armor</b></font>."
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_splinter_chance"	"%Proc Chance:"
 
 		// Bristleback Auto Quill

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1156,7 +1156,7 @@
 
 		// Drow Ranger Splinter Shot
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>Splinter Shot Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"Attacks have a chance to splinter into arrows that fly at up to %splinter_targets% enemies around the primary target, each dealing %splinter_damage_pct%%% of the attack's damage as physical damage and applying Frost Arrows' slow."
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"Attacks have a chance to splinter into arrows that fly at up to %splinter_targets% enemies around the primary target, each dealing %splinter_damage_pct%%% of the attack's damage as physical damage and applying Frost Arrows' slow.<br>Splinter arrows pierce through defenses, <font color='#FFFFFF'><b>ignoring their base armor</b></font>."
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_splinter_chance"	"%Proc Chance:"
 
 		// Bristleback Auto Quill

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1154,7 +1154,7 @@
 
 		// 卓尔游侠 裂影箭
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>裂影箭 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"普攻有概率分裂出箭矢，射向主目标周围最多%splinter_targets%名敌人，每支造成本次攻击伤害%splinter_damage_pct%%%的物理伤害，并附带霜冻之箭的减速效果。"
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"普攻有概率分裂出箭矢，射向主目标周围最多%splinter_targets%名敌人，每支造成本次攻击伤害%splinter_damage_pct%%%的物理伤害，并附带霜冻之箭的减速效果。<br>分裂箭矢将穿透敌人的防御，<font color='#FFFFFF'><b>无视他们的基础护甲</b></font>。"
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_splinter_chance"	"%触发概率："
 
 		// 钢背兽 自动喷刺

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1154,7 +1154,7 @@
 
 		// 卓尔游侠 裂影箭
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>裂影箭 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"普攻有概率分裂出箭矢，射向主目标周围最多%splinter_targets%名敌人，每支造成本次攻击伤害%splinter_damage_pct%%%的物理伤害，并附带霜冻之箭的减速效果。<br>分裂箭矢将穿透敌人的防御，<font color='#FFFFFF'><b>无视他们的基础护甲</b></font>。"
+		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_Description"		"普攻有概率分裂出箭矢，射向主目标周围最多%splinter_targets%名敌人，每支造成本次攻击伤害%splinter_damage_pct%%%的物理伤害，并附带霜冻之箭的减速效果。<br>分裂箭矢将穿透敌人的防御，无视他们的<font color='#FFFFFF'><b>基础护甲</b></font>。"
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade_splinter_chance"	"%触发概率："
 
 		// 钢背兽 自动喷刺

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -165,6 +165,8 @@
 		"RequiredLevel"					"6"
 		"LevelsBetweenUpgrades"			"6"
 		"LinkedAbility"					"axe_culling_blade"	// 与大招淘汰之刃双向联动同步升级
+		"AbilityCharges"				"3"
+		"AbilityChargeRestoreTime"		"2"
 	}
 
 	// 死灵法师 竭心光环-觉醒

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -443,7 +443,7 @@
 			}
 			"splinter_targets"			"2"
 			"splinter_radius"			"500"
-			"splinter_damage_pct"		"40"
+			"splinter_damage_pct"		"50"
 			"slow_duration"				"1.5"
 			"projectile_speed"			"1250"
 		}

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -6203,15 +6203,17 @@
 	{
 		"MaxLevel"						"5"
 		"AbilityManaCost"				"85 90 95 100 105"
+		"AbilityCastPoint"				"0.1"		// 0.4
 		"AbilityValues"
 		{
 			"stun_duration"
 			{
 				"value"										"0.7 0.9 1.1 1.3 1.5"
+				"special_bonus_unique_monkey_king_9"		"+0.5"	// +0.2 +0.3
 			}
 			"strike_crit_mult"
 			{
-				"value"						"120 140 160 180 200"
+				"value"						"120 160 200 240 280"	// 120 140 160 180 差值+20
 			}
 			"strike_flat_damage"
 			{
@@ -6237,7 +6239,16 @@
 	// 丛林之舞 无法扩展5级
 	// "monkey_king_tree_dance"
 	// 乾坤之跃 同步丛林之舞等级，无法扩展5级
-	// "monkey_king_primal_spring"
+	"monkey_king_primal_spring"
+	{
+		"AbilityValues"
+		{
+			"impact_damage"
+			{
+				"value"						"220 400 580 760"	// 110 200 290 380 x2
+			}
+		}
+	}
 	// 如意棒法 金箍棒法
 	"monkey_king_jingu_mastery"
 	{

--- a/game/scripts/npc/npc_items_override.txt
+++ b/game/scripts/npc/npc_items_override.txt
@@ -224,9 +224,6 @@
 		"ItemStockInitial"				"1"
 		"ItemStockMax"					"1"
 		"ItemStockTime"					"600"
-		"ItemInitialCharges"			"1"
-		"ItemStackable"					"1"
-		"ItemStackableMax"				"2"
 		"AbilityValues"
 		{
 			"duration"				"180"	// 120

--- a/game/scripts/npc/npc_items_override.txt
+++ b/game/scripts/npc/npc_items_override.txt
@@ -219,12 +219,17 @@
 	// 肉山的战旗 旗帜
 	"item_roshans_banner"
 	{
+		"ItemPurchasable"				"1"
+		"ItemCost"						"8000"
+		"ItemStockInitial"				"1"
+		"ItemStockMax"					"1"
+		"ItemStockTime"					"600"
 		"AbilityValues"
 		{
 			"duration"				"180"	// 120
 			"health"				"40 80 120"
 			"health_tooltip"		"10 20 30"
-			"buff_linger_duration"		"15"// 0.1
+			"buff_linger_duration"		"30"// 0.1
 		}
 	}
 

--- a/game/scripts/npc/npc_items_override.txt
+++ b/game/scripts/npc/npc_items_override.txt
@@ -224,6 +224,9 @@
 		"ItemStockInitial"				"1"
 		"ItemStockMax"					"1"
 		"ItemStockTime"					"600"
+		"ItemInitialCharges"			"1"
+		"ItemStackable"					"1"
+		"ItemStackableMax"				"2"
 		"AbilityValues"
 		{
 			"duration"				"180"	// 120

--- a/game/scripts/shops.txt
+++ b/game/scripts/shops.txt
@@ -44,7 +44,7 @@
 
 		"item"		"item_diadem"				// 宝冕
 		"item"		"item_travel_boots"			// 飞鞋 远行鞋
-		"item"		"item_radar_of_dragon"
+		"item"		"item_candy_candy"			// 嘉心糖
 		"item"		"item_recipe_greater_famango" // 巨大疗伤莲花配方
 	}
 	// 装备
@@ -155,7 +155,7 @@
 		// "item"		"item_pers"					// 坚韧球
  		"item"		"item_mask_of_madness"
 		"item"		"item_hand_of_group"		// 团队之手
-		"item"		"item_candy_candy"
+		"item"		"item_roshans_banner"		// 肉山的战旗
 		"item"		"item_wings_of_haste"		// 急速之翼
 		"item"		"item_moon_shard_datadriven"
 		"item"		"item_consumable_gem"		// 幻影宝石

--- a/src/vscripts/abilities/ts_abilities/axe_auto_culling_blade.ts
+++ b/src/vscripts/abilities/ts_abilities/axe_auto_culling_blade.ts
@@ -28,6 +28,7 @@ export class AxeAutoCullingBlade extends AutoCastAbility {
     }
 
     if (!culling.IsFullyCastable()) return;
+    if (this.GetCurrentAbilityCharges() <= 0) return;
 
     // 淘汰之刃可对魔免单位施放
     const enemies = findEnemiesInRange(
@@ -44,6 +45,7 @@ export class AxeAutoCullingBlade extends AutoCastAbility {
       if (!enemy.IsNull() && enemy.IsAlive() && enemy.GetHealth() <= threshold) {
         castImmediatelyOnTarget(caster, culling, enemy);
         culling.EndCooldown(); // 不进入 CD
+        this.SetCurrentAbilityCharges(this.GetCurrentAbilityCharges() - 1);
         this.pendingTarget = enemy;
         return;
       }

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_drow_ranger_upgrade.ts
@@ -107,7 +107,7 @@ export class modifier_special_bonus_unique_drow_ranger_upgrade extends BaseModif
       attacker: parent,
       damage,
       damage_type: DamageTypes.PHYSICAL,
-      damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION,
+      damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION + DamageFlag.IGNORES_BASE_PHYSICAL_ARMOR,
       ability,
     });
 

--- a/src/vscripts/modules/event/event-npc-spawned.ts
+++ b/src/vscripts/modules/event/event-npc-spawned.ts
@@ -55,7 +55,8 @@ export class EventNpcSpawned {
     ListenToGameEvent('npc_spawned', (keys) => this.OnNpcSpawned(keys), this);
 
     // 预加载休眠期长度不可预测，无法在出生时算准 duration；改为检测小兵真正开始移动后再补无敌
-    Timers.CreateTimer(0.5, () => this.checkPendingInvuln());
+    // 暂时关闭
+    // Timers.CreateTimer(0.5, () => this.checkPendingInvuln());
   }
 
   // 单个全局 timer 轮询：等待预加载小兵离开出生点（激活），此刻才加 travelTime 时长的无敌
@@ -289,7 +290,8 @@ export class EventNpcSpawned {
     }
 
     // 兵线小兵：出生到己方一塔前无敌，防止中途被拉断线
-    this.applyCreepLaneInvulnerable(creep, creepName);
+    // 暂时关闭
+    // this.applyCreepLaneInvulnerable(creep, creepName);
   }
 
   private applyCreepLaneInvulnerable(creep: CDOTA_BaseNPC, creepName: string): void {

--- a/src/vscripts/modules/event/game-end/game-end-point.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.ts
@@ -101,9 +101,9 @@ export class GameEndPoint {
       multiplier *= 2.3;
     } else if (option.direGoldXpMultiplier >= 15) {
       multiplier *= 2.2;
-    } else if (option.direGoldXpMultiplier === 12) {
+    } else if (option.direGoldXpMultiplier >= 12) {
       multiplier *= 2.1;
-    } else if (option.direGoldXpMultiplier === 10) {
+    } else if (option.direGoldXpMultiplier >= 10) {
       multiplier *= 2.0;
     } else if (option.direGoldXpMultiplier >= 5) {
       multiplier *= 1.5;

--- a/src/vscripts/modules/lottery/item/lottery-items.ts
+++ b/src/vscripts/modules/lottery/item/lottery-items.ts
@@ -41,10 +41,11 @@ export const itemTiers: Tier[] = [
       'item_tome_of_agility', // 敏捷之书
       'item_tome_of_intelligence', // 智力之书
       'item_tome_of_strength', // 力量之书
-      'item_light_part', // 圣光组件
-      'item_dark_part', // 暗影组件
       'item_ultimate_scepter_2', // 真·阿哈利姆神杖
       'item_hydras_breath', // 怪蛇之息
+      'item_roshans_banner', // 肉山的战旗
+      'item_light_part', // 圣光组件
+      'item_dark_part', // 暗影组件
     ],
   },
   // 3~5k
@@ -66,8 +67,8 @@ export const itemTiers: Tier[] = [
   {
     level: 2,
     names: [
+      // 'item_collector', // 收纳符
       'item_rune_transmuter_random', // 洗炼石
-      'item_collector', // 收纳符
       'item_tome_of_knowledge', // 知识之书
       'item_aghanims_shard', // 阿哈利姆魔晶
       'item_great_famango', // 大疗伤莲花


### PR DESCRIPTION
## Issue

- [ ] fix #9999

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.38a[/b]

- 移除兵线小兵无敌机制，肉山的战旗现可在商店购买。
- 加强卓尔游侠觉醒，分裂箭矢改成无视基础护甲
- 削弱斧王觉醒改成最大充能 3 次，每 2 秒充能1次
- 轮替自定义模式固定技能池
```

```
[b]Gameplay update v5.38a[/b]

- Removed creep lane invulnerability, Roshan's Banner is now purchasable in the shop.
- Buff Drow Ranger Awaken: Splinter Shot arrows now ignore base armor.
- Nerf Axe Awaken: Auto Culling Blade now has 3 charges, restoring 1 charge every 2 seconds.
- Rotated custom mod fixed ability pool options
```
