### PR TITLE
修复命运轮盘自身驱散产生永恒之盘错误特效

### DIFF
--- a/game/scripts/vscripts/abilities/ability_fate_roulette.lua
+++ b/game/scripts/vscripts/abilities/ability_fate_roulette.lua
@@ -259,13 +259,9 @@ function modifier_ability_fate_roulette_counter:PlayRouletteEffect(target, effec
     local ability = self:GetAbility()
     if not ability or ability:IsNull() or not target or target:IsNull() then return end
 
+    -- The purge is gameplay-only. Do not reuse Aeon Disk's looping buff particle here: it can
+    -- leave a golden haze behind and incorrectly suggests that an item effect was triggered.
     parent:Purge(false, true, false, false, false)
-    local dispel_particle = ParticleManager:CreateParticle(
-        "particles/items4_fx/combo_breaker_buff.vpcf",
-        PATTACH_ABSORIGIN_FOLLOW,
-        parent
-    )
-    ParticleManager:ReleaseParticleIndex(dispel_particle)
 
     if effect == FATE_EFFECT_CRITICAL then
         target:EmitSound("Hero_Brewmaster.Brawler.Crit")


### PR DESCRIPTION
## Issue

- No related issue

## Checklist

- [x] `npm run build:vscripts`
- [x] `npm test -- --runInBand`
- [x] `git diff --check`
- [ ] Confirmed the final patch in Dota 2 Tools

## 修改内容

命运轮盘每次触发轮盘效果时都会对施法者执行一次弱驱散。原实现同时复用了永恒之盘的 `combo_breaker_buff.vpcf` 循环粒子，导致未装备永恒之盘或其升级装备时，也可能出现永恒之盘的金色氤氲和地面圆环。

本次修改：

- 保留命运轮盘每次触发时对自身进行一次弱驱散的游戏性效果。
- 移除对永恒之盘循环粒子的错误复用。
- 避免金色氤氲、地面圆环及潜在的粒子残留。
- 不修改命运轮盘的数值、触发频率、轮盘结果、图标、音效和 Tooltip。
- 不修改永恒之盘及其升级装备本身。

## Gameplay / Tooltip / VFX / SFX

- 游戏性：自身弱驱散效果保持不变。
- 数值：无变化。
- Tooltip：无变化。
- 特效：移除命运轮盘错误显示的永恒之盘金色循环特效。
- 音效：无变化。

## 验证

- `npm run build:vscripts`
- `npm test -- --runInBand`
- `git diff --check`

自动测试结果：

- Test Suites: 20 passed, 20 total
- Tests: 205 passed, 205 total

最终补丁尚待再次进行游戏内实测。

## Release Note

```
[b]游戏性更新 v5.00a[/b]

- 修复命运轮盘触发自身驱散时可能错误显示永恒之盘金色特效的问题。
```

```
[b]Gameplay update v5.00a[/b]

- Fixed Fate Roulette incorrectly displaying Aeon Disk's golden visual effect when triggering its self-dispel.
```