### PR TITLE
Add bot item build config for Viper, Vengeful Spirit, Sven, Riki, Drow Ranger

### DIFF
--- a/.claude/skills/bot-ability-usage/SKILL.md
+++ b/.claude/skills/bot-ability-usage/SKILL.md
@@ -53,7 +53,6 @@ Glob pattern: src/vscripts/ai/ability/specs/<abilityName>.ts
 | `AbilityBehavior` | 决定 cast 调用方式 | dispatcher 自动按 `UNIT_TARGET / POINT / AOE / NO_TARGET` 派发，**spec 不用关心** |
 | `AbilityUnitTargetTeam` | 决定 `TargetSide` | `ENEMY` → `EnemyHero/EnemyCreep/EnemyBuilding`；`FRIENDLY` → `FriendlyHero/FriendlyBuilding`；技能仅作用施法者 → `Self` |
 | `AbilityUnitTargetType` | 区分英雄/小兵/建筑 | 含 `HERO` 用 `*Hero`；仅 `BASIC/CREEP` 用 `EnemyCreep`；含 `BUILDING` 用 `*Building`；同一技能多种合法目标且语义合理时**注册多条 spec**（如冰霜魔盾对友方英雄 + 友方建筑） |
-| `AbilityUnitTargetFlags` 含 `INVULNERABLE` | 友方建筑通常带无敌（未暴露的塔），`aroundFriendlyBuildings` 已包含无敌目标 | 对友方建筑的技能（如 `lich_frost_shield`）天然可用 |
 | `AbilityCastRange` | 施法距离 | **dispatcher 会自动按 cast range + 施法距离加成过滤目标**，spec 通常**不要**手写 `range.lte` |
 
 如该技能是 `PASSIVE` 或纯 `NO_TARGET` 自身 buff 不需要选目标 → `TargetSide.Self`。

--- a/.claude/skills/bot-item-build/SKILL.md
+++ b/.claude/skills/bot-item-build/SKILL.md
@@ -78,6 +78,14 @@ description: >-
   `item_ultimate_scepter_2`、`item_aghanims_shard`、`item_moon_shard_datadriven`、
   `item_tome_of_strength`/`item_tome_of_agility`/`item_tome_of_intelligence`。
   这些不进入 `targetItemsByTier` 候选池提案，混进来会和自动购买逻辑重复。
+- **`sell-item-config.ts` 的 `SellItemCommonJunkList` 里的装备**（`item_magic_wand` 和「消耗品」
+  段落里列出的几件除外——它们是设计上就该用完即扔的一次性/早期消耗品）：这份列表是背包超过出售阈值
+  （7~9件，`SellItem.GetSellThreshold`）时 `SellCommonJunkItems` **无条件**优先出售的清单。
+  `RemoveCurrentTierItems` 只保护"当前正在购买的这一 tier"，一旦出装进度推进到下一 tier，前面买的、
+  但在这份名单里的装备就会在下次背包超阈值时被半价甩卖——不管是不是特意买的。CSV 信号再强也不能用
+  （如 `item_diffusal_blade`、`item_eagle`、`item_talisman_of_evasion`、裸的
+  `item_kaya`/`item_sange`/`item_yasha`）。**每次生成候选池前必须对照这份列表逐条过滤**，不要只凭
+  tier 归属和信号强度判断。
 
 ---
 

--- a/.claude/skills/bot-item-build/SKILL.md
+++ b/.claude/skills/bot-item-build/SKILL.md
@@ -158,6 +158,13 @@ description: >-
 `sell-item-config.ts` 的 `ItemUpgradeReplacements`：如果两件候选是同一功能槽位的不同分支
 （如多种鞋子、或某组件与其"合成成品"没有 sell-replacement 关系），只留其中一件，其余用别的非冲突装备替代。
 
+**同一 `prerequisite` 的平行分支同理，不只是鞋子**：`item-tier-config.ts` 里两件装备如果
+`prerequisite` 字段指向同一个下位装备（如 `item_wasp_callous` 和 `item_wasp_despotic` 都以
+`item_butterfly` 为前置，分别升级到蝴蝶的两条不同分支），它们是**互斥的平行分支**，不是互补装备——
+两者都不在对方的 `ItemUpgradeReplacements` 里，买了不会互相顶替出售，会被同时买下白白浪费金钱。
+添加候选前扫一遍 `item-tier-config.ts` 找出所有共享同一 `prerequisite` 的装备组，同一 tier 只保留
+其中信号最强的一个（前置装备本身，如 `item_butterfly`，可以和分支之一共存，因为分支会顶替前置）。
+
 ---
 
 ## 第六步：展示提案，等待确认
@@ -202,9 +209,10 @@ description: >-
 放 scratchpad 目录即可）解析 `hero-build-config.ts` / `hero-build-config-template.ts` 里每个
 `[ItemTier.Tn]: [...]` 区块中的装备名，对照 `item-tier-config.ts` 的 `tier` 字段，确认 0 处不一致。
 
