### PR TITLE
Add Windrunner awaken ability

### DIFF
--- a/.claude/skills/awaken-ability/SKILL.md
+++ b/.claude/skills/awaken-ability/SKILL.md
@@ -162,6 +162,8 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
 
 > **关键坑：key 必须是 `special_bonus_` 前缀的技能名**。引擎靠前缀识别哪些子 key 是「bonus 覆盖」，非此前缀的子 key 被当无关元数据**静默忽略**（数值不变，无报错）。觉醒技能即使是普通可学习主动技（如 PA `special_bonus_unique_phantom_assassin_upgrade` 是 `UNIT_TARGET` 主动），只要名字带前缀就能当 key；反之，不带前缀的觉醒技能名（如曾用的 `sniper_assassinate_upgrade`）写进去不生效，须把觉醒技能**重命名**为 `special_bonus_unique_*`（连带改抽奖池引用、Lua 类名、本地化 key；ScriptFile 路径/Lua 文件名可不动，仅同步文件内 ability 类名）。该 key 技能还须被英雄拥有且等级 ≥ 1 才应用。
 
+> **动手前必查：一个 value 块只能有一个 `special_bonus_` key**。选定目标数值前，先按 `update-abilities-override` skill 的方法读该技能整段（override 差分 + `docs/reference/<version>/heroes/` 原版全集），确认目标 value 块**没有**已被占用的 `special_bonus_unique_*`（常见来源：原版天赋、其它觉醒）。若已占用（如 `windrunner_shackleshot` 的 `stun_duration` 已挂天赋 `special_bonus_unique_windranger_6`），该字段不能再挂第二个 special_bonus key 作觉醒专属加强，需换一个未被占用的字段，或改用其它实现方式（DataDriven Modifiers / TS）。
+
 > 参考：PA 觉醒后潜匿之刺 `dagger_speed` 1200→2100；狙击手 `special_bonus_unique_sniper_assassinate_upgrade` 觉醒后爆头 `proc_chance` `=100`。
 
 ### 进阶 5：加魔免但不顶替真 BKB
@@ -190,6 +192,31 @@ ApplyAwakenMagicImmunity(unit, ability, duration)
   - **TS/Lua 脚本类 modifier**（`ability_lua` + `GetIntrinsicModifierName`，如进阶 3 的监听型觉醒）：数值若会变化（随等级、天赋等），**不要写死**——用 `MODIFIER_PROPERTY_TOOLTIP` 动态取值：`DeclareFunctions` 加 `ModifierFunction.TOOLTIP`，实现 `OnTooltip(): number` 返回目标值（如 `this.GetAbility()?.GetSpecialValueFor('xxx') ?? 0`），本地化里用 `%dMODIFIER_PROPERTY_TOOLTIP%%%` 占位（同一 modifier 最多两个动态值，第二个用 `MODIFIER_PROPERTY_TOOLTIP2`/`OnTooltip2`/`%dMODIFIER_PROPERTY_TOOLTIP2%`）。只有真正固定不变的数值才写死。**`%dMODIFIER_PROPERTY_TOOLTIP%` 不会像 ability 的 `%key%` 一样自动套白色粗体**（实测），需要手动包 `<font color='#FFFFFF'><b>...</b></font>`，和写死数值的处理方式一样。
 
 > 参考：寒冬飞龙觉醒 `special_bonus_unique_winter_wyvern_upgrade`（DataDriven 写死数值）；卓尔游侠裂影箭觉醒 `special_bonus_unique_drow_ranger_upgrade`（TS modifier，分裂概率会被天赋提升，用 `OnTooltip` 动态显示而非写死）。
+
+### 进阶 7：借用原生 hardcoded modifier（如隐身）实现效果
+
+某些效果（如隐身）引擎有原生硬编码 modifier 支撑，但目标 KV 里查不到 `Modifiers` 块（完全编译进引擎，无法照抄），仍可在 TS 里直接 `AddNewModifier` 按名字借用：
+
+```ts
+const invis = parent.AddNewModifier(parent, this.GetAbility(), 'modifier_riki_backstab', {
+  duration,
+  fade_delay: fadeDelay,
+});
+```
+
+`duration` 参数通常能让原生 modifier 自动到期（如 `modifier_black_king_bar_immune`）。**若实机验证发现某个借用的原生 modifier 不吃 `duration` 自动移除**，改用 `Timers.CreateTimer(duration, callback)` 手动 `Destroy()`，`callback` 内先 `IsNull()` 判空再 `Destroy()`（防止已被其它途径提前移除时重复调用报错）：
+
+```ts
+if (!invis) return;
+Timers.CreateTimer(duration, () => {
+  if (invis.IsNull()) return;
+  invis.Destroy();
+});
+```
+
+原生 modifier 内部可能还支持其它同名参数覆写（如本例 `fade_delay`），具体哪些参数生效、哪些字段该从自身觉醒技能 KV 读取（而非硬编码），**没有文档，只能靠实机反复验证**，不要凭一次测试结果下结论。
+
+> 参考：风行者觉醒 `special_bonus_unique_windrunner_upgrade` 借用隐刺 `modifier_riki_backstab`。
 
 ---
 

