### PR TITLE
新增防堵泉机制及自定义开关

### DIFF
--- a/content/panorama/layout/custom_game/custom_loading_screen.xml
+++ b/content/panorama/layout/custom_game/custom_loading_screen.xml
@@ -171,6 +171,11 @@
 						<Label id="MidOnlyModeTitle" class="GameOptionsLabel" text="#mid_only_mode" />
 						<ToggleButton checked="false" class="GameOptionsToggle" id="mid_only_mode" onactivate="SendGameOptionsToServer()"/>
 					</Panel>
+					<!-- 防堵泉机制 -->
+					<Panel id="FountainAntiCampPanel" class="GameOptionsSubPanel">
+						<Label id="FountainAntiCampTitle" class="GameOptionsLabel" text="#enable_fountain_anti_camp" />
+						<ToggleButton checked="false" class="GameOptionsToggle" id="enable_fountain_anti_camp" onactivate="SendGameOptionsToServer()"/>
+					</Panel>
 				</Panel>
 			</Panel>
 			<!-- 游戏选项显示 START-->
@@ -200,7 +205,7 @@
 			</Panel>
 
 			<!-- QQ Discord 二维码 -->
-			<Panel id="QQDiscordContainer" >
+			<Panel id="QQDiscordContainer" hittest="false" hittestchildren="false">
 				<Panel id="QQDiscordPanel">
 					<Panel id="QQPanel" class="QQDiscordSubPanel">
 						<Image id="QQQRCodeImage" src="file://{images}/custom_game/sns/qq_qr_code1.png"/>