-同时检查第 5.1 节的互斥组问题：至少要扫描"鞋子互斥组"（`item_boots`/`item_power_treads`/
-`item_arcane_boots`/`item_phase_boots`/`item_tranquil_boots`）在每个英雄每个 tier 里是否同时出现
-2 件以上，若有则必须修复。
+同时检查第 5.1 节的互斥组问题：脚本里从 `item-tier-config.ts` 解析出所有共享同一 `prerequisite`
+的装备分组（鞋子互斥组 `item_boots`/`item_power_treads`/`item_arcane_boots`/`item_phase_boots`/
+`item_tranquil_boots` 只是其中一种，`item_wasp_callous`/`item_wasp_despotic` 这类共享同一前置的
+平行分支同理），逐组扫描每个英雄每个 tier 是否同时出现 2 件以上，若有则必须修复。
 
 然后运行：
 ```bash

--- a/.claude/skills/bot-item-build/SKILL.md
+++ b/.claude/skills/bot-item-build/SKILL.md
@@ -94,6 +94,12 @@ description: >-
 装备互相印证），`tier` 按该 cost 对照本节的价格区间表得出。补完后再按正常流程把它纳入候选。只有当信号
 很弱（个位数、极低事件数）或明显是过时/已改名的历史装备时才跳过。
 
+**`ItemQuality: "component"` 的装备即使信号很强也跳过**：在 `docs/reference/<version>/items.txt`
+查该装备的 `ItemQuality` 字段——标为 `"component"` 说明官方就把它定位为合成中间件（如
+`item_orb_of_venom`、`item_helm_of_iron_will`、`item_diadem`），不是玩家会长期持有的终局装备，
+不应作为候选池目标，无论 CSV 事件数多高都跳过。`"secret_shop"`、`"artifact"` 等其他 quality 标签
+才是可以正常收录的终局装备。
+
 **`nameCN` 取值来源，禁止自己猜译名**：优先在现有代码里找权威译名——`item-tier-config.ts` 里若已有
 该装备的 `nameCN` 字段直接用；没有的话查 `game/scripts/vscripts/bot/bot_item_data.lua` 或其他英雄配置
 里出现过的同装备注释。都找不到时，去 `game/resource/addon_schinese.txt` 搜

--- a/.claude/skills/bot-item-build/SKILL.md
+++ b/.claude/skills/bot-item-build/SKILL.md
@@ -88,9 +88,16 @@ description: >-
 （例如价格/tier 规则调整后遗留的历史归属）。
 
 **CSV 里出现但 `item-tier-config.ts` 完全没收录的装备**（不属于第二步噪音过滤名单，是真实遗漏）：
-不要因为查不到 tier 就直接跳过或换用别的装备顶替。先在 `item-tier-config.ts` 里补上这条配置——
-`cost` 取 CSV 的「Average 金钱」列（同一装备各行数值应一致，可与命名/功能相近的同价位装备互相印证），
-`tier` 按该 cost 对照本节的价格区间表得出。补完后再按正常流程把它纳入候选。
+不要因为查不到 tier 就直接跳过或换用别的装备顶替。**信号强（事件数明显不低，尤其是多个英雄反复出现同
+一件未收录装备）时直接自动补录，不需要额外用 AskUserQuestion 确认**——先在 `item-tier-config.ts` 里
+补上这条配置：`cost` 取 CSV 的「Average 金钱」列（同一装备各行数值应一致，可与命名/功能相近的同价位
+装备互相印证），`tier` 按该 cost 对照本节的价格区间表得出。补完后再按正常流程把它纳入候选。只有当信号
+很弱（个位数、极低事件数）或明显是过时/已改名的历史装备时才跳过。
+
+**`nameCN` 取值来源，禁止自己猜译名**：优先在现有代码里找权威译名——`item-tier-config.ts` 里若已有
+该装备的 `nameCN` 字段直接用；没有的话查 `game/scripts/vscripts/bot/bot_item_data.lua` 或其他英雄配置
+里出现过的同装备注释。都找不到时，去 `game/resource/addon_schinese.txt` 搜
+`DOTA_Tooltip_Ability_<item_name>` 键取其值。三处都查不到再询问用户，不要凭印象/相似装备名称推测。
 
 ---
 

--- a/.claude/skills/bot-item-build/SKILL.md
+++ b/.claude/skills/bot-item-build/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   基于 bot（英雄_BOT.csv）与玩家（英雄_玩家.csv）出装统计 CSV（列：物品,英雄,Average 时长_秒,胜率,事件数,Average 金钱），
   按装备在 src/vscripts/ai/build-item/item-tier-config.ts 的 canonical tier 过滤数据，
   为 src/vscripts/ai/build-item/hero-build-config.ts / hero-build-config-template.ts 的候选池生成扩充建议：
-  bot 数据优先、玩家数据补充、同英雄模板兜底，目标每个 tier 候选数 > 6（MAX_ITEMS_PER_TIER=6 的抽样上限）。
+  bot 数据优先、玩家数据补充、同英雄模板兜底，目标每个 tier 候选数 7~9（MAX_ITEMS_PER_TIER=6 的抽样上限）。
   与用户确认后执行编辑并校验 tier 一致性。
 ---
 
@@ -29,8 +29,9 @@ description: >-
 `{ item, weight }` 才能自定义权重。排序、分组只是给人看的，不影响游戏内行为。
 
 **候选池 ≤ 6 件时，抽样等于原样返回，没有随机性**；必须 **> 6** 件才能让"这把和上把出的不一样"，
-也才能留出以后根据胜率数据继续优化候选池的空间（正好卡在 6 就没有改进余地了）。这是本 skill 每个
-tier 目标数量 > 6（而不是 ≥ 6）的根本原因。
+也才能留出以后根据胜率数据继续优化候选池的空间（正好卡在 6 就没有改进余地了）。但也不宜无限扩张——
+候选过多会稀释每件装备的实际入选概率、增加后续维护和人工核对成本。这是本 skill 每个 tier 目标数量
+定为 **7~9**（而不是恰好 6，也不超过 9）的根本原因。
 
 ### Tier 归属规则（`item-tier-config.ts`）
 
@@ -61,7 +62,9 @@ tier 目标数量 > 6（而不是 ≥ 6）的根本原因。
 至少需要一份；两份都有时按下文"数据优先级"处理。CSV 格式：
 `物品,英雄,Average 时长_秒,胜率,事件数,Average 金钱`（表头行跳过）。
 
-确认本次要调整的英雄范围（英雄内部代号，如 `npc_dota_hero_axe`）。
+确认本次要调整的英雄范围（英雄内部代号，如 `npc_dota_hero_axe`）。若用户给出的是英雄中文名（如
+「风行者」「莱恩」），在 `npc_heroes.txt`（`docs/reference/<version>/`）中查出对应的
+`npc_dota_hero_<id>` 系统名，并在回复中明确列出中文名 → 系统名的对照，供用户确认没有认错英雄。
 
 ---
 
@@ -84,6 +87,11 @@ tier 目标数量 > 6（而不是 ≥ 6）的根本原因。
 不要看装备当前摆在 `hero-build-config.ts` 的哪个 tier 桶里——当前摆放位置可能本身就是待修正的错误
 （例如价格/tier 规则调整后遗留的历史归属）。
 
+**CSV 里出现但 `item-tier-config.ts` 完全没收录的装备**（不属于第二步噪音过滤名单，是真实遗漏）：
+不要因为查不到 tier 就直接跳过或换用别的装备顶替。先在 `item-tier-config.ts` 里补上这条配置——
+`cost` 取 CSV 的「Average 金钱」列（同一装备各行数值应一致，可与命名/功能相近的同价位装备互相印证），
+`tier` 按该 cost 对照本节的价格区间表得出。补完后再按正常流程把它纳入候选。
+
 ---
 
 ## 第四步：读取当前候选池状态
@@ -97,17 +105,19 @@ tier 目标数量 > 6（而不是 ≥ 6）的根本原因。
 
 ## 第五步：逐 tier 构建扩充候选（数据优先级）
 
-对每个目标英雄的每个 tier，按以下优先级顺序纳入候选，直到数量 > 6（**不是恰好 6**）：
+对每个目标英雄的每个 tier，按以下优先级顺序纳入候选，直到数量落在 **7~9** 之间（不是恰好 6，也不宜超过 9）：
 
 1. **保留现有池子里的所有装备**
 2. **Bot 数据优先**：该 tier 下、该英雄的 Bot CSV 里出现过的装备，**全部纳入**（不设事件数阈值，
    只要 tier 匹配、非噪音就算，因为这是历史实际购买行为，信号本身就有意义）
-3. **玩家数据补充**：若"现有 + Bot"仍不足 6，从玩家 CSV 按事件数降序取，补到 6 件以上
+3. **玩家数据补充**：若"现有 + Bot"仍不足 7，从玩家 CSV 按事件数降序取，补到 7 件以上
 4. **同英雄模板兜底**：若上述来源仍不够，检查该英雄所用 `HeroTemplate` 里同 tier（或角色定位相近的
    其他 tier，如力量坦克模板的 T5 可能被辅助英雄借用）是否有尚未使用的条目，按角色定位是否合理挑选
 5. **纯角色定位判断**：若以上全部来源都补不出第 7 件（数据彻底稀薄，模板也没有可借的），
    允许挑选一件契合该英雄技能定位、但完全没有数据支撑的装备。这类装备**必须单独列出**，
    用 AskUserQuestion 请用户确认是否认可这个判断，不能自行决定后直接写入配置
+6. **超过 9 件时按信号强度（Bot/玩家事件数之和）裁剪**：数据来源已经足够多、总数超过 9 时，
+   优先保留事件数总和最高的条目，裁掉信号最弱的，不要为了"数据全都要"而堆到两位数
 
 每个候选标注来源（Bot 胜率/事件数、玩家事件数、模板借用、纯判断），供用户在确认阶段判断取舍。
 
@@ -156,7 +166,12 @@ tier 目标数量 > 6（而不是 ≥ 6）的根本原因。
 
 1. **`src/vscripts/ai/hero/bot-base.ts`** 的 `NEW_BUILD_SYSTEM_HEROES` 静态记录：这是 TS 侧判定英雄使用新/老出装系统的唯一来源（替代了原先在每个 hero 文件里 `override useNewBuildSystem: boolean = true` 的做法）。在记录中添加一行：`['npc_dota_hero_<name>']: true,`，按字母顺序排列。
 2. **`game/scripts/vscripts/events.lua`** 的 `excludeHeroes` 表：如果不在这里排除，该英雄会被额外添加 `modifier_bot_think_strategy`（老 Lua 系统的旧 AI 逻辑），必须阻止。在表内新增一行：`["npc_dota_hero_<name>"] = true,`，按字母顺序插入。
-3. **`src/vscripts/ai/hero/hero-<name>.ts`**：如果该英雄还没有对应的 TS 英雄 AI 文件，需要创建。内容参考已有文件（如 `hero-bane.ts`），只需 `@registerModifier` 装饰器 + 继承 `BotBaseAIModifier`，**不需要** `override useNewBuildSystem` 字段（集中列表已经接管此判断）。
+
+以上 2 项对每个首次迁移的英雄都必须做。**不需要**额外新建 `src/vscripts/ai/hero/hero-<name>.ts`：
+`AI.ts` 的 `getModifierName()` 对没有专属判断分支的英雄会默认落到通用的 `BotBaseAIModifier`，
+已迁移的 abaddon/axe/bane/bloodseeker/bounty_hunter 均无专属文件、全部走这条默认路径。只有当英雄
+需要**自定义技能施法逻辑**（超出通用出装/攻击行为）时才新建专属文件并在 `AI.ts` 的
+`getModifierName()` 里加判断分支，参考 `hero-viper.ts`、`hero-drow-ranger.ts` 等既有实现。
 
 ---
 
@@ -182,7 +197,8 @@ npx jest src/vscripts/ai/build-item
 
 - **数据优先级固定**：Bot 优先、玩家补充、模板兜底、纯判断兜底，不跳过前面的层级直接用判断。
 - **纯判断类装备必须 AskUserQuestion 确认**，不得自行决定。
-- **目标是 > 6 件，不是 ≥ 6 件**——正好 6 件没有为后续胜率驱动的迭代留出空间。
+- **目标是 7~9 件，不是恰好 6 件，也不宜超过 9 件**——正好 6 件没有为后续胜率驱动的迭代留出空间，
+  超过 9 件则稀释权重、增加维护成本。
 - **不修改** `MAX_ITEMS_PER_TIER`、`GetT5ItemCount` 难度阶梯、tier 边界规则本身。
 - **注释只写装备中文名**，不写数据来源推导过程；tier 归属修正类改动才附简短原因。
 - **同一 tier 内鞋子（及其他无 sell-replacement 关系的同槽位装备）只能保留一种**，`item_boots`

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -116,6 +116,11 @@ function AIGameMode:OnNPCSpawned(keys)
                     ["npc_dota_hero_bane"] = true,
                     ["npc_dota_hero_bloodseeker"] = true,
                     ["npc_dota_hero_bounty_hunter"] = true,
+                    ["npc_dota_hero_drow_ranger"] = true,
+                    ["npc_dota_hero_riki"] = true,
+                    ["npc_dota_hero_sven"] = true,
+                    ["npc_dota_hero_vengefulspirit"] = true,
+                    ["npc_dota_hero_viper"] = true,
                 }
                 if not excludeHeroes[sName] then
                     hEntity:AddNewModifier(hEntity, nil, "modifier_bot_think_strategy", {})

--- a/src/vscripts/ai/ability/ability-spec.ts
+++ b/src/vscripts/ai/ability/ability-spec.ts
@@ -5,7 +5,7 @@ import { CastCoindition } from '../action/cast-condition';
  *  - EnemyHero / EnemyCreep:   复用 bot-base 预搜的 aroundEnemyHeroes / aroundEnemyCreeps
  *  - EnemyBuilding:            复用 bot-base 预搜的 aroundEnemyBuildings（防御塔/兵营等）
  *  - FriendlyHero:             复用 bot-base 预搜的 aroundFriendlyHeroes（含自己）
- *  - FriendlyBuilding:         复用 bot-base 预搜的 aroundFriendlyBuildings（含无敌塔/兵营）
+ *  - FriendlyBuilding:         复用 bot-base 预搜的 aroundFriendlyBuildings（防御塔/兵营等）
  *  - Self:                     直接以施法者为目标
  *
  * 使用 const object + 字面量联合，TSTL 编译为零开销字符串常量。

--- a/src/vscripts/ai/action/action-find.ts
+++ b/src/vscripts/ai/action/action-find.ts
@@ -56,7 +56,7 @@ export class ActionFind {
   }
 
   static FindFriendlyBuildings(self: CDOTA_BaseNPC_Hero, radius: number): CDOTA_BaseNPC[] {
-    return this.FindTeams(self, radius, UnitTargetType.BUILDING, UnitTargetFlags.INVULNERABLE);
+    return this.FindTeams(self, radius, UnitTargetType.BUILDING);
   }
 
   static FindTeamBuildingsInvulnerable(self: CDOTA_BaseNPC_Hero, radius: number): CDOTA_BaseNPC[] {

--- a/src/vscripts/ai/build-item/hero-build-config-template.ts
+++ b/src/vscripts/ai/build-item/hero-build-config-template.ts
@@ -205,7 +205,6 @@ const MagicalCarryTemplate: HeroTemplateConfig = {
       'item_hand_of_midas', // 金手指
     ],
     [ItemTier.T2]: [
-      'item_kaya', // 慧光
       'item_octarine_core', // 玲珑心
       'item_rod_of_atos', // 阿托斯之棍
       'item_glimmer_cape', // 微光披风

--- a/src/vscripts/ai/build-item/hero-build-config.ts
+++ b/src/vscripts/ai/build-item/hero-build-config.ts
@@ -230,7 +230,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_hydras_breath', // 怪蛇之息
         'item_dodo_desolator', // 黯灭头
         'item_wasp_callous', // 大核荣耀冷酷
-        'item_wasp_despotic', // 大核荣耀暴虐
         'item_mjollnir', // 雷神之锤
         'item_sacred_trident', // 三叉戟
       ],
@@ -364,7 +363,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_hydras_breath', // 怪蛇之息
         'item_mjollnir', // 雷神之锤
         'item_sacred_trident', // 三叉戟
-        'item_wasp_despotic', // 大核荣耀暴虐
       ],
       [ItemTier.T4]: [
         'item_monkey_king_bar_2', // 定海神针

--- a/src/vscripts/ai/build-item/hero-build-config.ts
+++ b/src/vscripts/ai/build-item/hero-build-config.ts
@@ -381,7 +381,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_refresh_core', // 熔火核心
         'item_shivas_guard_2', // 希瓦的守护2
         'item_hallowed_scepter', // 仙云法杖
-        'item_arcane_octarine_core', // 阿卡尼玲珑心
+        'item_arcane_octarine_core', // 奥术之心
       ],
       [ItemTier.T5]: [
         'item_time_gem', // 时间宝石

--- a/src/vscripts/ai/build-item/hero-build-config.ts
+++ b/src/vscripts/ai/build-item/hero-build-config.ts
@@ -139,18 +139,17 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 金手指
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
-        'item_talisman_of_evasion', // 闪避护符
+        'item_vanguard', // 先锋盾
       ],
       [ItemTier.T2]: [
         'item_bfury', // 狂战斧
         'item_sange_and_yasha', // 散夜对剑
         'item_basher', // 碎颅锤
-        'item_diffusal_blade', // 净魂之刃
-        'item_eagle', // 鹰歌弓
         'item_hand_of_group', // 团队之手
         'item_desolator', // 黯灭
         'item_octarine_core', // 玲珑心
         'item_aether_lens_2', // 以太透镜2
+        'item_monkey_king_bar', // 金箍棒
       ],
       [ItemTier.T3]: [
         'item_greater_crit', // 代达罗斯之殇
@@ -211,19 +210,18 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_falcon_blade', // 猎鹰战刃
         'item_mask_of_madness', // 疯狂面具
         'item_magic_wand', // 魔杖
-        'item_talisman_of_evasion', // 闪避护符
         'item_bracer', // 护腕
       ],
       [ItemTier.T2]: [
         'item_hurricane_pike', // 飓风长戟
         'item_hand_of_group', // 团队之手
         'item_desolator', // 黯灭
-        'item_eagle', // 鹰歌弓
         'item_force_staff', // 原力法杖
         'item_black_king_bar', // 黑皇杖
         'item_shotgun', // 双管霰弹枪
         'item_sange_and_yasha', // 散夜对剑
         'item_monkey_king_bar', // 金箍棒
+        'item_aether_lens_2', // 以太透镜2
       ],
       [ItemTier.T3]: [
         'item_hurricane_pike_2', // 大推推
@@ -297,8 +295,8 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_hurricane_pike', // 飓风长戟
         'item_black_king_bar', // 黑皇杖
         'item_desolator', // 黯灭
-        'item_kaya', // 慧光
         'item_shivas_guard', // 希瓦的守护
+        'item_aether_lens_2', // 以太透镜2
       ],
       [ItemTier.T3]: [
         'item_hurricane_pike_2', // 黄金魔龙枪 Ultimate
@@ -344,19 +342,19 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_wraith_band', // 怨灵细带
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_talisman_of_evasion', // 闪避护符
         'item_hand_of_midas', // 金手指
         'item_mask_of_madness', // 疯狂面具
+        'item_soul_ring', // 灵魂之戒
       ],
       [ItemTier.T2]: [
         'item_desolator', // 黯灭
         'item_sange_and_yasha', // 散夜对剑
-        'item_eagle', // 鹰歌弓
         'item_hand_of_group', // 团队之手
         'item_hurricane_pike', // 飓风长戟
         'item_black_king_bar', // 黑皇杖
         'item_bfury', // 狂战斧
         'item_shotgun', // 双管霰弹枪
+        'item_monkey_king_bar', // 金箍棒
       ],
       [ItemTier.T3]: [
         'item_hurricane_pike_2', // 大推推

--- a/src/vscripts/ai/build-item/hero-build-config.ts
+++ b/src/vscripts/ai/build-item/hero-build-config.ts
@@ -128,6 +128,64 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       ],
     },
   },
+  // 力丸
+  npc_dota_hero_riki: {
+    template: HeroTemplate.AgilityCarryMelee,
+    targetItemsByTier: {
+      [ItemTier.T1]: [
+        'item_power_treads', // 动力鞋
+        'item_wraith_band', // 怨灵细带
+        'item_falcon_blade', // 猎鹰战刃
+        'item_magic_wand', // 魔杖
+        'item_hand_of_midas', // 金手指
+        'item_quelling_blade_2_datadriven', // 毒瘤之刃
+        'item_talisman_of_evasion', // 闪避护符
+      ],
+      [ItemTier.T2]: [
+        'item_bfury', // 狂战斧
+        'item_sange_and_yasha', // 散夜对剑
+        'item_basher', // 碎颅锤
+        'item_diffusal_blade', // 净魂之刃
+        'item_eagle', // 鹰歌弓
+        'item_hand_of_group', // 团队之手
+        'item_desolator', // 黯灭
+        'item_octarine_core', // 玲珑心
+        'item_aether_lens_2', // 以太透镜2
+      ],
+      [ItemTier.T3]: [
+        'item_greater_crit', // 代达罗斯之殇
+        'item_dodo_desolator', // 黯灭头
+        'item_butterfly', // 蝴蝶刀
+        'item_wasp_despotic', // 大核荣耀暴虐
+        'item_sacred_trident', // 三叉戟
+        'item_radiance_2', // 圣焰之光
+        'item_satanic', // 撒旦之邪力
+      ],
+      [ItemTier.T4]: [
+        'item_monkey_king_bar_2', // 定海神针
+        'item_infernal_desolator', // 绝对破防之刃
+        'item_blue_fantasy', // 苍蓝幻想
+        'item_sange_and_yasha_1', // 神器·散夜对剑
+        'item_abyssal_blade_v2', // 一闪
+        'item_satanic_2', // 真红·撒旦之邪力
+        'item_excalibur', // EX咖喱棒
+        'item_bfury_ultra', // 救世狂战
+        'item_refresh_core', // 熔火核心
+      ],
+      [ItemTier.T5]: [
+        'item_rapier_ultra_bot_1', // 解放的诅咒圣剑
+        'item_magic_sword', // 魔渊剑
+        'item_switchable_crit_blade', // 归海一刀
+        'item_time_gem', // 时间宝石
+        'item_ten_thousand_swords', // 万剑归宗
+        'item_forbidden_staff', // 禁忌法杖
+        'item_magic_crit_blade', // 魔龙狂舞
+        'item_dracula_mask', // 生命之盔
+        'item_swift_glove', // 无限手套
+      ],
+    },
+  },
+
   // ===== 敏捷核心英雄(远程) =====
 
   npc_dota_hero_luna: {
@@ -146,14 +204,59 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
   npc_dota_hero_drow_ranger: {
     template: HeroTemplate.AgilityCarryRanged,
     targetItemsByTier: {
+      [ItemTier.T1]: [
+        'item_power_treads', // 动力鞋
+        'item_wraith_band', // 怨灵细带
+        'item_hand_of_midas', // 金手指
+        'item_falcon_blade', // 猎鹰战刃
+        'item_mask_of_madness', // 疯狂面具
+        'item_magic_wand', // 魔杖
+        'item_talisman_of_evasion', // 闪避护符
+        'item_bracer', // 护腕
+      ],
+      [ItemTier.T2]: [
+        'item_hurricane_pike', // 飓风长戟
+        'item_hand_of_group', // 团队之手
+        'item_desolator', // 黯灭
+        'item_eagle', // 鹰歌弓
+        'item_force_staff', // 原力法杖
+        'item_black_king_bar', // 黑皇杖
+        'item_shotgun', // 双管霰弹枪
+        'item_sange_and_yasha', // 散夜对剑
+        'item_monkey_king_bar', // 金箍棒
+      ],
       [ItemTier.T3]: [
         'item_hurricane_pike_2', // 大推推
+        'item_shotgun_v2', // 三管霰弹枪
+        'item_butterfly', // 蝴蝶刀
+        'item_hydras_breath', // 怪蛇之息
+        'item_dodo_desolator', // 黯灭头
+        'item_wasp_callous', // 大核荣耀冷酷
+        'item_wasp_despotic', // 大核荣耀暴虐
+        'item_mjollnir', // 雷神之锤
+        'item_sacred_trident', // 三叉戟
       ],
       [ItemTier.T4]: [
         'item_monkey_king_bar_2', // 定海神针（tier 归属修正：真实价格属于 T4）
         'item_excalibur', // 圣剑
         'item_satanic_2', // 真·撒旦
         'item_black_king_bar_2', // 真·BKB
+        'item_infernal_desolator', // 绝对破防之刃
+        'item_wasp_golden', // 黄金大核荣耀
+        'item_sacred_six_vein', // 六脉神剑
+        'item_hydras_breath_2', // 神器·千年毒蛟之息
+        'item_sange_and_yasha_1', // 神器·散夜对剑
+      ],
+      [ItemTier.T5]: [
+        'item_hawkeye_turret', // 鹰眼炮台
+        'item_switchable_crit_blade', // 归海一刀
+        'item_swift_glove', // 无限手套
+        'item_ten_thousand_swords', // 万剑归宗
+        'item_dracula_mask', // 生命之盔
+        'item_beast_shield', // 兽化盾
+        'item_time_gem', // 时间宝石
+        'item_rapier_ultra_bot_1', // 解放的诅咒圣剑
+        'item_magic_sword', // 魔渊剑
       ],
     },
   },
@@ -169,6 +272,123 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_monkey_king_bar_2', // 定海神针（tier 归属修正：真实价格属于 T4）
         'item_satanic_2', // 真·撒旦
         'item_black_king_bar_2', // 真·BKB
+      ],
+    },
+  },
+
+  // 冥界亚龙
+  npc_dota_hero_viper: {
+    template: HeroTemplate.AgilityCarryRanged,
+    targetItemsByTier: {
+      [ItemTier.T1]: [
+        'item_power_treads', // 动力鞋
+        'item_wraith_band', // 怨灵细带
+        'item_null_talisman', // 空灵挂件
+        'item_vanguard', // 先锋盾
+        'item_bracer', // 护腕
+        'item_falcon_blade', // 猎鹰战刃
+        'item_magic_wand', // 魔杖
+        'item_hand_of_midas', // 金手指
+      ],
+      [ItemTier.T2]: [
+        'item_sange_and_yasha', // 散夜对剑
+        'item_travel_boots', // 远行鞋
+        'item_hand_of_group', // 团队之手
+        'item_hurricane_pike', // 飓风长戟
+        'item_black_king_bar', // 黑皇杖
+        'item_desolator', // 黯灭
+        'item_kaya', // 慧光
+        'item_shivas_guard', // 希瓦的守护
+      ],
+      [ItemTier.T3]: [
+        'item_hurricane_pike_2', // 黄金魔龙枪 Ultimate
+        'item_wasp_callous', // 大核荣耀冷酷
+        'item_shotgun_v2', // 三管霰弹枪
+        'item_hydras_breath', // 怪蛇之息
+        'item_dodo_desolator', // 黯灭头
+        'item_sacred_trident', // 三叉戟
+        'item_radiance_2', // 圣焰之光
+        'item_mjollnir', // 雷神之锤
+      ],
+      [ItemTier.T4]: [
+        'item_monkey_king_bar_2', // 定海神针
+        'item_black_king_bar_2', // 天神杖
+        'item_wasp_golden', // 黄金大核荣耀
+        'item_refresh_core', // 熔火核心
+        'item_skadi_2', // 粘妈之眼
+        'item_excalibur', // EX咖喱棒
+        'item_sacred_six_vein', // 六脉神剑
+        'item_infernal_desolator', // 绝对破防之刃
+        'item_hydras_breath_2', // 神器·千年毒蛟之息
+      ],
+      [ItemTier.T5]: [
+        'item_rapier_ultra_bot_1', // 解放的诅咒圣剑
+        'item_hawkeye_turret', // 鹰眼炮台
+        'item_swift_glove', // 无限手套
+        'item_time_gem', // 时间宝石
+        'item_ten_thousand_swords', // 万剑归宗
+        'item_switchable_crit_blade', // 归海一刀
+        'item_magic_crit_blade', // 魔龙狂舞
+        'item_beast_armor', // 兽化甲
+        'item_magic_sword', // 魔渊剑
+      ],
+    },
+  },
+
+  // 复仇之魂
+  npc_dota_hero_vengefulspirit: {
+    template: HeroTemplate.AgilityCarryRanged,
+    targetItemsByTier: {
+      [ItemTier.T1]: [
+        'item_power_treads', // 动力鞋
+        'item_wraith_band', // 怨灵细带
+        'item_falcon_blade', // 猎鹰战刃
+        'item_magic_wand', // 魔杖
+        'item_talisman_of_evasion', // 闪避护符
+        'item_hand_of_midas', // 金手指
+        'item_mask_of_madness', // 疯狂面具
+      ],
+      [ItemTier.T2]: [
+        'item_desolator', // 黯灭
+        'item_sange_and_yasha', // 散夜对剑
+        'item_eagle', // 鹰歌弓
+        'item_hand_of_group', // 团队之手
+        'item_hurricane_pike', // 飓风长戟
+        'item_black_king_bar', // 黑皇杖
+        'item_bfury', // 狂战斧
+        'item_shotgun', // 双管霰弹枪
+      ],
+      [ItemTier.T3]: [
+        'item_hurricane_pike_2', // 大推推
+        'item_wasp_callous', // 大核荣耀冷酷
+        'item_dodo_desolator', // 黯灭头
+        'item_shotgun_v2', // 三管霰弹枪
+        'item_hydras_breath', // 怪蛇之息
+        'item_mjollnir', // 雷神之锤
+        'item_sacred_trident', // 三叉戟
+        'item_wasp_despotic', // 大核荣耀暴虐
+      ],
+      [ItemTier.T4]: [
+        'item_monkey_king_bar_2', // 定海神针
+        'item_infernal_desolator', // 绝对破防之刃
+        'item_black_king_bar_2', // 天神杖
+        'item_wasp_golden', // 黄金大核荣耀
+        'item_skadi_2', // 粘妈之眼
+        'item_excalibur', // EX咖喱棒
+        'item_hydras_breath_2', // 神器·千年毒蛟之息
+        'item_sacred_six_vein', // 六脉神剑
+        'item_bfury_ultra', // 救世狂战
+      ],
+      [ItemTier.T5]: [
+        'item_rapier_ultra_bot_1', // 解放的诅咒圣剑
+        'item_hawkeye_turret', // 鹰眼炮台
+        'item_swift_glove', // 无限手套
+        'item_magic_sword', // 魔渊剑
+        'item_switchable_crit_blade', // 归海一刀
+        'item_ten_thousand_swords', // 万剑归宗
+        'item_beast_shield', // 兽化盾
+        'item_time_gem', // 时间宝石
+        'item_dracula_mask', // 生命之盔
       ],
     },
   },
@@ -334,6 +554,66 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_undying_heart', // 不朽之心
         'item_black_king_bar_2', // 真·BKB
         'item_overwhelming_blink_2', // 大力量跳刀
+      ],
+    },
+  },
+
+  // 斯温
+  npc_dota_hero_sven: {
+    template: HeroTemplate.StrengthTank,
+    targetItemsByTier: {
+      [ItemTier.T1]: [
+        'item_power_treads', // 动力鞋
+        'item_bracer', // 护腕
+        'item_quelling_blade_2_datadriven', // 毒瘤之刃
+        'item_mask_of_madness', // 疯狂面具
+        'item_vanguard', // 先锋盾
+        'item_falcon_blade', // 猎鹰战刃
+        'item_magic_wand', // 魔杖
+        'item_hand_of_midas', // 金手指
+        'item_wraith_band', // 怨灵细带
+      ],
+      [ItemTier.T2]: [
+        'item_sange_and_yasha', // 散夜对剑
+        'item_blink', // 闪烁匕首
+        'item_echo_sabre_2', // 音速战刃
+        'item_black_king_bar', // 黑皇杖
+        'item_hand_of_group', // 团队之手
+        'item_desolator', // 黯灭
+        'item_monkey_king_bar', // 金箍棒
+        'item_armlet_plus', // 小鸡臂章Plus
+      ],
+      [ItemTier.T3]: [
+        'item_vladmir_2', // 强袭祭品
+        'item_wasp_despotic', // 大核荣耀暴虐
+        'item_armlet_pro_max', // 小鸡臂章Pro Max
+        'item_dodo_desolator', // 黯灭头
+        'item_greater_crit', // 代达罗斯之殇
+        'item_sacred_trident', // 三叉戟
+        'item_heart', // 恐鳌之心
+        'item_satanic', // 撒旦之邪力
+      ],
+      [ItemTier.T4]: [
+        'item_black_king_bar_2', // 天神杖
+        'item_monkey_king_bar_2', // 定海神针
+        'item_infernal_desolator', // 绝对破防之刃
+        'item_wasp_golden', // 黄金大核荣耀
+        'item_undying_heart', // 不朽之心
+        'item_sacred_six_vein', // 六脉神剑
+        'item_excalibur', // EX咖喱棒
+        'item_refresh_core', // 熔火核心
+        'item_sange_and_yasha_1', // 神器·散夜对剑
+      ],
+      [ItemTier.T5]: [
+        'item_rapier_ultra_bot_1', // 解放的诅咒圣剑
+        'item_switchable_crit_blade', // 归海一刀
+        'item_ten_thousand_swords', // 万剑归宗
+        'item_magic_sword', // 魔渊剑
+        'item_withered_spring', // 生命之心
+        'item_beast_shield', // 兽化盾
+        'item_dracula_mask', // 生命之盔
+        'item_swift_glove', // 无限手套
+        'item_time_gem', // 时间宝石
       ],
     },
   },

--- a/src/vscripts/ai/build-item/item-tier-config.ts
+++ b/src/vscripts/ai/build-item/item-tier-config.ts
@@ -74,6 +74,12 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     tier: ItemTier.T1,
     cost: 500,
   },
+  item_talisman_of_evasion: {
+    name: 'item_talisman_of_evasion',
+    nameCN: '闪避护符',
+    tier: ItemTier.T1,
+    cost: 1300,
+  },
   item_quelling_blade_2_datadriven: {
     name: 'item_quelling_blade_2_datadriven',
     nameCN: '毒瘤之刃',
@@ -209,6 +215,12 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     tier: ItemTier.T2,
     cost: 2150,
   },
+  item_eagle: {
+    name: 'item_eagle',
+    nameCN: '鹰歌弓',
+    tier: ItemTier.T2,
+    cost: 2800,
+  },
   item_vladmir: {
     name: 'item_vladmir',
     nameCN: '弗拉迪米尔的祭品',
@@ -304,6 +316,12 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     tier: ItemTier.T2,
     cost: 2875,
     upgrades: ['item_abyssal_blade', 'item_abyssal_blade_v2'],
+  },
+  item_diffusal_blade: {
+    name: 'item_diffusal_blade',
+    nameCN: '净魂之刃',
+    tier: ItemTier.T2,
+    cost: 2500,
   },
 
   // 高价T2装备
@@ -808,6 +826,13 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     prerequisite: 'item_butterfly',
     upgrades: ['item_wasp_golden'],
   },
+  item_hydras_breath: {
+    name: 'item_hydras_breath',
+    nameCN: '怪蛇之息',
+    tier: ItemTier.T3,
+    cost: 5900,
+    upgrades: ['item_hydras_breath_2'],
+  },
 
   // ===== T4: 后期装备 (10000-30000金) =====
   item_shotgun_v2: {
@@ -926,6 +951,20 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     cost: 13800,
     prerequisite: 'item_heart',
   },
+  item_hydras_breath_2: {
+    name: 'item_hydras_breath_2',
+    nameCN: '神器·千年毒蛟之息',
+    tier: ItemTier.T4,
+    cost: 20000,
+    prerequisite: 'item_hydras_breath',
+  },
+  item_armlet_artifact: {
+    name: 'item_armlet_artifact',
+    nameCN: '神器·光暗臂章',
+    tier: ItemTier.T4,
+    cost: 18500,
+    prerequisite: 'item_armlet_pro_max',
+  },
   item_shivas_guard_2: {
     name: 'item_shivas_guard_2',
     nameCN: '雅典娜的守护',
@@ -946,6 +985,13 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     tier: ItemTier.T4,
     cost: 14000,
     prerequisite: 'item_sange_and_yasha',
+  },
+  item_yasha_and_kaya_1: {
+    name: 'item_yasha_and_kaya_1',
+    nameCN: '神器·慧夜对剑',
+    tier: ItemTier.T4,
+    cost: 14000,
+    prerequisite: 'item_yasha_and_kaya',
   },
   item_gungir_2: {
     name: 'item_gungir_2',

--- a/src/vscripts/ai/build-item/item-tier-config.ts
+++ b/src/vscripts/ai/build-item/item-tier-config.ts
@@ -74,12 +74,6 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     tier: ItemTier.T1,
     cost: 500,
   },
-  item_talisman_of_evasion: {
-    name: 'item_talisman_of_evasion',
-    nameCN: '闪避护符',
-    tier: ItemTier.T1,
-    cost: 1300,
-  },
   item_quelling_blade_2_datadriven: {
     name: 'item_quelling_blade_2_datadriven',
     nameCN: '毒瘤之刃',
@@ -215,12 +209,6 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     tier: ItemTier.T2,
     cost: 2150,
   },
-  item_eagle: {
-    name: 'item_eagle',
-    nameCN: '鹰歌弓',
-    tier: ItemTier.T2,
-    cost: 2800,
-  },
   item_vladmir: {
     name: 'item_vladmir',
     nameCN: '弗拉迪米尔的祭品',
@@ -316,12 +304,6 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     tier: ItemTier.T2,
     cost: 2875,
     upgrades: ['item_abyssal_blade', 'item_abyssal_blade_v2'],
-  },
-  item_diffusal_blade: {
-    name: 'item_diffusal_blade',
-    nameCN: '净魂之刃',
-    tier: ItemTier.T2,
-    cost: 2500,
   },
 
   // 高价T2装备

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -68,6 +68,11 @@ export class BotBaseAIModifier extends BaseModifier {
     ['npc_dota_hero_bane']: true,
     ['npc_dota_hero_bloodseeker']: true,
     ['npc_dota_hero_bounty_hunter']: true,
+    ['npc_dota_hero_drow_ranger']: true,
+    ['npc_dota_hero_riki']: true,
+    ['npc_dota_hero_sven']: true,
+    ['npc_dota_hero_vengefulspirit']: true,
+    ['npc_dota_hero_viper']: true,
   };
 
   /** 当前英雄是否使用新出装系统 */


### PR DESCRIPTION
## Issue

无关联 Issue，基于 bot 出装统计 CSV 的候选池优化。

## Checklist

- [x] I have tested the changes works well.

## 改动说明

将冥界亚龙(Viper)、复仇之魂(Vengeful Spirit)、斯温(Sven)、力丸(Riki)、卓尔游侠(Drow Ranger)迁移到新的基于 Tier 的出装系统，并根据出装统计 CSV（Bot + 玩家）为每个英雄的 T1-T5 候选池扩充到 7~9 件装备。

- `hero-build-config.ts`：新增 `npc_dota_hero_viper`、`npc_dota_hero_vengefulspirit`、`npc_dota_hero_sven`、`npc_dota_hero_riki` 配置，扩充 `npc_dota_hero_drow_ranger` 的 T1/T2/T3/T5（原有 T3/T4 条目保留）
- `bot-base.ts` / `events.lua`：五个英雄注册进 `NEW_BUILD_SYSTEM_HEROES` / `excludeHeroes`，正式启用新出装系统
- `item-tier-config.ts`：新增 2 件此前完全未收录、CSV 信号很强的真实装备——`item_hydras_breath`/`item_hydras_breath_2`(怪蛇之息/神器·千年毒蛟之息)、`item_armlet_artifact`(神器·光暗臂章，本轮未被任何英雄选中但已收录供后续使用)；`cost` 取自 CSV「Average 金钱」列或已有 KV 定义，`tier` 按价格区间表推算
- **修正**：`item_diffusal_blade`(净魂之刃)、`item_eagle`(鹰歌弓)、`item_talisman_of_evasion`(闪避护符)最初根据 CSV 信号被收录，但发现它们都在 `sell-item-config.ts` 的 `SellItemCommonJunkList` 里——背包超过出售阈值时会被无条件半价甩卖，不管是不是本次 tier 特意买的，等于白买，已从候选池和 `item-tier-config.ts` 中移除
- 同时修正了 `hero-build-config-template.ts` 的 `MagicalCarryTemplate` T2 池里同样问题的裸 `item_kaya`（也在垃圾出售名单里），该模板由莉娜、暗影萨满等法系核心英雄共享；此项 Release Note 已写在 #2193（同一 bug 的原始发现处），此处不重复
- **修正**：复仇之魂、卓尔游侠的 T3 池最初同时包含 `item_wasp_callous`(大核荣耀冷酷) 与
  `item_wasp_despotic`(大核荣耀暴虐)——两者是 `item_butterfly` 的平行升级分支，互不顶替出售
  （`ItemUpgradeReplacements` 里没有互相替代关系），会被同一 tier 同时买下浪费金钱，已各自保留信号
  更强的大核荣耀冷酷；顺带扫描了全部 8 个已迁移英雄，确认没有其他"共享同一前置装备"的平行分支冲突
- 鞋子互斥：五个英雄均选定动力鞋，候选池内不与其他鞋子并存
- 已跑一致性校验脚本（tier 归属 + 鞋子互斥 + 共享前置的平行分支互斥）与 `npx eslint` / `npx jest src/vscripts/ai/build-item`，均通过

### 候选池明细（按英雄、Tier，装备中文名）

**冥界亚龙 Viper**（模板：AgilityCarryRanged）

| Tier | 装备 |
|---|---|
| T1 | 动力鞋、怨灵细带、空灵挂件、先锋盾、护腕、猎鹰战刃、魔杖、金手指 |
| T2 | 散夜对剑、远行鞋、团队之手、飓风长戟、黑皇杖、黯灭、希瓦的守护、以太透镜2 |
| T3 | 黄金魔龙枪Ultimate、大核荣耀冷酷、三管霰弹枪、怪蛇之息、黯灭头、三叉戟、圣焰之光、雷神之锤 |
| T4 | 定海神针、天神杖、黄金大核荣耀、熔火核心、粘妈之眼、EX咖喱棒、六脉神剑、绝对破防之刃、神器·千年毒蛟之息 |
| T5 | 解放的诅咒圣剑、鹰眼炮台、无限手套、时间宝石、万剑归宗、归海一刀、魔龙狂舞、兽化甲、魔渊剑 |

**复仇之魂 Vengeful Spirit**（模板：AgilityCarryRanged）

| Tier | 装备 |
|---|---|
| T1 | 动力鞋、怨灵细带、猎鹰战刃、魔杖、金手指、疯狂面具、灵魂之戒 |
| T2 | 黯灭、散夜对剑、团队之手、飓风长戟、黑皇杖、狂战斧、双管霰弹枪、金箍棒 |
| T3 | 大推推（黄金魔龙枪Ultimate）、大核荣耀冷酷、黯灭头、三管霰弹枪、怪蛇之息、雷神之锤、三叉戟 |
| T4 | 定海神针、绝对破防之刃、天神杖、黄金大核荣耀、粘妈之眼、EX咖喱棒、神器·千年毒蛟之息、六脉神剑、救世狂战 |
| T5 | 解放的诅咒圣剑、鹰眼炮台、无限手套、魔渊剑、归海一刀、万剑归宗、兽化盾、时间宝石、生命之盔 |

**斯温 Sven**（模板：StrengthTank）

| Tier | 装备 |
|---|---|
| T1 | 动力鞋、护腕、毒瘤之刃、疯狂面具、先锋盾、猎鹰战刃、魔杖、金手指、怨灵细带 |
| T2 | 散夜对剑、闪烁匕首、音速战刃、黑皇杖、团队之手、黯灭、金箍棒、小鸡臂章Plus |
| T3 | 强袭祭品、大核荣耀暴虐、小鸡臂章Pro Max、黯灭头、代达罗斯之殇、三叉戟、恐鳌之心、撒旦之邪力 |
| T4 | 天神杖、定海神针、绝对破防之刃、黄金大核荣耀、不朽之心、六脉神剑、EX咖喱棒、熔火核心、神器·散夜对剑 |
| T5 | 解放的诅咒圣剑、归海一刀、万剑归宗、魔渊剑、生命之心、兽化盾、生命之盔、无限手套、时间宝石 |

**力丸 Riki**（模板：AgilityCarryMelee）

| Tier | 装备 |
|---|---|
| T1 | 动力鞋、怨灵细带、猎鹰战刃、魔杖、金手指、毒瘤之刃、先锋盾 |
| T2 | 狂战斧、散夜对剑、碎颅锤、团队之手、黯灭、玲珑心、以太透镜2、金箍棒 |
| T3 | 代达罗斯之殇、黯灭头、蝴蝶刀、大核荣耀暴虐、三叉戟、圣焰之光、撒旦之邪力 |
| T4 | 定海神针、绝对破防之刃、苍蓝幻想、神器·散夜对剑、一闪、真红·撒旦之邪力、EX咖喱棒、救世狂战、熔火核心 |
| T5 | 解放的诅咒圣剑、魔渊剑、归海一刀、时间宝石、万剑归宗、禁忌法杖、魔龙狂舞、生命之盔、无限手套 |

**卓尔游侠 Drow Ranger**（模板：AgilityCarryRanged）

| Tier | 装备 |
|---|---|
| T1 | 动力鞋、怨灵细带、金手指、猎鹰战刃、疯狂面具、魔杖、护腕 |
| T2 | 飓风长戟、团队之手、黯灭、原力法杖、黑皇杖、双管霰弹枪、散夜对剑、金箍棒、以太透镜2 |
| T3 | 大推推（黄金魔龙枪Ultimate）、三管霰弹枪、蝴蝶刀、怪蛇之息、黯灭头、大核荣耀冷酷、雷神之锤、三叉戟 |
| T4 | 定海神针、圣剑、真·撒旦、真·BKB、绝对破防之刃、黄金大核荣耀、六脉神剑、神器·千年毒蛟之息、神器·散夜对剑 |
| T5 | 鹰眼炮台、归海一刀、无限手套、万剑归宗、生命之盔、兽化盾、时间宝石、解放的诅咒圣剑、魔渊剑 |

## Release Note

```
[b]游戏性更新 v5.40[/b]

- 优化电脑(BOT)冥界亚龙，复仇之魂，斯温，力丸，卓尔游侠的出装逻辑，装备选择更丰富、更贴合英雄定位
```

```
[b]Gameplay update v5.40[/b]

- Improved bot item builds for Viper, Vengeful Spirit, Sven, Riki, and Drow Ranger with a wider, more fitting range of item choices
```