--- a/.claude/skills/awaken-ability/SKILL.md
+++ b/.claude/skills/awaken-ability/SKILL.md
@@ -144,6 +144,8 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
 
 > **关键坑**：不要为了让 listener 常驻而给主动技 `AbilityBehavior` 叠加 `DOTA_ABILITY_BEHAVIOR_PASSIVE`——实测会使该主动技**无法施放**。DataDriven 的 `Passive` modifier 不依赖技能 behavior 即可常驻，保持原主动 behavior 即可。
 
+> **关键坑**：`OnAbilityExecuted` 的 `RunScript` 里若要再给自己加一个**同一技能 KV `Modifiers` 里定义的** DataDriven modifier（如限时减伤 buff），必须用 `ability:ApplyDataDrivenModifier(caster, target, "modifier_name", {})`，**不能**用通用的 `unit:AddNewModifier(...)`——用 `AddNewModifier` 加载 DataDriven 定义的 modifier 时，**modifier 本身不会被加载**（不是 KV 占位符解析失败，是整个 modifier 都没生效），buff 图标不会出现在状态栏。`AddNewModifier` 只适用于借用别的技能/原生 hardcoded modifier（见进阶 7），不适用于自己 KV 里定义的 DataDriven modifier。
+
 > 参考：影魔 `ability_lua` + `GetIntrinsicModifierName` 监听 `nevermore_requiem`；PA `ability_datadriven`（`UNIT_TARGET`，未加 PASSIVE）的 `modifier_pa_awaken_dagger_listener` 用 `OnAbilityExecuted`；宙斯 `special_bonus_unique_zuus_upgrade` 是 PASSIVE datadriven 监听范例。
 
 ### 进阶 4：数值仅觉醒后生效（special_bonus 关联）