--- a/content/panorama/scripts/custom_game/game_mode.js
+++ b/content/panorama/scripts/custom_game/game_mode.js
@@ -20,6 +20,7 @@ var CUSTOM_PRESET_TOGGLES = [
   ['forceRandomHero', 'force_random_hero'],
   ['enablePlayerAttribute', 'enable_player_attribute'],
   ['midOnlyMode', 'mid_only_mode'],
+  ['enableFountainAntiCamp', 'enable_fountain_anti_camp'],
 ];
 
 function CheckForHostPrivileges() {
@@ -100,6 +101,7 @@ function InitCustomSetting() {
   $('#force_random_hero').checked = false; // 默认不强制随机
   $('#enable_player_attribute').checked = true;
   $('#mid_only_mode').checked = false;
+  $('#enable_fountain_anti_camp').checked = false;
   $('#player_gold_xp_multiplier_dropdown').SetSelected('1.5');
   $('#bot_gold_xp_multiplier_dropdown').SetSelected('10');
   $('#radiant_player_number_dropdown').SetSelected('1');
@@ -141,6 +143,7 @@ function LockOption() {
   $('#force_random_hero').enabled = false;
   $('#enable_player_attribute').enabled = false;
   $('#mid_only_mode').enabled = false;
+  $('#enable_fountain_anti_camp').enabled = false;
 }
 
 function UnLockOptionAll() {
@@ -159,6 +162,7 @@ function UnLockOptionAll() {
   $('#force_random_hero').enabled = true;
   $('#enable_player_attribute').enabled = true;
   $('#mid_only_mode').enabled = true;
+  $('#enable_fountain_anti_camp').enabled = true;
 }
 
 // N1-N8 通用设置
@@ -173,6 +177,7 @@ function InitDifficultyCommonSetting() {
   $('#force_random_hero').checked = false;
   $('#enable_player_attribute').checked = true;
   $('#mid_only_mode').checked = false;
+  $('#enable_fountain_anti_camp').checked = true;
 }
 
 function InitN1Setting() {
@@ -294,6 +299,7 @@ function SendGameOptionsToServer() {
   const forceRandomHero = $('#force_random_hero').checked;
   const enablePlayerAttribute = $('#enable_player_attribute').checked;
   const midOnlyMode = $('#mid_only_mode').checked;
+  const enableFountainAntiCamp = $('#enable_fountain_anti_camp').checked;
 
   GameEvents.SendCustomGameEventToServer('game_options_change', {
     multiplier_radiant: Number(playerGoldXpMultiplier),
@@ -309,6 +315,7 @@ function SendGameOptionsToServer() {
     force_random_hero: forceRandomHero,
     enable_player_attribute: enablePlayerAttribute,
     mid_only_mode: midOnlyMode,
+    enable_fountain_anti_camp: Number(enableFountainAntiCamp),
   });
 }
 

--- a/content/panorama/styles/custom_game/custom_loading_screen.css
+++ b/content/panorama/styles/custom_game/custom_loading_screen.css
@@ -17,7 +17,7 @@
 
 #game_options_container {
   width: 450px;
-  height: 76%;
+  height: 82%;
   background-color: gradient(
     linear,
     100% 0%,
@@ -80,7 +80,7 @@
 }
 
 #QQDiscordContainer {
-  width: 500px;
+  width: 380px;
   vertical-align: bottom;
   margin-bottom: 60px;
 }
@@ -94,8 +94,8 @@
 
 #QQQRCodeImage,
 #DiscordQRCodeImage {
-  width: 200px;
-  height: 260px;
+  width: 150px;
+  height: 195px;
 }
 
 #LinkButtonContainer {

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1,4 +1,4 @@
-"lang"
+﻿"lang"
 {
 	"Language"		"english"
 	"Tokens"
@@ -44,6 +44,7 @@
 		"force_random_hero"			"Force Random Hero"
 		"enable_player_attribute"	"Enable Player Attribute"
 		"mid_only_mode"				"Mid Only Mode"
+		"enable_fountain_anti_camp"	"Enable Anti-Fountain-Camping"
 		"hide_chat_team"			"Hide Chat and Team"
 		"show_chat_team"			"Show Chat and Team"
 
@@ -3365,6 +3366,12 @@
 
 		// 藏宝箱
 		"npc_treasure_chest"											"Treasure Chest"
+
+		// 泉水防堵泉
+		"DOTA_Tooltip_modifier_fountain_outer_zone"									"Dire Base Warning Zone"
+		"DOTA_Tooltip_modifier_fountain_outer_zone_Description"							"AI hero kills in this area grant only 10% gold and experience. AI hero kills within fountain attack range grant no gold or experience."
+		"DOTA_Tooltip_modifier_fountain_intrusion"									"Fountain Warning"
+		"DOTA_Tooltip_modifier_fountain_intrusion_Description"							"After remaining inside the enemy fountain for more than 5 seconds, items and active abilities are disabled, passives and custom triggers stop working, and health and mana restoration are prevented. Leaving the fountain removes the effect."
 
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -1,4 +1,4 @@
-"lang"
+﻿"lang"
 {
 	"Language"		"Russian"
 	"Tokens"
@@ -37,6 +37,7 @@
 		"starting_gold_bot"			"Стартовое золото ботов"
 		"force_random_hero"			"Принудительно случайный героя"
 		"enable_player_attribute"	"Enable Player Attribute"
+		"enable_fountain_anti_camp"	"Enable Anti-Fountain-Camping"
 		"hide_chat_team"			"Скрыть командный чат"
 		"show_chat_team"			"Показать командный чат"
 
@@ -474,5 +475,6 @@
 
 		// Сундук с сокровищами
 		"npc_treasure_chest"													"Сундук с сокровищами"
+
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -44,6 +44,7 @@
 		"force_random_hero"			"强制随机英雄"
 		"enable_player_attribute"	"启用玩家属性"
 		"mid_only_mode"				"中路乱斗模式"
+		"enable_fountain_anti_camp"	"启用防堵泉机制"
 		"hide_chat_team"			"隐藏聊天框"
 		"show_chat_team"			"显示聊天框"
 
@@ -3375,6 +3376,12 @@
 
 		// 藏宝箱
 		"npc_treasure_chest"															"藏宝箱"
+
+		// 泉水防堵泉
+		"DOTA_Tooltip_modifier_fountain_outer_zone"									"夜魇基地警戒区"
+		"DOTA_Tooltip_modifier_fountain_outer_zone_Description"							"在此区域内击杀AI英雄只能获得10%金币和经验；进入泉水攻击范围后击杀AI英雄不获得金币和经验。"
+		"DOTA_Tooltip_modifier_fountain_intrusion"									"泉水警戒"
+		"DOTA_Tooltip_modifier_fountain_intrusion_Description"							"在敌方泉水内连续停留超过5秒后，装备和主动技能将被禁用，被动及自定义触发效果失效，且无法恢复生命和魔法；离开泉水后解除。"
 
 	}
 }

--- a/game/scripts/npc/npc_units_custom.txt
+++ b/game/scripts/npc/npc_units_custom.txt
@@ -94,6 +94,47 @@
 		"AttackDesire"				"1.5"		// How much bots want to attack them vs other non-hero things
 	}
 
+	"npc_fountain_damage_proxy"
+	{
+		"BaseClass"					"npc_dota_base_additive"
+		"Model"						"models/development/invisiblebox.vmdl"
+		"SoundSet"					""
+		"Level"						"1"
+		"UnitLabel"					"creep"
+
+		"ArmorPhysical"				"0"
+		"MagicalResistance"			"0"
+
+		"AttackCapabilities"		"DOTA_UNIT_CAP_NO_ATTACK"
+		"AttackDamageMin"			"0"
+		"AttackDamageMax"			"0"
+		"AttackAcquisitionRange"	"0"
+		"AttackRange"				"0"
+
+		"BountyXP"					"0"
+		"BountyGoldMin"				"0"
+		"BountyGoldMax"				"0"
+
+		"BoundsHullName"			"DOTA_HULL_SIZE_SMALL"
+		"MovementCapabilities"		"DOTA_UNIT_CAP_MOVE_NONE"
+		"MovementSpeed"				"0"
+		"MovementTurnRate"			"0"
+
+		"StatusHealth"				"100000"
+		"StatusHealthRegen"			"0"
+		"StatusMana"					"0"
+		"StatusManaRegen"			"0"
+
+		"TeamName"					"DOTA_TEAM_NEUTRALS"
+		"CombatClassAttack"			"DOTA_COMBAT_CLASS_ATTACK_BASIC"
+		"CombatClassDefend"			"DOTA_COMBAT_CLASS_DEFEND_BASIC"
+		"UnitRelationshipClass"		"DOTA_NPC_UNIT_RELATIONSHIP_TYPE_DEFAULT"
+
+		"VisionDaytimeRange"			"0"
+		"VisionNighttimeRange"		"0"
+		"WakesNeutrals"				"0"
+	}
+
 	"npc_dota_courier"
 	{
 		"StatusHealth"				"10"	// 6

--- a/game/scripts/vscripts/abilities/ability_charge_damage.lua
+++ b/game/scripts/vscripts/abilities/ability_charge_damage.lua
@@ -48,6 +48,7 @@ end
 
 function modifier_ability_charge_damage_tracker:OnIntervalThink()
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     local caster = self:GetParent()
     local ability = self:GetAbility()
@@ -184,6 +185,7 @@ end
 
 function modifier_ability_charge_damage_tracker:OnAbilityExecuted(keys)
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     if keys.unit ~= self:GetParent() then
         return

--- a/game/scripts/vscripts/abilities/ability_trigger_learned_skills.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_learned_skills.lua
@@ -50,6 +50,7 @@ end
 
 function modifier_trigger_learned_skills:OnAttackLanded(params)
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     local attacker = params.attacker
     local parent = self:GetParent()

--- a/game/scripts/vscripts/abilities/ability_trigger_on_active.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_active.lua
@@ -90,6 +90,7 @@ end
 
 function modifier_ability_trigger_on_active:OnIntervalThink()
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     --print("[ability_trigger_on_active1332] OnIntervalThink")
     -- 自动施放所有可用技能

--- a/game/scripts/vscripts/abilities/ability_trigger_on_attacked.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_attacked.lua
@@ -38,6 +38,7 @@ end
 
 function modifier_trigger_on_attacked:OnAttacked(params)
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     local attacker = params.attacker
     local parent = self:GetParent() -- 被攻击者

--- a/game/scripts/vscripts/abilities/ability_trigger_on_cast.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_cast.lua
@@ -67,6 +67,7 @@ end
 
 function modifier_trigger_on_cast:OnAbilityExecuted(params)
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     local caster = params.unit
     local parent = self:GetParent()

--- a/game/scripts/vscripts/abilities/ability_trigger_on_move.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_move.lua
@@ -42,6 +42,7 @@ end
 
 function modifier_trigger_on_move:OnIntervalThink()
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     local parent = self:GetParent()
     if not parent or parent:IsNull() or not parent:IsAlive() then return end

--- a/game/scripts/vscripts/abilities/ability_trigger_on_spell_reflect.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_spell_reflect.lua
@@ -38,6 +38,7 @@ end
 
 function modifier_trigger_on_spell_reflect:OnTakeDamage(params)
     if not IsServer() then return end
+    if IsFountainLocked and IsFountainLocked(self:GetParent()) then return end
 
     local parent = self:GetParent()
     local attacker = params.attacker

--- a/game/scripts/vscripts/abilities/spectre_dispersion2.lua
+++ b/game/scripts/vscripts/abilities/spectre_dispersion2.lua
@@ -2,6 +2,14 @@
 spectre_dispersion2 = class({})
 LinkLuaModifier("modifier_spectre_dispersion2", "abilities/spectre_dispersion2", LUA_MODIFIER_MOTION_NONE)
 
+local function IsUnitFountainLocked(unit)
+    if not unit or unit:IsNull() then return false end
+    if IsFountainLocked then return IsFountainLocked(unit) end
+
+    local modifier = unit:FindModifierByName("modifier_fountain_intrusion")
+    return modifier ~= nil and modifier:GetElapsedTime() >= 5
+end
+
 function spectre_dispersion2:GetIntrinsicModifierName()
     return "modifier_spectre_dispersion2"
 end
@@ -15,14 +23,17 @@ function modifier_spectre_dispersion2:IsPurgable() return false end
 
 function modifier_spectre_dispersion2:OnCreated()
     if IsServer() then
-        -- 分别累积不同类型的伤害
-        self.accumulated_damage = {
-            [DAMAGE_TYPE_PHYSICAL] = 0,
-            [DAMAGE_TYPE_MAGICAL] = 0,
-            [DAMAGE_TYPE_PURE] = 0,
-        }
-        self.is_timer_active = false
+        self:ResetAccumulatedDamage()
     end
+end
+
+function modifier_spectre_dispersion2:ResetAccumulatedDamage()
+    self.accumulated_damage = {
+        [DAMAGE_TYPE_PHYSICAL] = 0,
+        [DAMAGE_TYPE_MAGICAL] = 0,
+        [DAMAGE_TYPE_PURE] = 0,
+    }
+    self.is_timer_active = false
 end
 
 function modifier_spectre_dispersion2:DeclareFunctions()
@@ -33,6 +44,11 @@ end
 
 function modifier_spectre_dispersion2:GetModifierIncomingDamage_Percentage(keys)
     if IsServer() then
+        if IsUnitFountainLocked(self:GetParent()) then
+            self:ResetAccumulatedDamage()
+            return 0
+        end
+
         if keys.target == self:GetParent() then
             local damage = keys.original_damage
             if damage >= self:GetAbility():GetSpecialValueFor("threshold") then
@@ -72,6 +88,11 @@ function modifier_spectre_dispersion2:ReleaseAccumulatedDamage()
     if not IsServer() then return end
 
     local caster = self:GetParent()
+    if IsUnitFountainLocked(caster) then
+        self:ResetAccumulatedDamage()
+        return
+    end
+
     local ability = self:GetAbility()
     local radius = ability:GetSpecialValueFor("radius")
 
@@ -124,10 +145,5 @@ function modifier_spectre_dispersion2:ReleaseAccumulatedDamage()
     end
 
     -- 重置累积数据
-    self.accumulated_damage = {
-        [DAMAGE_TYPE_PHYSICAL] = 0,
-        [DAMAGE_TYPE_MAGICAL] = 0,
-        [DAMAGE_TYPE_PURE] = 0,
-    }
-    self.is_timer_active = false
+    self:ResetAccumulatedDamage()
 end

--- a/game/scripts/vscripts/items/item_withered_spring.lua
+++ b/game/scripts/vscripts/items/item_withered_spring.lua
@@ -3,6 +3,14 @@ LinkLuaModifier("modifier_item_withered_spring_active", "items/item_withered_spr
 
 item_withered_spring = class({})
 
+local function IsUnitFountainLocked(unit)
+    if not unit or unit:IsNull() then return false end
+    if IsFountainLocked then return IsFountainLocked(unit) end
+
+    local modifier = unit:FindModifierByName("modifier_fountain_intrusion")
+    return modifier ~= nil and modifier:GetElapsedTime() >= 5
+end
+
 function item_withered_spring:GetIntrinsicModifierName()
     return "modifier_item_withered_spring"
 end
@@ -11,6 +19,8 @@ function item_withered_spring:OnSpellStart()
     if not IsServer() then return end
 
     local caster = self:GetCaster()
+    if IsUnitFountainLocked(caster) then return end
+
     local duration = self:GetSpecialValueFor("active_duration")
 
     -- 回血 音效
@@ -86,6 +96,8 @@ end
 
 -- 血量下限锁在 1，伤害结算时引擎同步钳制，避免单次爆发直接秒杀绕过阈值判定
 function modifier_item_withered_spring:GetMinHealth()
+    if IsUnitFountainLocked(self:GetParent()) then return 0 end
+
     local ability = self:GetAbility()
     if ability and not ability:IsNull() and ability:IsFullyCastable() then
         return 1
@@ -97,7 +109,7 @@ function modifier_item_withered_spring:OnTakeDamage(event)
     if not IsServer() then return end
 
     local parent = self:GetParent()
-    if event.unit ~= parent then return end
+    if event.unit ~= parent or IsUnitFountainLocked(parent) then return end
 
     local ability = self:GetAbility()
     if not ability or ability:IsNull() or not ability:IsFullyCastable() then return end
@@ -124,10 +136,12 @@ function modifier_item_withered_spring:DeclareFunctions()
 end
 
 function modifier_item_withered_spring:GetModifierHealthRegenPercentageUnique()
+    if IsUnitFountainLocked(self:GetParent()) then return 0 end
     return self.health_regen_pct or 0
 end
 
 function modifier_item_withered_spring:GetModifierStatusResistanceStacking()
+    if IsUnitFountainLocked(self:GetParent()) then return 0 end
     return self.status_resistance or 0
 end
 
@@ -153,8 +167,13 @@ function modifier_item_withered_spring_active:OnCreated()
     self.status_resistance = self:GetAbility():GetSpecialValueFor("status_resistance_active") or 80
 
     if not IsServer() then return end
+    if IsUnitFountainLocked(self:GetParent()) then
+        self:Destroy()
+        return
+    end
 
-    -- 服务器端逻辑
+    self:StartIntervalThink(FrameTime())
+
     self.damage_reduction = self:GetAbility():GetSpecialValueFor("damage_reduction") or -30 -- 30%减伤 = 不受任何伤害
     -- 添加持续的视觉效果(只在主动触发时显示)
     local particle = ParticleManager:CreateParticle(
@@ -163,6 +182,12 @@ function modifier_item_withered_spring_active:OnCreated()
         self:GetParent()
     )
     self:AddParticle(particle, false, false, -1, false, false)
+end
+
+function modifier_item_withered_spring_active:OnIntervalThink()
+    if IsUnitFountainLocked(self:GetParent()) then
+        self:Destroy()
+    end
 end
 
 function modifier_item_withered_spring_active:DeclareFunctions()
@@ -175,22 +200,27 @@ function modifier_item_withered_spring_active:DeclareFunctions()
 end
 
 function modifier_item_withered_spring_active:GetModifierPhysicalArmorBonus()
+    if IsUnitFountainLocked(self:GetParent()) then return 0 end
     return self.bonus_armor_active or 0
 end
 
 function modifier_item_withered_spring_active:GetModifierConstantHealthRegen()
+    if IsUnitFountainLocked(self:GetParent()) then return 0 end
     return self.bonus_regen_active or 0
 end
 
 function modifier_item_withered_spring_active:GetModifierIncomingDamage_Percentage()
+    if IsUnitFountainLocked(self:GetParent()) then return 0 end
     return self.damage_reduction or -30
 end
 
 function modifier_item_withered_spring_active:GetModifierStatusResistanceStacking()
+    if IsUnitFountainLocked(self:GetParent()) then return 0 end
     return self.status_resistance or 80
 end
 
 function modifier_item_withered_spring_active:CheckState()
+    if IsUnitFountainLocked(self:GetParent()) then return {} end
     return {
         [MODIFIER_STATE_DEBUFF_IMMUNE] = true, -- 免疫debuff
     }

--- a/src/common/events.d.ts
+++ b/src/common/events.d.ts
@@ -64,6 +64,7 @@ interface GameOptionsChangeEventData {
   force_random_hero: number;
   enable_player_attribute: number;
   mid_only_mode: number;
+  enable_fountain_anti_camp: number;
 }
 
 interface LoadingSetOptionsEventData {

--- a/src/common/net_tables.d.ts
+++ b/src/common/net_tables.d.ts
@@ -152,4 +152,5 @@ export interface GameOptions {
   force_random_hero: number;
   enable_player_attribute: number;
   mid_only_mode: number;
+  enable_fountain_anti_camp: number;
 }

--- a/src/vscripts/api/player-setting.ts
+++ b/src/vscripts/api/player-setting.ts
@@ -126,7 +126,8 @@ export class PlayerGamePresetApi {
       a.fixedAbility === b.fixedAbility &&
       a.forceRandomHero === b.forceRandomHero &&
       a.enablePlayerAttribute === b.enablePlayerAttribute &&
-      a.midOnlyMode === b.midOnlyMode
+      a.midOnlyMode === b.midOnlyMode &&
+      a.enableFountainAntiCamp === b.enableFountainAntiCamp
     );
   }
 
@@ -151,6 +152,7 @@ export class PlayerGamePresetApi {
       forceRandomHero: o.forceRandomHero ? 1 : 0,
       enablePlayerAttribute: o.enablePlayerAttribute ? 1 : 0,
       midOnlyMode: o.midOnlyMode ? 1 : 0,
+      enableFountainAntiCamp: o.enableFountainAntiCamp ? 1 : 0,
     };
   }
 

--- a/src/vscripts/api/player.ts
+++ b/src/vscripts/api/player.ts
@@ -29,6 +29,7 @@ export class GamePresetCustomOptions {
   forceRandomHero!: number;
   enablePlayerAttribute!: number;
   midOnlyMode!: number;
+  enableFountainAntiCamp!: number;
 }
 
 export class PlayerSetting {

--- a/src/vscripts/modifiers/global/fountain_anti_camp.ts
+++ b/src/vscripts/modifiers/global/fountain_anti_camp.ts
@@ -1,0 +1,355 @@
+import { BaseModifier, registerModifier } from '../../utils/dota_ts_adapter';
+import { PlayerHelper } from '../../modules/helper/player-helper';
+
+@registerModifier('modifiers/global/fountain_anti_camp')
+export class modifier_fountain_outer_zone extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return 'fountain_hp_aura';
+  }
+}
+
+@registerModifier('modifiers/global/fountain_anti_camp')
+export class modifier_fountain_intrusion extends BaseModifier {
+  private maximumAllowedHealth?: number;
+  private maximumAllowedMana?: number;
+  private lockEffectsCleared = false;
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return 'fountain_hp_aura';
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.StartIntervalThink(FrameTime());
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer() || !this.isLocked()) return;
+
+    const parent = this.GetParent();
+    if (!parent.IsAlive()) return;
+
+    if (!this.lockEffectsCleared) {
+      parent.RemoveModifierByName('modifier_black_king_bar_immune');
+      parent.RemoveModifierByName('modifier_item_beast_shield_active');
+      parent.RemoveModifierByName('modifier_item_withered_spring_active');
+      this.lockEffectsCleared = true;
+    }
+
+    const currentHealth = parent.GetHealth();
+    if (this.maximumAllowedHealth === undefined) {
+      this.maximumAllowedHealth = currentHealth;
+    } else if (currentHealth > this.maximumAllowedHealth) {
+      parent.SetHealth(this.maximumAllowedHealth);
+    } else {
+      this.maximumAllowedHealth = currentHealth;
+    }
+
+    const currentMana = parent.GetMana();
+    if (this.maximumAllowedMana === undefined) {
+      this.maximumAllowedMana = currentMana;
+    } else if (currentMana > this.maximumAllowedMana) {
+      parent.SetMana(this.maximumAllowedMana);
+    } else {
+      this.maximumAllowedMana = currentMana;
+    }
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    if (!this.isLocked()) return {};
+
+    return {
+      [ModifierState.MUTED]: true,
+      [ModifierState.SILENCED]: true,
+      [ModifierState.PASSIVES_DISABLED]: true,
+    };
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.DISABLE_HEALING,
+      ModifierFunction.DISABLE_MANA_GAIN,
+      ModifierFunction.HEALTH_REGEN_PERCENTAGE,
+      ModifierFunction.MANA_REGEN_TOTAL_PERCENTAGE,
+      ModifierFunction.HP_REGEN_AMPLIFY_PERCENTAGE,
+      ModifierFunction.MP_REGEN_AMPLIFY_PERCENTAGE,
+      ModifierFunction.HEAL_AMPLIFY_PERCENTAGE_TARGET,
+      ModifierFunction.LIFESTEAL_AMPLIFY_PERCENTAGE,
+      ModifierFunction.SPELL_LIFESTEAL_AMPLIFY_PERCENTAGE,
+    ];
+  }
+
+  GetDisableHealing(): 0 | 1 {
+    return this.isLocked() ? 1 : 0;
+  }
+
+  GetDisableManaGain(): number {
+    return this.isLocked() ? 1 : 0;
+  }
+
+  GetModifierHealthRegenPercentage(): number {
+    return this.getRegenReduction();
+  }
+
+  GetModifierTotalPercentageManaRegen(): number {
+    return this.getRegenReduction();
+  }
+
+  GetModifierHPRegenAmplify_Percentage(): number {
+    return this.getRegenReduction();
+  }
+
+  GetModifierMPRegenAmplify_Percentage(): number {
+    return this.getRegenReduction();
+  }
+
+  GetModifierHealAmplify_PercentageTarget(): number {
+    return this.getRegenReduction();
+  }
+
+  GetModifierLifestealRegenAmplify_Percentage(): number {
+    return this.getRegenReduction();
+  }
+
+  GetModifierSpellLifestealRegenAmplify_Percentage(): number {
+    return this.getRegenReduction();
+  }
+
+  private getRegenReduction(): number {
+    return this.isLocked() ? -100 : 0;
+  }
+
+  private isLocked(): boolean {
+    return this.GetElapsedTime() >= 5;
+  }
+}
+
+@registerModifier('modifiers/global/fountain_anti_camp')
+export class modifier_fountain_attack_percent_damage extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_ATTACK_LANDED];
+  }
+
+  OnAttackLanded(event: ModifierAttackEvent): void {
+    if (!IsServer()) return;
+
+    const fountain = this.GetParent();
+    const target = event.target;
+    if (
+      GameRules.FountainAntiCamp.IsFountainDestroyed(fountain.GetTeamNumber() as DotaTeam) ||
+      event.attacker !== fountain ||
+      !target ||
+      !target.IsRealHero() ||
+      target.GetTeamNumber() === fountain.GetTeamNumber() ||
+      !PlayerHelper.IsHumanPlayer(target)
+    ) {
+      return;
+    }
+
+    const percent = GameRules.FountainAntiCamp.IsUnitLocked(target) ? 0.05 : 0.01;
+    ApplyDamage({
+      victim: target,
+      attacker: fountain,
+      damage: target.GetMaxHealth() * percent,
+      damage_type: DamageTypes.PURE,
+      damage_flags:
+        DamageFlag.HPLOSS +
+        DamageFlag.NO_DAMAGE_MULTIPLIERS +
+        DamageFlag.NO_SPELL_AMPLIFICATION +
+        DamageFlag.NO_SPELL_LIFESTEAL +
+        DamageFlag.NO_REFLECTION,
+    });
+  }
+}
+
+@registerModifier('modifiers/global/fountain_anti_camp')
+export class modifier_fountain_damage_proxy extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetDisableHealthBar(): boolean {
+    return true;
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.NO_HEALTH_BAR]: true,
+      [ModifierState.UNSELECTABLE]: true,
+      [ModifierState.NOT_ON_MINIMAP]: true,
+      [ModifierState.NO_UNIT_COLLISION]: true,
+    };
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.MIN_HEALTH];
+  }
+
+  GetMinHealth(): number {
+    return 1;
+  }
+}
+
+@registerModifier('modifiers/global/fountain_anti_camp')
+export class modifier_fountain_destructible extends BaseModifier {
+  private destroyed = false;
+
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetDisableHealthBar(): boolean {
+    return true;
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.NO_HEALTH_BAR]: true,
+      [ModifierState.UNSELECTABLE]: true,
+      [ModifierState.INVULNERABLE]: true,
+    };
+  }
+
+  DestroyFountain(): void {
+    if (!IsServer() || this.destroyed) return;
+
+    this.destroyed = true;
+    const fountain = this.GetParent();
+
+    fountain.Stop();
+    fountain.SetAttackCapability(UnitAttackCapability.NO_ATTACK);
+    fountain.SetIdleAcquire(false);
+    fountain.SetAcquisitionRange(0);
+
+    const abilityNames: string[] = [];
+    for (let i = 0; i < fountain.GetAbilityCount(); i++) {
+      const ability = fountain.GetAbilityByIndex(i);
+      if (ability) {
+        ability.SetActivated(false);
+        abilityNames.push(ability.GetAbilityName());
+      }
+    }
+    for (const abilityName of abilityNames) {
+      fountain.RemoveAbility(abilityName);
+    }
+
+    GameRules.FountainAntiCamp.OnFountainDestroyed(fountain.GetTeamNumber() as DotaTeam);
+  }
+}
+
+@registerModifier('modifiers/global/fountain_anti_camp')
+export class modifier_fountain_damage_statistics extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_TAKEDAMAGE];
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer() || event.unit !== this.GetParent() || !event.attacker) return;
+    GameRules.FountainAntiCamp.RecordDamageTaken(this.GetParent(), event.attacker, event.damage);
+  }
+}
+
+@registerModifier('modifiers/global/fountain_anti_camp')
+export class modifier_fountain_reward_tracker extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_TAKEDAMAGE, ModifierFunction.ON_DEATH];
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer() || event.unit !== this.GetParent()) return;
+
+    const victim = this.GetParent();
+    if (victim.GetHealth() <= 0 || !victim.IsAlive()) {
+      GameRules.FountainAntiCamp.RecordDireBotDeath(victim, event.attacker);
+    }
+  }
+
+  OnDeath(event: ModifierInstanceEvent): void {
+    if (!IsServer() || event.unit !== this.GetParent()) return;
+    GameRules.FountainAntiCamp.RecordDireBotDeath(this.GetParent(), event.attacker);
+  }
+}

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.41';
+  public static readonly GAME_VERSION = 'v5.42';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数

--- a/src/vscripts/modules/event/game-end/game-end.ts
+++ b/src/vscripts/modules/event/game-end/game-end.ts
@@ -76,14 +76,18 @@ export class GameEnd {
       }
 
       let damageTaken = 0;
-      for (let victimID = 0; victimID < DOTA_MAX_TEAM_PLAYERS; victimID++) {
-        if (
-          PlayerResource.IsValidPlayerID(victimID) &&
-          PlayerResource.IsValidPlayer(victimID) &&
-          PlayerResource.GetSelectedHeroEntity(victimID)
-        ) {
-          if (PlayerResource.GetTeam(victimID) !== PlayerResource.GetTeam(playerId)) {
-            damageTaken += PlayerResource.GetDamageDoneToHero(victimID, playerId);
+      if (GameRules.FountainAntiCamp?.IsEnabled()) {
+        damageTaken = GameRules.FountainAntiCamp.GetDamageTaken(playerId);
+      } else {
+        for (let victimID = 0; victimID < DOTA_MAX_TEAM_PLAYERS; victimID++) {
+          if (
+            PlayerResource.IsValidPlayerID(victimID) &&
+            PlayerResource.IsValidPlayer(victimID) &&
+            PlayerResource.GetSelectedHeroEntity(victimID)
+          ) {
+            if (PlayerResource.GetTeam(victimID) !== PlayerResource.GetTeam(playerId)) {
+              damageTaken += PlayerResource.GetDamageDoneToHero(victimID, playerId);
+            }
           }
         }
       }

--- a/src/vscripts/modules/filter/gold-xp-filter.ts
+++ b/src/vscripts/modules/filter/gold-xp-filter.ts
@@ -55,7 +55,22 @@ export class GoldXPFilter {
       mul = this.filterHeroKillGoldByMultiplier(mul);
     }
 
-    args.gold = Math.floor(gold * mul);
+    if (reason === ModifyGoldReason.HERO_KILL || reason === ModifyGoldReason.SHARED_GOLD) {
+      mul *= this.getFountainRewardMultiplier(playerID);
+    }
+
+    const filteredGold = Math.floor(gold * mul);
+    if (
+      reason === ModifyGoldReason.HERO_KILL &&
+      filteredGold === 0 &&
+      this.shouldPreserveZeroRewardKillMessage(playerID)
+    ) {
+      // 保留引擎生成的原生击杀来源，临时金币会在结算后立即抵消。
+      args.gold = 1;
+      this.removeTemporaryKillMessageGold(playerID, args.reliable === 1);
+    } else {
+      args.gold = filteredGold;
+    }
 
     return true;
   }
@@ -80,11 +95,29 @@ export class GoldXPFilter {
 
     if (reason === ModifyXpReason.HERO_KILL) {
       mul = this.filterHeroKillGoldByMultiplier(mul);
+      mul *= this.getFountainRewardMultiplier(playerID);
     }
 
     args.experience = Math.floor(xp * mul);
 
     return true;
+  }
+
+  private getFountainRewardMultiplier(playerID: PlayerID): number {
+    const fountainAntiCamp = GameRules.FountainAntiCamp;
+    return fountainAntiCamp !== undefined
+      ? fountainAntiCamp.GetActiveRewardMultiplier(playerID)
+      : 1;
+  }
+
+  private shouldPreserveZeroRewardKillMessage(playerID: PlayerID): boolean {
+    return GameRules.FountainAntiCamp?.ShouldPreserveZeroRewardKillMessage(playerID) ?? false;
+  }
+
+  private removeTemporaryKillMessageGold(playerID: PlayerID, reliable: boolean): void {
+    Timers.CreateTimer(0, () => {
+      PlayerResource.ModifyGold(playerID, -1, reliable, ModifyGoldReason.UNSPECIFIED);
+    });
   }
 
   /**

--- a/src/vscripts/modules/fountain/fountain-anti-camp.ts
+++ b/src/vscripts/modules/fountain/fountain-anti-camp.ts
@@ -1,0 +1,599 @@
+import {
+  modifier_fountain_attack_percent_damage,
+  modifier_fountain_damage_proxy,
+  modifier_fountain_damage_statistics,
+  modifier_fountain_destructible,
+  modifier_fountain_intrusion,
+  modifier_fountain_outer_zone,
+  modifier_fountain_reward_tracker,
+} from '../../modifiers/global/fountain_anti_camp';
+import { PlayerHelper } from '../helper/player-helper';
+
+declare global {
+  let IsFountainLocked: (this: void, unit: CDOTA_BaseNPC | undefined) => boolean;
+}
+
+interface FountainZone {
+  fountain: CDOTA_BaseNPC;
+  center: Vector;
+  innerRadius: number;
+  outerRadius: number;
+  damageProxy?: CDOTA_BaseNPC;
+  hiddenHealth: number;
+  lastHealthUpdate: number;
+  destroyed: boolean;
+}
+
+interface KillRewardContext {
+  expiresAt: number;
+  multiplier: number;
+  killerPlayerId: PlayerID;
+}
+
+interface FountainDamageFilterEvent extends DamageFilterEvent {
+  damage_flags?: DOTADamageFlag_t;
+}
+
+export class FountainAntiCamp {
+  private static readonly THINK_TIMER = 'fountain_anti_camp_think';
+  private static readonly THINK_INTERVAL = 0.1;
+  private static readonly REWARD_CONTEXT_DURATION = 0.25;
+  private static readonly FOUNTAIN_MAX_HEALTH = 100000;
+  private static readonly FOUNTAIN_HEALTH_REGEN = 1000;
+  private static readonly DAMAGE_PROXY_UNIT = 'npc_fountain_damage_proxy';
+
+  private readonly fountains = new Map<DotaTeam, FountainZone>();
+  private readonly damageTaken = new Map<PlayerID, number>();
+  private readonly rewardContexts: KillRewardContext[] = [];
+  private readonly recordedBotDeaths = new Map<number, number>();
+  private initialized = false;
+
+  constructor() {
+    ListenToGameEvent('game_rules_state_change', () => this.onGameStateChanged(), this);
+    ListenToGameEvent('entity_killed', (event) => this.onEntityKilled(event), this);
+    GameRules.GetGameModeEntity().SetHealingFilter((event) => this.filterHealing(event), this);
+    GameRules.GetGameModeEntity().SetDamageFilter((event) => this.filterDamage(event), this);
+    GameRules.GetGameModeEntity().SetExecuteOrderFilter(
+      (event) => this.filterExecuteOrder(event),
+      this,
+    );
+
+    IsFountainLocked = (unit: CDOTA_BaseNPC | undefined): boolean => {
+      return this.isUnitFountainLocked(unit);
+    };
+  }
+
+  IsEnabled(): boolean {
+    return GameRules.Option.enableFountainAntiCamp;
+  }
+
+  GetDamageTaken(playerId: PlayerID): number {
+    return Math.floor(this.damageTaken.get(playerId) ?? 0);
+  }
+
+  RecordDamageTaken(victim: CDOTA_BaseNPC, attacker: CDOTA_BaseNPC, damage: number): void {
+    if (!this.IsEnabled() || damage <= 0 || !victim.IsRealHero()) return;
+
+    const victimPlayerId = victim.GetPlayerOwnerID();
+    if (!PlayerHelper.IsHumanPlayerByPlayerId(victimPlayerId)) return;
+    if (this.IsInEnemyFountain(victim)) return;
+
+    const attackerPlayerId = this.getOwningPlayerId(attacker);
+    if (attackerPlayerId < 0 || !PlayerResource.IsValidPlayerID(attackerPlayerId)) return;
+    if (PlayerResource.GetTeam(attackerPlayerId) === victim.GetTeamNumber()) return;
+
+    this.damageTaken.set(victimPlayerId, (this.damageTaken.get(victimPlayerId) ?? 0) + damage);
+  }
+
+  RecordDireBotDeath(victim: CDOTA_BaseNPC, attacker: CDOTA_BaseNPC | undefined): void {
+    if (!this.IsEnabled() || !this.isDireBotHero(victim)) return;
+
+    const now = GameRules.GetGameTime();
+    const victimEntityIndex = victim.GetEntityIndex();
+    const lastRecordedAt = this.recordedBotDeaths.get(victimEntityIndex);
+    if (lastRecordedAt !== undefined && now - lastRecordedAt < 0.5) return;
+    this.recordedBotDeaths.set(victimEntityIndex, now);
+
+    let multiplier = 1;
+    if (this.IsInFountainAttackRange(DotaTeam.BADGUYS, victim)) {
+      multiplier = 0;
+    }
+
+    if (attacker && IsValidEntity(attacker)) {
+      multiplier = Math.min(multiplier, this.getDireZoneMultiplier(attacker.GetAbsOrigin()));
+
+      const ownerHero = this.getOwnerHero(attacker);
+      if (ownerHero) {
+        multiplier = Math.min(multiplier, this.getDireZoneMultiplier(ownerHero.GetAbsOrigin()));
+      }
+    }
+
+    if (multiplier >= 1) return;
+
+    this.rewardContexts.push({
+      expiresAt: now + FountainAntiCamp.REWARD_CONTEXT_DURATION,
+      multiplier,
+      killerPlayerId: attacker ? this.getOwningPlayerId(attacker) : (-1 as PlayerID),
+    });
+    this.pruneRewardContexts(now);
+  }
+
+  GetActiveRewardMultiplier(playerId: PlayerID): number {
+    if (!this.IsEnabled() || !PlayerHelper.IsHumanPlayerByPlayerId(playerId)) return 1;
+
+    const now = GameRules.GetGameTime();
+    this.pruneRewardContexts(now);
+
+    let multiplier = 1;
+    for (const context of this.rewardContexts) {
+      multiplier = Math.min(multiplier, context.multiplier);
+    }
+    return multiplier;
+  }
+
+  ShouldPreserveZeroRewardKillMessage(playerId: PlayerID): boolean {
+    if (!this.IsEnabled() || !PlayerHelper.IsHumanPlayerByPlayerId(playerId)) return false;
+
+    const now = GameRules.GetGameTime();
+    this.pruneRewardContexts(now);
+    return this.rewardContexts.some(
+      (context) => context.multiplier === 0 && context.killerPlayerId === playerId,
+    );
+  }
+
+  IsInEnemyFountain(unit: CDOTA_BaseNPC): boolean {
+    const enemyTeam =
+      unit.GetTeamNumber() === DotaTeam.GOODGUYS ? DotaTeam.BADGUYS : DotaTeam.GOODGUYS;
+    return this.IsInFountainAttackRange(enemyTeam, unit);
+  }
+
+  IsInFountainAttackRange(team: DotaTeam, unitOrPosition: CDOTA_BaseNPC | Vector): boolean {
+    const zone = this.fountains.get(team);
+    if (!zone) return false;
+
+    const position = this.getPosition(unitOrPosition);
+    return this.distance2D(position, zone.center) <= zone.innerRadius;
+  }
+
+  IsInOuterZone(team: DotaTeam, unitOrPosition: CDOTA_BaseNPC | Vector): boolean {
+    const zone = this.fountains.get(team);
+    if (!zone) return false;
+
+    const position = this.getPosition(unitOrPosition);
+    return this.distance2D(position, zone.center) <= zone.outerRadius;
+  }
+
+  IsInDireOuterZone(unitOrPosition: CDOTA_BaseNPC | Vector): boolean {
+    return this.IsInOuterZone(DotaTeam.BADGUYS, unitOrPosition);
+  }
+
+  IsFountainDestroyed(team: DotaTeam): boolean {
+    return this.fountains.get(team)?.destroyed ?? false;
+  }
+
+  OnFountainDestroyed(team: DotaTeam): void {
+    const zone = this.fountains.get(team);
+    if (!zone || zone.destroyed) return;
+
+    zone.destroyed = true;
+    zone.hiddenHealth = 0;
+    const damageProxy = zone.damageProxy;
+    zone.damageProxy = undefined;
+    if (damageProxy) {
+      Timers.CreateTimer(0, () => {
+        if (IsValidEntity(damageProxy)) {
+          UTIL_Remove(damageProxy);
+        }
+      });
+    }
+
+    print(`[FountainAntiCamp] fountain destroyed for team ${team}`);
+
+    for (const hero of HeroList.GetAllHeroes()) {
+      this.removeFountainProvidedModifiers(hero, zone.fountain);
+    }
+  }
+
+  IsUnitLocked(unit: CDOTA_BaseNPC | undefined): boolean {
+    return this.isUnitFountainLocked(unit);
+  }
+
+  private onGameStateChanged(): void {
+    if (GameRules.State_Get() !== GameState.PRE_GAME) return;
+
+    Timers.CreateTimer(0.1, () => {
+      this.initializeFountains();
+      this.startThinkTimer();
+    });
+  }
+
+  private initializeFountains(): void {
+    if (!this.IsEnabled() || this.initialized) return;
+
+    const fountains = Entities.FindAllByClassname('ent_dota_fountain') as CDOTA_BaseNPC[];
+    const forts = Entities.FindAllByClassname('npc_dota_fort') as CDOTA_BaseNPC[];
+
+    for (const fountain of fountains) {
+      const team = fountain.GetTeamNumber() as DotaTeam;
+      const fort = forts.find((candidate) => candidate.GetTeamNumber() === team);
+      const center = fountain.GetAbsOrigin();
+      const innerRadius = fountain.Script_GetAttackRange();
+      const outerRadius = fort ? this.distance2D(center, fort.GetAbsOrigin()) : innerRadius;
+
+      const zone: FountainZone = {
+        fountain,
+        center,
+        innerRadius,
+        outerRadius,
+        hiddenHealth: FountainAntiCamp.FOUNTAIN_MAX_HEALTH,
+        lastHealthUpdate: GameRules.GetGameTime(),
+        destroyed: false,
+      };
+      this.fountains.set(team, zone);
+
+      if (!fountain.HasModifier(modifier_fountain_destructible.name)) {
+        fountain.AddNewModifier(fountain, undefined, modifier_fountain_destructible.name, {});
+      }
+
+      zone.damageProxy = this.createDamageProxy(zone);
+
+      this.enableFountainCombat(fountain);
+
+      print(
+        `[FountainAntiCamp] initialized team=${team} inner=${innerRadius} outer=${Math.floor(outerRadius)}`,
+      );
+    }
+
+    this.initialized = this.fountains.size > 0;
+  }
+
+  private enableFountainCombat(fountain: CDOTA_BaseNPC): void {
+    let splitShot = fountain.FindAbilityByName('tower_split_shot');
+    if (!splitShot) {
+      splitShot = fountain.AddAbility('tower_split_shot');
+    }
+    if (splitShot !== undefined) {
+      splitShot.SetLevel(4);
+      if (!splitShot.GetToggleState()) {
+        splitShot.ToggleAbility();
+      }
+    }
+
+    if (!fountain.HasModifier(modifier_fountain_attack_percent_damage.name)) {
+      fountain.AddNewModifier(
+        fountain,
+        splitShot,
+        modifier_fountain_attack_percent_damage.name,
+        {},
+      );
+    }
+  }
+
+  private startThinkTimer(): void {
+    Timers.RemoveTimer(FountainAntiCamp.THINK_TIMER);
+    Timers.CreateTimer(FountainAntiCamp.THINK_TIMER, {
+      endTime: FountainAntiCamp.THINK_INTERVAL,
+      callback: () => {
+        this.onThink();
+        return FountainAntiCamp.THINK_INTERVAL;
+      },
+    });
+  }
+
+  private onThink(): void {
+    if (!this.initialized) {
+      this.initializeFountains();
+      return;
+    }
+
+    const now = GameRules.GetGameTime();
+    for (const zone of this.fountains.values()) {
+      if (zone.destroyed) {
+        this.removeFountainBuffsFromHeroes(zone.fountain);
+      } else {
+        this.updateHiddenHealth(zone, now);
+      }
+    }
+
+    if (!this.IsEnabled()) return;
+
+    PlayerHelper.ForEachPlayer((playerId) => {
+      const player = PlayerResource.GetPlayer(playerId);
+      const hero = player?.GetAssignedHero();
+      if (!hero || !hero.IsRealHero()) return;
+
+      if (PlayerHelper.IsHumanPlayerByPlayerId(playerId)) {
+        this.ensureModifier(hero, modifier_fountain_damage_statistics.name);
+        this.updateIntrusionModifier(hero);
+      } else if (this.isDireBotHero(hero)) {
+        this.ensureModifier(hero, modifier_fountain_reward_tracker.name);
+      }
+    });
+  }
+
+  private updateIntrusionModifier(hero: CDOTA_BaseNPC_Hero): void {
+    const enemyTeam =
+      hero.GetTeamNumber() === DotaTeam.GOODGUYS ? DotaTeam.BADGUYS : DotaTeam.GOODGUYS;
+    const enemyFountain = this.fountains.get(enemyTeam);
+    const isInOuterZone =
+      enemyFountain !== undefined &&
+      !enemyFountain.destroyed &&
+      hero.IsAlive() &&
+      this.IsInOuterZone(enemyTeam, hero);
+    const isInFountain = isInOuterZone && this.IsInFountainAttackRange(enemyTeam, hero);
+
+    if (isInFountain) {
+      hero.RemoveModifierByName(modifier_fountain_outer_zone.name);
+      this.ensureModifier(
+        hero,
+        modifier_fountain_intrusion.name,
+        enemyFountain.fountain,
+        enemyFountain.fountain.FindAbilityByName('fountain_hp_aura'),
+      );
+    } else if (isInOuterZone) {
+      hero.RemoveModifierByName(modifier_fountain_intrusion.name);
+      this.ensureModifier(
+        hero,
+        modifier_fountain_outer_zone.name,
+        enemyFountain.fountain,
+        enemyFountain.fountain.FindAbilityByName('fountain_hp_aura'),
+      );
+    } else {
+      hero.RemoveModifierByName(modifier_fountain_intrusion.name);
+      hero.RemoveModifierByName(modifier_fountain_outer_zone.name);
+    }
+  }
+
+  private ensureModifier(
+    unit: CDOTA_BaseNPC,
+    modifierName: string,
+    caster: CDOTA_BaseNPC = unit,
+    ability?: CDOTABaseAbility,
+  ): void {
+    if (!unit.HasModifier(modifierName)) {
+      unit.AddNewModifier(caster, ability, modifierName, {});
+    }
+  }
+
+  private filterHealing(event: HealingFilterEvent): boolean {
+    const target = EntIndexToHScript(event.entindex_target_const) as CDOTA_BaseNPC | undefined;
+    if (target && this.getZoneByDamageProxy(target)) {
+      event.heal = 0;
+      return true;
+    }
+
+    if (this.IsEnabled() && target && this.isUnitFountainLocked(target)) {
+      event.heal = 0;
+    }
+    return true;
+  }
+
+  private filterExecuteOrder(event: ExecuteOrderFilterEvent): boolean {
+    if (!this.IsEnabled() || !this.isAbilityUseOrder(event.order_type)) return true;
+
+    if (event.entindex_ability > 0) {
+      const ability = EntIndexToHScript(event.entindex_ability) as CDOTABaseAbility | undefined;
+      const caster = ability?.GetCaster();
+      if (caster && this.isUnitOrOwnerLocked(caster)) return false;
+    }
+
+    for (const [, entityIndex] of pairs(event.units)) {
+      const unit = EntIndexToHScript(entityIndex) as CDOTA_BaseNPC | undefined;
+      if (unit && this.isUnitOrOwnerLocked(unit)) return false;
+    }
+
+    return true;
+  }
+
+  private filterDamage(event: FountainDamageFilterEvent): boolean {
+    const victim = EntIndexToHScript(event.entindex_victim_const) as CDOTA_BaseNPC | undefined;
+    const attacker = EntIndexToHScript(event.entindex_attacker_const) as CDOTA_BaseNPC | undefined;
+
+    if (attacker && this.shouldBlockLockedUnitDamage(event, attacker)) {
+      return false;
+    }
+
+    if (
+      this.IsEnabled() &&
+      victim &&
+      this.isDireBotHero(victim) &&
+      event.damage > 0 &&
+      event.damage >= victim.GetHealth()
+    ) {
+      this.RecordDireBotDeath(victim, attacker);
+    }
+
+    const zone = victim ? this.getZoneByDamageProxy(victim) : undefined;
+    if (!zone) return true;
+    if (zone.destroyed) return false;
+
+    if (!attacker || attacker.GetTeamNumber() === zone.fountain.GetTeamNumber()) return false;
+
+    this.updateHiddenHealth(zone, GameRules.GetGameTime());
+    zone.hiddenHealth = Math.max(0, zone.hiddenHealth - Math.max(0, event.damage));
+    if (zone.hiddenHealth <= 0) {
+      const modifier = zone.fountain.FindModifierByName(modifier_fountain_destructible.name) as
+        | modifier_fountain_destructible
+        | undefined;
+      modifier?.DestroyFountain();
+    }
+
+    return false;
+  }
+
+  private createDamageProxy(zone: FountainZone): CDOTA_BaseNPC | undefined {
+    const proxy = CreateUnitByName(
+      FountainAntiCamp.DAMAGE_PROXY_UNIT,
+      zone.center,
+      false,
+      zone.fountain,
+      zone.fountain,
+      zone.fountain.GetTeamNumber(),
+    );
+    if (!proxy) {
+      print(
+        `[FountainAntiCamp] failed to create damage proxy for team ${zone.fountain.GetTeamNumber()}`,
+      );
+      return undefined;
+    }
+
+    proxy.AddNoDraw();
+    proxy.SetIdleAcquire(false);
+    proxy.SetAcquisitionRange(0);
+    proxy.SetAttackCapability(UnitAttackCapability.NO_ATTACK);
+    proxy.AddNewModifier(proxy, undefined, modifier_fountain_damage_proxy.name, {});
+    return proxy;
+  }
+
+  private getZoneByDamageProxy(unit: CDOTA_BaseNPC): FountainZone | undefined {
+    for (const zone of this.fountains.values()) {
+      if (zone.damageProxy === unit) return zone;
+    }
+    return undefined;
+  }
+
+  private updateHiddenHealth(zone: FountainZone, now: number): void {
+    const elapsed = Math.max(0, now - zone.lastHealthUpdate);
+    zone.lastHealthUpdate = now;
+    zone.hiddenHealth = Math.min(
+      FountainAntiCamp.FOUNTAIN_MAX_HEALTH,
+      zone.hiddenHealth + elapsed * FountainAntiCamp.FOUNTAIN_HEALTH_REGEN,
+    );
+  }
+
+  private onEntityKilled(event: EntityKilledEvent): void {
+    if (!this.IsEnabled()) return;
+
+    const victim = EntIndexToHScript(event.entindex_killed) as CDOTA_BaseNPC | undefined;
+    if (!victim || !this.isDireBotHero(victim)) return;
+
+    const attacker = EntIndexToHScript(event.entindex_attacker) as CDOTA_BaseNPC | undefined;
+    this.RecordDireBotDeath(victim, attacker);
+  }
+
+  private isAbilityUseOrder(orderType: dotaunitorder_t): boolean {
+    switch (orderType) {
+      case UnitOrder.CAST_POSITION:
+      case UnitOrder.CAST_TARGET:
+      case UnitOrder.CAST_TARGET_TREE:
+      case UnitOrder.CAST_NO_TARGET:
+      case UnitOrder.CAST_TOGGLE:
+      case UnitOrder.CAST_TOGGLE_AUTO:
+      case UnitOrder.CAST_RUNE:
+      case UnitOrder.VECTOR_TARGET_POSITION:
+      case UnitOrder.CAST_TOGGLE_ALT:
+      case UnitOrder.CONSUME_ITEM:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private shouldBlockLockedUnitDamage(
+    event: FountainDamageFilterEvent,
+    attacker: CDOTA_BaseNPC,
+  ): boolean {
+    if (!this.IsEnabled() || event.damage <= 0 || !this.isUnitOrOwnerLocked(attacker)) {
+      return false;
+    }
+
+    if (event.entindex_inflictor_const !== undefined && event.entindex_inflictor_const > 0) {
+      return true;
+    }
+
+    const damageFlags = event.damage_flags ?? DamageFlag.NONE;
+    return (
+      (damageFlags & DamageFlag.REFLECTION) === DamageFlag.REFLECTION ||
+      (damageFlags & DamageFlag.SECONDARY_PROJECTILE_ATTACK) ===
+        DamageFlag.SECONDARY_PROJECTILE_ATTACK
+    );
+  }
+
+  private isUnitOrOwnerLocked(unit: CDOTA_BaseNPC): boolean {
+    if (this.isUnitFountainLocked(unit)) return true;
+    return this.isUnitFountainLocked(this.getOwnerHero(unit));
+  }
+
+  private isDireBotHero(unit: CDOTA_BaseNPC | undefined): unit is CDOTA_BaseNPC_Hero {
+    return (
+      unit !== undefined &&
+      unit.IsRealHero() &&
+      unit.GetTeamNumber() === DotaTeam.BADGUYS &&
+      PlayerHelper.IsBotPlayer(unit)
+    );
+  }
+
+  private isUnitFountainLocked(unit: CDOTA_BaseNPC | undefined): boolean {
+    if (!this.IsEnabled() || !unit || !unit.HasModifier(modifier_fountain_intrusion.name)) {
+      return false;
+    }
+
+    const modifier = unit.FindModifierByName(modifier_fountain_intrusion.name) as
+      | modifier_fountain_intrusion
+      | undefined;
+    return modifier !== undefined && modifier.GetElapsedTime() >= 5;
+  }
+
+  private getDireZoneMultiplier(position: Vector): number {
+    if (this.IsInFountainAttackRange(DotaTeam.BADGUYS, position)) return 0;
+    if (this.IsInDireOuterZone(position)) return 0.1;
+    return 1;
+  }
+
+  private getOwningPlayerId(unit: CDOTA_BaseNPC): PlayerID {
+    const directPlayerId = unit.GetPlayerOwnerID();
+    if (directPlayerId >= 0) return directPlayerId;
+
+    const ownerHero = this.getOwnerHero(unit);
+    return ownerHero?.GetPlayerOwnerID() ?? (-1 as PlayerID);
+  }
+
+  private getOwnerHero(unit: CDOTA_BaseNPC): CDOTA_BaseNPC_Hero | undefined {
+    if (unit.IsRealHero()) return unit as CDOTA_BaseNPC_Hero;
+
+    const owner = unit.GetOwnerEntity();
+    if (owner?.IsBaseNPC() && owner.IsRealHero()) return owner as CDOTA_BaseNPC_Hero;
+
+    const playerId = unit.GetPlayerOwnerID();
+    if (playerId >= 0) {
+      return PlayerResource.GetSelectedHeroEntity(playerId) ?? undefined;
+    }
+    return undefined;
+  }
+
+  private removeFountainBuffsFromHeroes(fountain: CDOTA_BaseNPC): void {
+    for (const hero of HeroList.GetAllHeroes()) {
+      this.removeFountainProvidedModifiers(hero, fountain);
+    }
+  }
+
+  private removeFountainProvidedModifiers(unit: CDOTA_BaseNPC, fountain: CDOTA_BaseNPC): void {
+    for (const modifier of unit.FindAllModifiers()) {
+      if (modifier.GetCaster() === fountain) {
+        unit.RemoveModifierByNameAndCaster(modifier.GetName(), fountain);
+      }
+    }
+  }
+
+  private pruneRewardContexts(now: number): void {
+    for (let i = this.rewardContexts.length - 1; i >= 0; i--) {
+      if (this.rewardContexts[i].expiresAt < now) {
+        this.rewardContexts.splice(i, 1);
+      }
+    }
+  }
+
+  private getPosition(unitOrPosition: CDOTA_BaseNPC | Vector): Vector {
+    const possiblePosition = unitOrPosition as Vector;
+    if (possiblePosition.x !== undefined && possiblePosition.y !== undefined) {
+      return possiblePosition;
+    }
+    return (unitOrPosition as CDOTA_BaseNPC).GetAbsOrigin();
+  }
+
+  private distance2D(first: Vector, second: Vector): number {
+    const dx = first.x - second.x;
+    const dy = first.y - second.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+}

--- a/src/vscripts/modules/index.ts
+++ b/src/vscripts/modules/index.ts
@@ -12,6 +12,7 @@ import { Debug } from './debug/Debug';
 import { HeroDebugPanel } from './debug-panel/hero-debug-panel';
 import { Event } from './event/event';
 import { GoldXPFilter } from './filter/gold-xp-filter';
+import { FountainAntiCamp } from './fountain/fountain-anti-camp';
 import { Lottery } from './lottery/lottery';
 import { Option } from './option';
 import { PropertyController } from './property/property_controller';
@@ -27,6 +28,7 @@ declare global {
     Lottery: Lottery;
     Event: Event;
     GoldXPFilter: GoldXPFilter;
+    FountainAntiCamp: FountainAntiCamp;
     Treasure: Treasure;
     WardSlot: WardSlot;
   }
@@ -68,6 +70,8 @@ export function ActivateModules() {
   if (GameRules.GameConfig == null) GameRules.GameConfig = new GameConfig();
 
   if (GameRules.Option == null) GameRules.Option = new Option();
+
+  if (GameRules.FountainAntiCamp == null) GameRules.FountainAntiCamp = new FountainAntiCamp();
 
   if (GameRules.Lottery == null) GameRules.Lottery = new Lottery();
 

--- a/src/vscripts/modules/option.ts
+++ b/src/vscripts/modules/option.ts
@@ -16,6 +16,7 @@ export class Option {
   fixedAbility = 'none';
   forceRandomHero = false;
   enablePlayerAttribute = true;
+  enableFountainAntiCamp = false;
 
   gameDifficulty = 0;
   midOnlyMode = false;
@@ -51,6 +52,7 @@ export class Option {
     this.fixedAbility = keys.fixed_ability;
     this.forceRandomHero = keys.force_random_hero === 1;
     this.enablePlayerAttribute = keys.enable_player_attribute === 1;
+    this.enableFountainAntiCamp = keys.enable_fountain_anti_camp === 1;
     this.midOnlyMode = keys.mid_only_mode === 1;
     CustomNetTables.SetTableValue('game_options', 'game_options', keys);
     CustomNetTables.SetTableValue('game_options', 'point_multiplier', {


### PR DESCRIPTION
## Issue

- 无关联 Issue。

## Checklist

- [x] VScripts、Panorama 构建、代码检查及定向单元测试均已通过。
- [x] 已在本地 Dota Tools 对局中触发泉水区域击杀流程。
- [ ] 泉水被摧毁场景尚未在 Dota Tools 中测试。

## 修改内容

- N1-N8 难度固定启用防堵泉机制；自定义模式提供独立勾选项，默认不启用，可由房主选择开启。
- 玩家进入夜魇基地外圈后，击杀 AI 英雄只能获得 10% 金币和经验；AI 死亡在泉水区域内时不提供金币和经验。
- 玩家在泉水内停留超过 5 秒后，禁止使用装备和主动技能，被动、自定义受击效果、治疗、回复及吸血无法生效，离开泉水后解除。
- 泉水获得分裂攻击和最大生命值伤害；泉水区域内受到的伤害不计入累计承伤。
- 双方泉水拥有隐藏生命值和生命回复，只能受到区域、弹射、散播、反弹等非直接选中泉水的伤害；泉水被摧毁后仅保留英雄复活功能。
- 在泉水击杀奖励为 0 时保留引擎原生击杀事件，使左下角战斗信息仍能显示真实击杀者和伤害来源。

## 影响范围

- **游戏性与平衡：** N1-N8 固定启用防堵泉规则，自定义模式可选启用。
- **数值：** 夜魇基地外圈击杀奖励为 10%；泉水区域击杀奖励为 0；泉水攻击附带 1% 最大生命值伤害，目标在泉水内停留超过 5 秒后提高至 5%。
- **界面与本地化：** 新增选择页面选项、状态效果及相关中英文文本。
- **特效与音效：** 未新增自定义粒子或音效。

## 测试情况

- `npm run build:vscripts`
- `npm run build:panorama`
- `npm run lint`
- `npm test -- --runInBand src/vscripts/modules/filter/gold-xp-filter.test.ts`：9 项测试全部通过
- `git diff --check`
- 泉水被摧毁后的完整功能失效场景尚未进行游戏内实测。

## Release Note

```
[b]游戏性更新 v5.42[/b]

- 新增夜魇基地防堵泉机制：N1-N8 固定启用，自定义模式可选择开启；该机制限制基地与泉水区域内的击杀收益，并压制长时间进入泉水的玩家。
```

```
[b]Gameplay update v5.42[/b]

- Added a Dire base anti-camping system that is always enabled in N1-N8 and optional in Custom mode, limiting kill rewards around the base and suppressing players who remain in the fountain.
```