@@ -158,7 +160,7 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
 }
 ```
 
-`=值` 覆盖、`+值` 增加。引擎检测英雄拥有该 key 同名技能时自动应用。
+`=值` 覆盖、`+值` 增加，此外还支持 `+N%` 按百分比增加（如 `+100%` 表示翻倍，项目里已有大量原版天赋先例，如 `special_bonus_unique_dragon_knight_9 "+120%"`）——多档位字段要整体等比缩放时用这个，不需要手算每档绝对值再写数组。引擎检测英雄拥有该 key 同名技能时自动应用。
 
 > **关键坑：key 必须是 `special_bonus_` 前缀的技能名**。引擎靠前缀识别哪些子 key 是「bonus 覆盖」，非此前缀的子 key 被当无关元数据**静默忽略**（数值不变，无报错）。觉醒技能即使是普通可学习主动技（如 PA `special_bonus_unique_phantom_assassin_upgrade` 是 `UNIT_TARGET` 主动），只要名字带前缀就能当 key；反之，不带前缀的觉醒技能名（如曾用的 `sniper_assassinate_upgrade`）写进去不生效，须把觉醒技能**重命名**为 `special_bonus_unique_*`（连带改抽奖池引用、Lua 类名、本地化 key；ScriptFile 路径/Lua 文件名可不动，仅同步文件内 ability 类名）。该 key 技能还须被英雄拥有且等级 ≥ 1 才应用。
 
@@ -187,11 +189,12 @@ ApplyAwakenMagicImmunity(unit, ability, duration)
 - KV：`AbilityBehavior` 加 `DOTA_ABILITY_BEHAVIOR_HIDDEN`（不进技能栏），同时加一个 `Modifiers` 子块，子 modifier 设 `"Passive" "1"` + `"IsHidden" "0"`（非隐藏，展示为常驻 buff 图标，自动复用 `AbilityTextureName` 做图标）。
 - 本地化：ability 自身的 `DOTA_Tooltip_ability_<name>` / `_Description` **保留不删**——觉醒预览页 `AwakenTab.tsx` 用 `DOTAAbilityImage` 读取的是 ability 的 tooltip，不是 modifier 的。额外补一组 `DOTA_Tooltip_modifier_<modifier_name>` / `_Description`，内容与 ability 标题/描述完全一致，确保游玩时看到的 buff tooltip 与觉醒页说明一致。
 - modifier 描述里若有写死的字面 `%` 号，**同样要转义成 `%%`**（不要因为是 modifier 就漏掉，规则与正文一致，见 CLAUDE.md 本地化文案规约）。
-- **modifier tooltip 不支持直接 `%key%` 读取 ability 的 `AbilityValues`**（会显示空白或吞掉百分号）；ability 自身的描述不受影响，仍可正常用 `%key%`。modifier 这边按实现方式分两种处理：
-  - **DataDriven 标记技能**（本节默认场景，KV `Modifiers` 子块、无脚本）：没有代码可补，描述里**写死成具体数字**。
-  - **TS/Lua 脚本类 modifier**（`ability_lua` + `GetIntrinsicModifierName`，如进阶 3 的监听型觉醒）：数值若会变化（随等级、天赋等），**不要写死**——用 `MODIFIER_PROPERTY_TOOLTIP` 动态取值：`DeclareFunctions` 加 `ModifierFunction.TOOLTIP`，实现 `OnTooltip(): number` 返回目标值（如 `this.GetAbility()?.GetSpecialValueFor('xxx') ?? 0`），本地化里用 `%dMODIFIER_PROPERTY_TOOLTIP%%%` 占位（同一 modifier 最多两个动态值，第二个用 `MODIFIER_PROPERTY_TOOLTIP2`/`OnTooltip2`/`%dMODIFIER_PROPERTY_TOOLTIP2%`）。只有真正固定不变的数值才写死。**`%dMODIFIER_PROPERTY_TOOLTIP%` 不会像 ability 的 `%key%` 一样自动套白色粗体**（实测），需要手动包 `<font color='#FFFFFF'><b>...</b></font>`，和写死数值的处理方式一样。
+- **modifier tooltip 不支持直接 `%key%` 读取 ability 的 `AbilityValues`**（会显示空白或吞掉百分号）；ability 自身的描述不受影响，仍可正常用 `%key%`。modifier 这边按实现方式分三种处理：
+  - **DataDriven 且数值挂在内置 `MODIFIER_PROPERTY_*`**（如 `MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE`、`MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT` 等标准属性，`Properties` 块里已声明）：**可以**直接动态取值，本地化写 `%dMODIFIER_PROPERTY_<属性名>%%%` 即可，引擎自动读取该 modifier 当前的属性值，**不需要**任何 RunScript/OnTooltip 代码，也**不需要**手动包白色粗体（项目里已有先例：`monkey_king_defy`、`insight_armor_aura`）。
+  - **DataDriven 且数值不对应任何内置 Property**（纯标记技能、无脚本）：没有代码可补，描述里**写死成具体数字**。
+  - **TS/Lua 脚本类 modifier**（`ability_lua` + `GetIntrinsicModifierName`，如进阶 3 的监听型觉醒）：数值若会变化（随等级、天赋等），**不要写死**——用 `MODIFIER_PROPERTY_TOOLTIP` 动态取值：`DeclareFunctions` 加 `ModifierFunction.TOOLTIP`，实现 `OnTooltip(): number` 返回目标值（如 `this.GetAbility()?.GetSpecialValueFor('xxx') ?? 0`），本地化里用 `%dMODIFIER_PROPERTY_TOOLTIP%%%` 占位（同一 modifier 最多两个动态值，第二个用 `MODIFIER_PROPERTY_TOOLTIP2`/`OnTooltip2`/`%dMODIFIER_PROPERTY_TOOLTIP2%`）。只有真正固定不变的数值才写死。**`%dMODIFIER_PROPERTY_TOOLTIP%` 不会像 ability 的 `%key%` 一样自动套白色粗体**（实测），需要手动包 `<font color='#FFFFFF'><b>...</b></font>`，和写死数值的处理方式一样（这条仅限自定义 `TOOLTIP`/`TOOLTIP2`，内置 Property 不受影响）。
 
-> 参考：寒冬飞龙觉醒 `special_bonus_unique_winter_wyvern_upgrade`（DataDriven 写死数值）；卓尔游侠裂影箭觉醒 `special_bonus_unique_drow_ranger_upgrade`（TS modifier，分裂概率会被天赋提升，用 `OnTooltip` 动态显示而非写死）。
+> 参考：寒冬飞龙觉醒 `special_bonus_unique_winter_wyvern_upgrade`（DataDriven 写死数值）；卓尔游侠裂影箭觉醒 `special_bonus_unique_drow_ranger_upgrade`（TS modifier，分裂概率会被天赋提升，用 `OnTooltip` 动态显示而非写死）；发条技师觉醒 `special_bonus_unique_rattletrap_upgrade_shield`（DataDriven 内置 Property 动态取值，`%dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%`）。
 
 ### 进阶 7：借用原生 hardcoded modifier（如隐身）实现效果
 

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1203,6 +1203,12 @@
 		"DOTA_Tooltip_ability_kunkka_torrent_storm_Description"		"Releases a Torrent in a random area within %torrent_max_distance% range of the target position once every %torrent_interval% for %torrent_duration% seconds."
 		"DOTA_Tooltip_ability_kunkka_torrent_storm_Lore"			"A hundred leagues of dry land couldn't keep these seas at bay."
 
+		// Windrunner Awakened
+		"DOTA_Tooltip_ability_special_bonus_unique_windrunner_upgrade"					"<font color='#d000ff'>Windrun Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_windrunner_upgrade_Description"		"Casting Windrun grants <font color='#d7ccc7'>invisibility</font> for the same duration as Windrun. Attacking an enemy briefly reveals Windrunner before she fades back into invisibility. Moving does not break invisibility.<br>Powershot damage is increased by <font color='#FFFFFF'><b>100%%</b></font>."
+		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade"					"<font color='#d000ff'>Windrun Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade_Description"		"Casting Windrun grants <font color='#d7ccc7'>invisibility</font> for the same duration as Windrun. Attacking an enemy briefly reveals Windrunner before she fades back into invisibility. Moving does not break invisibility.<br>Powershot damage is increased by <font color='#FFFFFF'><b>100%%</b></font>."
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1217,6 +1217,14 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"Power Cogs Awakened"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"Damage taken is reduced by %dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%."
 
+		// Sven Awakened
+		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>Sven Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade_Description"		"Casting Storm Hammer grants <font color='#FFCC66'>Magic Immunity</font> for %duration% seconds, increasing Strength by %strength_bonus% and Attack Speed by %attackspeed_bonus% during that time."
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>Sven Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_Description"		"Casting Storm Hammer grants <font color='#FFCC66'>Magic Immunity</font> and briefly increases Strength and Attack Speed."
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff"				"Sven Awakened"
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff_Description"	"Strength increased by %dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS% and Attack Speed by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%."
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1209,6 +1209,14 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade"					"<font color='#d000ff'>Windrun Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade_Description"		"Casting Windrun grants <font color='#d7ccc7'>invisibility</font> for the same duration as Windrun. Attacking an enemy briefly reveals Windrunner before she fades back into invisibility. Moving does not break invisibility.<br>Powershot damage is increased by <font color='#FFFFFF'><b>100%%</b></font>."
 
+		// Clockwerk Awakened
+		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>Power Cogs Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade_Description"		"Casting Power Cogs grants <font color='#FFCC66'>Magic Immunity</font> for <font color='#FFFFFF'><b>3</b></font> seconds, reducing damage taken by <font color='#FFFFFF'><b>60%%</b></font> during that time."
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>Power Cogs Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_Description"		"Casting Power Cogs grants <font color='#FFCC66'>Magic Immunity</font> for <font color='#FFFFFF'><b>3</b></font> seconds, reducing damage taken by <font color='#FFFFFF'><b>60%%</b></font> during that time."
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"Power Cogs Awakened"
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"Damage taken is reduced by %dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%."
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1201,6 +1201,12 @@
 		"DOTA_Tooltip_ability_kunkka_torrent_storm_Description"		"在目标地点%torrent_max_distance%范围内，每%torrent_interval%秒在一个随机区域释放一道洪流，持续%torrent_duration%秒。"
 		"DOTA_Tooltip_ability_kunkka_torrent_storm_Lore"			"一百个陆地的联盟也牵制不了这些滔天海浪。"
 
+		// 风行者-觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_windrunner_upgrade"					"<font color='#d000ff'>风行 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_windrunner_upgrade_Description"		"施放风行时进入<font color='#d7ccc7'>隐身</font>状态，持续时间与风行相同。主动攻击敌人后会短暂显形，随后重新隐身。移动不会破坏隐身状态。<br>强力击伤害提升<font color='#FFFFFF'><b>100%%</b></font>。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade"					"<font color='#d000ff'>风行 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade_Description"		"施放风行时进入<font color='#d7ccc7'>隐身</font>状态，持续时间与风行相同。主动攻击敌人后会短暂显形，随后重新隐身。移动不会破坏隐身状态。<br>强力击伤害提升<font color='#FFFFFF'><b>100%%</b></font>。"
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1207,6 +1207,14 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade"					"<font color='#d000ff'>风行 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_windrunner_upgrade_Description"		"施放风行时进入<font color='#d7ccc7'>隐身</font>状态，持续时间与风行相同。主动攻击敌人后会短暂显形，随后重新隐身。移动不会破坏隐身状态。<br>强力击伤害提升<font color='#FFFFFF'><b>100%%</b></font>。"
 
+		// 发条技师-觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>发条 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade_Description"		"施放能量齿轮后获得<font color='#FFCC66'>技能免疫</font>，持续<font color='#FFFFFF'><b>3</b></font>秒，期间受到的伤害降低<font color='#FFFFFF'><b>60%%</b></font>。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>发条 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_Description"		"施放能量齿轮后获得<font color='#FFCC66'>技能免疫</font>，持续<font color='#FFFFFF'><b>3</b></font>秒，期间受到的伤害降低<font color='#FFFFFF'><b>60%%</b></font>。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"发条 觉醒"
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"受到的伤害降低%dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%。"
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1215,6 +1215,14 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"发条 觉醒"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"受到的伤害降低%dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%。"
 
+		// 斯温-觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>斯温 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade_Description"		"施放风暴之拳后获得<font color='#FFCC66'>技能免疫</font>，持续%duration%秒，期间力量提升%strength_bonus%点，攻击速度提升%attackspeed_bonus%点。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>斯温 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_Description"		"施放风暴之拳后获得<font color='#FFCC66'>技能免疫</font>，并短暂提升力量与攻击速度。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff"				"斯温 觉醒"
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff_Description"	"力量提升%dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS%点，攻击速度提升%dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%点。"
+
 		///////////////////////////////////////////////////
 		//
 		// 					Heroes Override 原版英雄技能

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -513,4 +513,51 @@
 			"fade_delay"					"0.2"
 		}
 	}
+
+	// 发条技师-觉醒
+	"special_bonus_unique_rattletrap_upgrade"
+	{
+		"BaseClass"						"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"rattletrap_power_cogs"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"duration"				"3"
+			"damage_reduction_pct"	"-60"
+		}
+
+		"Modifiers"
+		{
+			"modifier_special_bonus_unique_rattletrap_upgrade"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsPurgable"		"0"
+				"RemoveOnDeath"		"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"OnAbilityExecuted"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"abilities/special_bonus_unique_rattletrap_upgrade"
+						"Function"		"OnCogsCast"
+					}
+				}
+			}
+
+			"modifier_special_bonus_unique_rattletrap_upgrade_shield"
+			{
+				"IsBuff"		"1"
+				"Duration"		"%duration"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE"	"%damage_reduction_pct"
+				}
+			}
+		}
+	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -560,4 +560,54 @@
 			}
 		}
 	}
+
+	// 斯温-觉醒
+	"special_bonus_unique_sven_upgrade"
+	{
+		"BaseClass"						"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"sven_storm_bolt"
+		"MaxLevel"						"5"
+		"LinkedAbility"					"sven_storm_bolt"	// 双向联动同步升级
+
+		"AbilityValues"
+		{
+			"duration"				"2"
+			"strength_bonus"		"20 40 60 80 100"
+			"attackspeed_bonus"	"20 40 60 80 100"
+		}
+
+		"Modifiers"
+		{
+			"modifier_special_bonus_unique_sven_upgrade"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsPurgable"		"0"
+				"RemoveOnDeath"		"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"OnAbilityExecuted"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"abilities/special_bonus_unique_sven_upgrade"
+						"Function"		"OnStormBoltCast"
+					}
+				}
+			}
+
+			"modifier_special_bonus_unique_sven_upgrade_buff"
+			{
+				"IsBuff"		"1"
+				"Duration"		"%duration"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_STATS_STRENGTH_BONUS"			"%strength_bonus"
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT"		"%attackspeed_bonus"
+				}
+			}
+		}
+	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -349,7 +349,6 @@
 
 	// 巫医 神语-觉醒
 	// 死亡守卫/变身术守卫被召唤时，攻击力按巫医当前技能增强% 提升
-	// 不在 castbar 显示，改用常驻 buff 图标展示，说明仍读 ability tooltip 用于觉醒页面
 	"special_bonus_unique_witch_doctor_upgrade"
 	{
 		"BaseClass"						"ability_datadriven"
@@ -387,8 +386,6 @@
 	}
 
 	// 影魔 魂之挽歌护体-觉醒
-	// 新增被动：释放魂之挽歌前摇期间获得魔法免疫；提升支配死灵击杀英雄灵魂=10、小兵=3（见 override 联动）；提升施法速度降低暗影压制与魂之挽歌抬手
-	// 不在 castbar 显示，改用常驻 buff 图标展示，说明仍读 ability tooltip 用于觉醒页面
 	"special_bonus_unique_nevermore_upgrade"
 	{
 		"BaseClass"						"ability_lua"
@@ -406,7 +403,6 @@
 
 	// 莉娜 神灭斩-觉醒
 	// 新增被动：每次施放神灭斩，对目标额外造成等同大招当前伤害的纯粹伤害（吃技能增强）
-	// 不在 castbar 显示，改用常驻 buff 图标展示，说明仍读 ability tooltip 用于觉醒页面
 	"special_bonus_unique_lina_upgrade"
 	{
 		"BaseClass"						"ability_lua"
@@ -418,8 +414,6 @@
 
 	// 卓尔游侠 裂影箭-觉醒
 	// 新增被动：普攻有概率分裂出数支箭射向主目标周围的敌人，造成本次攻击伤害的百分比并附带霜冻箭减速
-	// 技能名同时作 special_bonus key 挂回 marksmanship，使精准箭触发概率提升（见 override 联动）
-	// 不在 castbar 显示，改用常驻 buff 图标展示，说明仍读 ability tooltip 用于觉醒页面
 	"special_bonus_unique_drow_ranger_upgrade"
 	{
 		"BaseClass"						"ability_lua"
@@ -463,8 +457,7 @@
 		"MaxLevel"						"1"
 	}
 
-	// 齐天大圣-觉醒（纯 KV 标记：special_bonus 键挂在大招 awaken_enabled 与如意金箍棒 override）
-	// 不在 castbar 显示，改用常驻 buff 图标展示，说明仍读 ability tooltip 用于觉醒页面
+	// 齐天大圣-觉醒
 	"special_bonus_unique_monkey_king_upgrade"
 	{
 		"BaseClass"						"ability_datadriven"
@@ -485,8 +478,7 @@
 		}
 	}
 
-	// 寒冬飞龙-觉醒（纯 KV 标记：special_bonus 键挂在寒冬诅咒 transfer_on_death/transfer_duration_pct override）
-	// 不在 castbar 显示，改用常驻 buff 图标展示，说明仍读 ability tooltip 用于觉醒页面
+	// 寒冬飞龙-觉醒
 	"special_bonus_unique_winter_wyvern_upgrade"
 	{
 		"BaseClass"						"ability_datadriven"
@@ -504,6 +496,21 @@
 				"RemoveOnDeath"		"0"
 				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
 			}
+		}
+	}
+
+	// 风行者-觉醒
+	"special_bonus_unique_windrunner_upgrade"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_windrunner_upgrade"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"windrunner_windrun"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"fade_delay"					"0.2"
 		}
 	}
 }

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -3866,6 +3866,7 @@
 	{
 		"MaxLevel"						"5"
 		"AbilityDamage"					"80 160 240 320 400"
+		"LinkedAbility"					"special_bonus_unique_sven_upgrade"	// 双向联动同步升级
 		"AbilityValues"
 		{
 				"AbilityCooldown"

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -12141,7 +12141,8 @@
 		{
 				"powershot_damage"
 				{
-					"value"					"170 270 370 470 570"	// 170 270 370 470
+					"value"									"170 270 370 470 570"	// 170 270 370 470
+					"special_bonus_unique_windrunner_upgrade"	"+100%"	// 风行 觉醒
 				}
 				"slow"
 				{

--- a/game/scripts/vscripts/abilities/special_bonus_unique_rattletrap_upgrade.lua
+++ b/game/scripts/vscripts/abilities/special_bonus_unique_rattletrap_upgrade.lua
@@ -1,0 +1,14 @@
+function OnCogsCast(keys)
+	local castedAbility = keys.event_ability
+	if not castedAbility or castedAbility:GetAbilityName() ~= "rattletrap_power_cogs" then
+		return
+	end
+	local caster = keys.caster
+	local awaken = caster:FindAbilityByName("special_bonus_unique_rattletrap_upgrade")
+	if not awaken then
+		return
+	end
+	local duration = awaken:GetSpecialValueFor("duration")
+	ApplyAwakenMagicImmunity(caster, awaken, duration)
+	awaken:ApplyDataDrivenModifier(caster, caster, "modifier_special_bonus_unique_rattletrap_upgrade_shield", {})
+end

--- a/game/scripts/vscripts/abilities/special_bonus_unique_sven_upgrade.lua
+++ b/game/scripts/vscripts/abilities/special_bonus_unique_sven_upgrade.lua
@@ -1,0 +1,14 @@
+function OnStormBoltCast(keys)
+	local castedAbility = keys.event_ability
+	if not castedAbility or castedAbility:GetAbilityName() ~= "sven_storm_bolt" then
+		return
+	end
+	local caster = keys.caster
+	local awaken = caster:FindAbilityByName("special_bonus_unique_sven_upgrade")
+	if not awaken then
+		return
+	end
+	local duration = awaken:GetSpecialValueFor("duration")
+	ApplyAwakenMagicImmunity(caster, awaken, duration)
+	awaken:ApplyDataDrivenModifier(caster, caster, "modifier_special_bonus_unique_sven_upgrade_buff", {})
+end

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -11,56 +11,57 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
  * 列表与 src/common 无关，是 vscripts awaken-config 中 ABILITY_REPLACEMENTS 的展示副本，
  * 增删觉醒英雄时需同步此处。每张卡复用引擎现成资源（英雄头像 + 觉醒图标自带本地化 tooltip）。
  */
+// 新加的英雄排在前面，旧的排在后面（随机卡固定第一个，不受此列表顺序影响）
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string }[] = [
-  { heroName: 'npc_dota_hero_pudge', abilityName: 'pudge_meat_hook_lua' },
-  { heroName: 'npc_dota_hero_juggernaut', abilityName: 'juggernaut_blade_fury_custom' },
   {
-    heroName: 'npc_dota_hero_sniper',
-    abilityName: 'special_bonus_unique_sniper_assassinate_upgrade',
-  },
-  { heroName: 'npc_dota_hero_axe', abilityName: 'axe_auto_culling_blade' },
-  { heroName: 'npc_dota_hero_necrolyte', abilityName: 'necrolyte_heartstopper_aura_datadriven' },
-  { heroName: 'npc_dota_hero_zuus', abilityName: 'special_bonus_unique_zuus_upgrade' },
-  {
-    heroName: 'npc_dota_hero_phantom_assassin',
-    abilityName: 'special_bonus_unique_phantom_assassin_upgrade',
-  },
-  {
-    heroName: 'npc_dota_hero_witch_doctor',
-    abilityName: 'special_bonus_unique_witch_doctor_upgrade',
-  },
-  { heroName: 'npc_dota_hero_nevermore', abilityName: 'special_bonus_unique_nevermore_upgrade' },
-  {
-    heroName: 'npc_dota_hero_drow_ranger',
-    abilityName: 'special_bonus_unique_drow_ranger_upgrade',
-  },
-  {
-    heroName: 'npc_dota_hero_bristleback',
-    abilityName: 'special_bonus_unique_bristleback_upgrade',
-  },
-  { heroName: 'npc_dota_hero_lina', abilityName: 'special_bonus_unique_lina_upgrade' },
-  {
-    heroName: 'npc_dota_hero_monkey_king',
-    abilityName: 'special_bonus_unique_monkey_king_upgrade',
-  },
-  {
-    heroName: 'npc_dota_hero_winter_wyvern',
-    abilityName: 'special_bonus_unique_winter_wyvern_upgrade',
-  },
-  { heroName: 'npc_dota_hero_ogre_magi', abilityName: 'ogre_magi_multicast_lua' },
-  { heroName: 'npc_dota_hero_kunkka', abilityName: 'kunkka_torrent_storm' },
-  {
-    heroName: 'npc_dota_hero_windrunner',
-    abilityName: 'special_bonus_unique_windrunner_upgrade',
+    heroName: 'npc_dota_hero_sven',
+    abilityName: 'special_bonus_unique_sven_upgrade',
   },
   {
     heroName: 'npc_dota_hero_rattletrap',
     abilityName: 'special_bonus_unique_rattletrap_upgrade',
   },
   {
-    heroName: 'npc_dota_hero_sven',
-    abilityName: 'special_bonus_unique_sven_upgrade',
+    heroName: 'npc_dota_hero_windrunner',
+    abilityName: 'special_bonus_unique_windrunner_upgrade',
   },
+  { heroName: 'npc_dota_hero_kunkka', abilityName: 'kunkka_torrent_storm' },
+  { heroName: 'npc_dota_hero_ogre_magi', abilityName: 'ogre_magi_multicast_lua' },
+  {
+    heroName: 'npc_dota_hero_winter_wyvern',
+    abilityName: 'special_bonus_unique_winter_wyvern_upgrade',
+  },
+  {
+    heroName: 'npc_dota_hero_monkey_king',
+    abilityName: 'special_bonus_unique_monkey_king_upgrade',
+  },
+  { heroName: 'npc_dota_hero_lina', abilityName: 'special_bonus_unique_lina_upgrade' },
+  {
+    heroName: 'npc_dota_hero_bristleback',
+    abilityName: 'special_bonus_unique_bristleback_upgrade',
+  },
+  {
+    heroName: 'npc_dota_hero_drow_ranger',
+    abilityName: 'special_bonus_unique_drow_ranger_upgrade',
+  },
+  { heroName: 'npc_dota_hero_nevermore', abilityName: 'special_bonus_unique_nevermore_upgrade' },
+  {
+    heroName: 'npc_dota_hero_witch_doctor',
+    abilityName: 'special_bonus_unique_witch_doctor_upgrade',
+  },
+  {
+    heroName: 'npc_dota_hero_phantom_assassin',
+    abilityName: 'special_bonus_unique_phantom_assassin_upgrade',
+  },
+  { heroName: 'npc_dota_hero_zuus', abilityName: 'special_bonus_unique_zuus_upgrade' },
+  { heroName: 'npc_dota_hero_necrolyte', abilityName: 'necrolyte_heartstopper_aura_datadriven' },
+  { heroName: 'npc_dota_hero_axe', abilityName: 'axe_auto_culling_blade' },
+  {
+    heroName: 'npc_dota_hero_sniper',
+    abilityName: 'special_bonus_unique_sniper_assassinate_upgrade',
+  },
+  { heroName: 'npc_dota_hero_juggernaut', abilityName: 'juggernaut_blade_fury_custom' },
+  { heroName: 'npc_dota_hero_pudge', abilityName: 'pudge_meat_hook_lua' },
 ];
 
 // 与后端 hero-awakening 接口保持一致（固定消耗，不分英雄）

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -57,6 +57,10 @@ const AWAKEN_ABILITIES: { heroName: string; abilityName: string }[] = [
     heroName: 'npc_dota_hero_rattletrap',
     abilityName: 'special_bonus_unique_rattletrap_upgrade',
   },
+  {
+    heroName: 'npc_dota_hero_sven',
+    abilityName: 'special_bonus_unique_sven_upgrade',
+  },
 ];
 
 // 与后端 hero-awakening 接口保持一致（固定消耗，不分英雄）

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -49,6 +49,10 @@ const AWAKEN_ABILITIES: { heroName: string; abilityName: string }[] = [
   },
   { heroName: 'npc_dota_hero_ogre_magi', abilityName: 'ogre_magi_multicast_lua' },
   { heroName: 'npc_dota_hero_kunkka', abilityName: 'kunkka_torrent_storm' },
+  {
+    heroName: 'npc_dota_hero_windrunner',
+    abilityName: 'special_bonus_unique_windrunner_upgrade',
+  },
 ];
 
 // 与后端 hero-awakening 接口保持一致（固定消耗，不分英雄）

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -53,6 +53,10 @@ const AWAKEN_ABILITIES: { heroName: string; abilityName: string }[] = [
     heroName: 'npc_dota_hero_windrunner',
     abilityName: 'special_bonus_unique_windrunner_upgrade',
   },
+  {
+    heroName: 'npc_dota_hero_rattletrap',
+    abilityName: 'special_bonus_unique_rattletrap_upgrade',
+  },
 ];
 
 // 与后端 hero-awakening 接口保持一致（固定消耗，不分英雄）

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_windrunner_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_windrunner_upgrade.ts
@@ -1,0 +1,62 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+/**
+ * 风行者 风行-觉醒：施放风行时借用隐刺的隐身效果，限时生效。
+ */
+@registerAbility('special_bonus_unique_windrunner_upgrade')
+export class SpecialBonusUniqueWindrunnerUpgrade extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return 'modifier_special_bonus_unique_windrunner_upgrade';
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_windrunner_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_windrunner_upgrade extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_ABILITY_FULLY_CAST];
+  }
+
+  OnAbilityFullyCast(event: ModifierAbilityEvent): void {
+    if (!IsServer()) return;
+    const parent = this.GetParent();
+    if (event.unit !== parent) return;
+
+    const ability = event.ability;
+    if (ability.GetAbilityName() !== 'windrunner_windrun') return;
+
+    const duration = ability.GetSpecialValueFor('AbilityDuration');
+    if (duration <= 0) return;
+
+    const selfAbility = this.GetAbility();
+    const fadeDelay = selfAbility?.GetSpecialValueFor('fade_delay') ?? 0;
+
+    const invis = parent.AddNewModifier(parent, selfAbility, 'modifier_riki_backstab', {
+      duration,
+      fade_delay: fadeDelay,
+    });
+    if (!invis) return;
+
+    Timers.CreateTimer(duration, () => {
+      if (invis.IsNull()) return;
+      invis.Destroy();
+    });
+  }
+}

--- a/src/vscripts/ai/team/bot-team.ts
+++ b/src/vscripts/ai/team/bot-team.ts
@@ -17,7 +17,7 @@ export class BotTeam {
   private addAmount: number = 0; // Bot发钱的基础金额
 
   private readonly addAmountBase: number = 1; // Bot发钱的基础金额
-  private readonly addAmountPlayerNumberBonus: number = 0.2; // 每个玩家增加的金额
+  private readonly addAmountPlayerNumberBonus: number = 0.1; // 每个玩家增加的金额
   private readonly addAmountNeedLevel: number = 0.02; // 每玩家等级增加的金额
   private readonly refreshInterval: number = 1; // 刷新策略间隔
 

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.40';
+  public static readonly GAME_VERSION = 'v5.41';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -128,6 +128,12 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
     newAbility: 'special_bonus_unique_windrunner_upgrade',
     newLevel: 1,
   },
+  // 发条技师 觉醒
+  {
+    heroName: 'npc_dota_hero_rattletrap',
+    newAbility: 'special_bonus_unique_rattletrap_upgrade',
+    newLevel: 1,
+  },
 ];
 
 /** 可觉醒英雄名去重列表（随机抽选的英雄池真源） */

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -134,6 +134,13 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
     newAbility: 'special_bonus_unique_rattletrap_upgrade',
     newLevel: 1,
   },
+  // 斯温 觉醒（与风暴之拳 LinkedAbility 同步升级，初始等级继承风暴之拳）
+  {
+    heroName: 'npc_dota_hero_sven',
+    newAbility: 'special_bonus_unique_sven_upgrade',
+    newLevel: 0,
+    inheritLevelFrom: 'sven_storm_bolt',
+  },
 ];
 
 /** 可觉醒英雄名去重列表（随机抽选的英雄池真源） */

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -122,6 +122,12 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
     newAbility: 'kunkka_torrent_storm',
     newLevel: 1,
   },
+  // 风行者 觉醒
+  {
+    heroName: 'npc_dota_hero_windrunner',
+    newAbility: 'special_bonus_unique_windrunner_upgrade',
+    newLevel: 1,
+  },
 ];
 
 /** 可觉醒英雄名去重列表（随机抽选的英雄池真源） */


### PR DESCRIPTION
## Checklist

- [x] I have tested the changes works well.
- [x] 确认 `windrunner_powershot.powershot_damage` 上新加的 `special_bonus_unique_windrunner_upgrade "+100%"` 百分比语法在实机中正确生效（多档位字段，此前未有先例）
- [x] 确认发条觉醒 `modifier_special_bonus_unique_rattletrap_upgrade_shield`（改用 `ApplyDataDrivenModifier` 加载后）能在状态栏正确显示，且减伤/魔免窗口随能量齿轮释放正确触发
- [x] 确认斯温觉醒 `LinkedAbility` 双向联动是否正确同步风暴之拳等级，力量/攻速加成随等级正确显示（`%dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS%` / `%dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%`）

## Release Note

```
[b]游戏性更新 v5.41[/b]

- 新增风行者觉醒：施放风行时进入隐身状态，攻击后短暂显形随后重新隐身，强力击伤害提升100%。
- 新增发条技师觉醒：施放能量齿轮后获得技能免疫，并将受到的伤害降低60%。
- 新增斯温觉醒：施放风暴之拳后获得技能免疫，并短暂提升力量与攻击速度。
```

```
[b]Gameplay update v5.41[/b]

- Added Windranger Awakened: casting Windrun grants invisibility that briefly breaks on attack before fading back in, and Powershot damage is increased by 100%.
- Added Clockwerk Awakened: casting Power Cogs grants Magic Immunity and reduces damage taken by 60%.
- Added Sven Awakened: casting Storm Hammer grants Magic Immunity and briefly increases Strength and Attack Speed.
```
