### PR TITLE
Remove Light/Dark Part purchase cooldown; move up Fusion Rune buy time

### DIFF
--- a/content/panorama/layout/custom_game/custom_loading_screen.xml
+++ b/content/panorama/layout/custom_game/custom_loading_screen.xml
@@ -36,6 +36,7 @@
 							<Label text="10" id="10"/>
 							<Label text="11" id="11"/>
 							<Label text="12" id="12"/>
+							<Label text="14" id="14"/>
 							<Label text="15" id="15"/>
 							<Label text="20" id="20"/>
 							<Label text="#bot_gold_xp_multiplier_40" id="40"/>

--- a/content/panorama/scripts/custom_game/game_mode.js
+++ b/content/panorama/scripts/custom_game/game_mode.js
@@ -240,9 +240,9 @@ function InitN7Setting() {
 }
 function InitN8Setting() {
   $('#player_gold_xp_multiplier_dropdown').SetSelected('1.5');
-  $('#bot_gold_xp_multiplier_dropdown').SetSelected('15');
+  $('#bot_gold_xp_multiplier_dropdown').SetSelected('14');
 
-  $('#tower_power_dropdown').SetSelected('400');
+  $('#tower_power_dropdown').SetSelected('500');
 
   $('#starting_gold_player_dropdown').SetSelected('3000');
   $('#starting_gold_bot_dropdown').SetSelected('5000');

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1201,9 +1201,9 @@
 
 		// Witch Doctor Divine Words - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_upgrade"					"<font color='#d000ff'>Divine Words Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_upgrade_Description"		"By communing with the gods, Witch Doctor's Death Wards and Voodoo Switcheroo wards gain attack damage scaled by his current Spell Amplification when summoned."
+		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_upgrade_Description"		"By communing with the gods, Witch Doctor's Death Wards and Voodoo Switcheroo wards gain attack damage scaled by %spell_amp_ratio_pct%%% of his current Spell Amplification when summoned."
 		"DOTA_Tooltip_modifier_special_bonus_unique_witch_doctor_upgrade"					"<font color='#d000ff'>Divine Words Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_witch_doctor_upgrade_Description"		"By communing with the gods, Witch Doctor's Death Wards and Voodoo Switcheroo wards gain attack damage scaled by his current Spell Amplification when summoned."
+		"DOTA_Tooltip_modifier_special_bonus_unique_witch_doctor_upgrade_Description"		"By communing with the gods, Witch Doctor's Death Wards and Voodoo Switcheroo wards gain attack damage scaled by 50%%% of his current Spell Amplification when summoned."
 
 		// Shadow Fiend Requiem Guard - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>Requiem of Souls Guard Awakened</font>"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3058,35 +3058,35 @@
 		// 融合符文系列
 		// 鹰眼符文
 		"DOTA_Tooltip_ability_item_fusion_hawkeye"										"Hawkeye Rune"
-		"DOTA_Tooltip_ability_item_fusion_hawkeye_Description"							"A mysterious fusion rune containing the power of hawkeye. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Hawkeye Turret, Hawkeye Fighter\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_hawkeye_Description"							"A mysterious fusion rune containing the power of hawkeye. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Hawkeye Turret, Hawkeye Fighter"
 
 		// 禁忌符文
 		"DOTA_Tooltip_ability_item_fusion_forbidden"									"Forbidden Rune"
-		"DOTA_Tooltip_ability_item_fusion_forbidden_Description"						"A mysterious fusion rune containing forbidden power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Forbidden Staff, Forbidden Blade\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_forbidden_Description"						"A mysterious fusion rune containing forbidden power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Forbidden Staff, Forbidden Blade"
 
 		// 暴虐符文
 		"DOTA_Tooltip_ability_item_fusion_brutal"										"Brutal Rune"
-		"DOTA_Tooltip_ability_item_fusion_brutal_Description"							"A mysterious fusion rune containing brutal power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Guihai Blade, Dragon Dance\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_brutal_Description"							"A mysterious fusion rune containing brutal power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Guihai Blade, Dragon Dance"
 
 		// 兽化符文
 		"DOTA_Tooltip_ability_item_fusion_beast"										"Beast Rune"
-		"DOTA_Tooltip_ability_item_fusion_beast_Description"							"A mysterious fusion rune containing beastly power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Beast Shield, Beast Armor\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_beast_Description"							"A mysterious fusion rune containing beastly power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Beast Shield, Beast Armor"
 
 		// 生命符文
 		"DOTA_Tooltip_ability_item_fusion_life"											"Life Rune"
-		"DOTA_Tooltip_ability_item_fusion_life_Description"								"A mysterious fusion rune containing life power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Withered Spring, Dracula Mask\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_life_Description"								"A mysterious fusion rune containing life power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Withered Spring, Dracula Mask"
 
 		// 暗影符文
 		"DOTA_Tooltip_ability_item_fusion_shadow"										"Shadow Rune"
-		"DOTA_Tooltip_ability_item_fusion_shadow_Description"							"A mysterious fusion rune containing shadow power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Shadow Judgment, Shadow Impact\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_shadow_Description"							"A mysterious fusion rune containing shadow power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Shadow Judgment, Shadow Impact"
 
 		// 魔化符文
 		"DOTA_Tooltip_ability_item_fusion_magic"										"Magic Rune"
-		"DOTA_Tooltip_ability_item_fusion_magic_Description"							"A mysterious fusion rune containing arcane power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Magic Sword, Time Gem\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_magic_Description"							"A mysterious fusion rune containing arcane power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Magic Sword, Time Gem"
 
 		// 灵动符文
 		"DOTA_Tooltip_ability_item_fusion_agile"										"Agile Rune"
-		"DOTA_Tooltip_ability_item_fusion_agile_Description"							"A mysterious fusion rune containing agile power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Swift Glove, Ten Thousand Swords\n\n<font color='#70B0FF'>Stock Refresh Time: First at 9 minutes, replenished every 3 minutes</font>"
+		"DOTA_Tooltip_ability_item_fusion_agile_Description"							"A mysterious fusion rune containing agile power. Can be obtained by killing neutral creeps. Currently available for limited-time purchase.\n\n<font color='#FFCC66'>Can craft:</font> Swift Glove, Ten Thousand Swords"
 
 		// item_universal_rune 通用符文
 		"DOTA_Tooltip_Ability_item_universal_rune"										"Universal Rune"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1199,9 +1199,9 @@
 
 		// 巫医 神语-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_upgrade"					"<font color='#d000ff'>神语 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_upgrade_Description"		"巫医沟通神明，死亡守卫与变身术守卫被召唤时，攻击力按巫医当前的技能增强等比提升。"
+		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_upgrade_Description"		"巫医沟通神明，死亡守卫与变身术守卫被召唤时，攻击力按巫医当前技能增强的%spell_amp_ratio_pct%%%等比提升。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_witch_doctor_upgrade"					"<font color='#d000ff'>神语 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_witch_doctor_upgrade_Description"		"巫医沟通神明，死亡守卫与变身术守卫被召唤时，攻击力按巫医当前的技能增强等比提升。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_witch_doctor_upgrade_Description"		"巫医沟通神明，死亡守卫与变身术守卫被召唤时，攻击力按巫医当前技能增强的50%%%等比提升。"
 
 		// 影魔 安魂曲护体-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>魂之挽歌护体 觉醒</font>"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -941,7 +941,7 @@
 		// 狙击手 暗杀-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_sniper_assassinate_upgrade"							"<font color='#d000ff'>暗杀 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_sniper_assassinate_upgrade_Description"				"狙击手锁定区域内的敌方英雄，发射毁灭性的子弹，在远距离造成一次必定暴击的攻击，并附带额外物理伤害。<br><br><font color='#FFFFFF'>神杖升级：命中的敌方英雄附加眩晕效果。</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_sniper_assassinate_upgrade_Lore"						"扣下扳机的那一刻，整片战场都为之屏息。 — by RN"
+		"DOTA_Tooltip_ability_special_bonus_unique_sniper_assassinate_upgrade_Lore"						"扣下扳机的那一刻，整片战场都为之屏息。"
 		"DOTA_Tooltip_ability_special_bonus_unique_sniper_assassinate_upgrade_Note0"						"准星效果只对友军可见。"
 		"DOTA_Tooltip_ability_special_bonus_unique_sniper_assassinate_upgrade_Note1"						"隐身不会使弹道偏移。"
 		"DOTA_Tooltip_ability_special_bonus_unique_sniper_assassinate_upgrade_Note2"						"打断引导法术，包括对魔法免疫单位。"
@@ -1173,7 +1173,7 @@
 		// 斧王 无情铁手-觉醒
 		"DOTA_Tooltip_ability_axe_auto_culling_blade"									"<font color='#d000ff'>无情铁手 觉醒</font>"
 		"DOTA_Tooltip_ability_axe_auto_culling_blade_Description"						"<font color='#FF0000'>自动施放：自动斩杀</font><br><br>开启自动施法后，只要淘汰之刃冷却就绪，斧王便自动检测施法范围内血量低于斩杀线的敌方英雄并立即施放淘汰之刃。"
-		"DOTA_Tooltip_ability_axe_auto_culling_blade_Lore"								"利刃所向，皆为收割。 — by RN"
+		"DOTA_Tooltip_ability_axe_auto_culling_blade_Lore"								"利刃所向，皆为收割。"
 
 		// 死灵法师 竭心光环-觉醒
 		"DOTA_Tooltip_ability_necrolyte_heartstopper_aura_datadriven"					"<font color='#d000ff'>竭心光环 觉醒</font>"
@@ -3060,35 +3060,35 @@
 		// 融合符文系列
 		// 鹰眼符文
 		"DOTA_Tooltip_ability_item_fusion_hawkeye"										"鹰眼符文"
-		"DOTA_Tooltip_ability_item_fusion_hawkeye_Description"							"一种神秘的融合符文,蕴含着鹰眼的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 鹰眼炮台、鹰眼战机\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_hawkeye_Description"							"一种神秘的融合符文,蕴含着鹰眼的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 鹰眼炮台、鹰眼战机"
 
 		// 禁忌符文
 		"DOTA_Tooltip_ability_item_fusion_forbidden"									"禁忌符文"
-		"DOTA_Tooltip_ability_item_fusion_forbidden_Description"						"一种神秘的融合符文,蕴含着禁忌的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 禁忌法锤、禁忌战刃\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_forbidden_Description"						"一种神秘的融合符文,蕴含着禁忌的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 禁忌法锤、禁忌战刃"
 
 		// 暴虐符文
 		"DOTA_Tooltip_ability_item_fusion_brutal"										"暴虐符文"
-		"DOTA_Tooltip_ability_item_fusion_brutal_Description"							"一种神秘的融合符文,蕴含着暴虐的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 归海一刀、魔龙狂舞\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_brutal_Description"							"一种神秘的融合符文,蕴含着暴虐的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 归海一刀、魔龙狂舞"
 
 		// 兽化符文
 		"DOTA_Tooltip_ability_item_fusion_beast"										"兽化符文"
-		"DOTA_Tooltip_ability_item_fusion_beast_Description"							"一种神秘的融合符文,蕴含着兽化的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 兽化盾、兽化甲\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_beast_Description"							"一种神秘的融合符文,蕴含着兽化的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 兽化盾、兽化甲"
 
 		// 生命符文
 		"DOTA_Tooltip_ability_item_fusion_life"											"生命符文"
-		"DOTA_Tooltip_ability_item_fusion_life_Description"								"一种神秘的融合符文,蕴含着生命的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 生命之心、生命之盔\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_life_Description"								"一种神秘的融合符文,蕴含着生命的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 生命之心、生命之盔"
 
 		// 暗影符文
 		"DOTA_Tooltip_ability_item_fusion_shadow"										"暗影符文"
-		"DOTA_Tooltip_ability_item_fusion_shadow_Description"							"一种神秘的融合符文,蕴含着暗影的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 暗影裁决、暗影咒灭\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_shadow_Description"							"一种神秘的融合符文,蕴含着暗影的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 暗影裁决、暗影咒灭"
 
 		// 魔化符文
 		"DOTA_Tooltip_ability_item_fusion_magic"										"魔化符文"
-		"DOTA_Tooltip_ability_item_fusion_magic_Description"							"一种神秘的融合符文,蕴含着魔化的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 魔渊剑、时间宝石\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_magic_Description"							"一种神秘的融合符文,蕴含着魔化的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 魔渊剑、时间宝石"
 
 		// 灵动符文
 		"DOTA_Tooltip_ability_item_fusion_agile"										"灵动符文"
-		"DOTA_Tooltip_ability_item_fusion_agile_Description"							"一种神秘的融合符文,蕴含着灵动的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 无限手套、万剑归宗\n\n<font color='#70B0FF'>库存刷新时间：9分钟首次，每3分钟补充</font>"
+		"DOTA_Tooltip_ability_item_fusion_agile_Description"							"一种神秘的融合符文,蕴含着灵动的力量。击杀中立生物有概率获得。目前限时开放购买\n\n<font color='#FFCC66'>可合成:</font> 无限手套、万剑归宗"
 
 		// item_universal_rune 通用符文
 		"DOTA_Tooltip_Ability_item_universal_rune"										"通用符文"
@@ -3098,7 +3098,7 @@
 		// 鹰眼炮台
 		"DOTA_Tooltip_Ability_item_hawkeye_turret"										"鹰眼炮台"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_Description"							"<h1><font color='#FFFF00'>主动：人形炮台（仅限远程）</font></h1>化身炮台，变为飞行单位，获得高空视野。持续%active_duration%秒，禁锢无法移动，获得额外攻击距离%active_attack_range%，视野范围为攻击距离 + %active_bonus_vision%。<br><br><font color='#FF6B6B'>近战英雄使用没有效果。</font>\n<h1>被动：霰弹（仅限远程）</h1>对攻击目标周围%attack_radius%范围内的敌人造成%attack_percent%%%溅射伤害。<br/>霰弹特效无法叠加，拥有%internal_cooldown%秒内置冷却。\n<h1>被动：绝对腐蚀</h1>物理攻击将降低目标%corruption_armor%点护甲，持续%corruption_duration%秒。<br><br>每次有英雄死于毁蚀效果下就会+%bonus_damage_per_kill%点攻击力，最多获得%max_damage%点。"
-		"DOTA_Tooltip_ability_item_hawkeye_turret_Lore"									"化身为固定炮台，以强大的火力压制敌人。 — by RN"
+		"DOTA_Tooltip_ability_item_hawkeye_turret_Lore"									"化身为固定炮台，以强大的火力压制敌人。"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_Note0"								"护甲降低效果对建筑有效。"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_bonus_damage"							"+$damage"
 		"DOTA_Tooltip_ability_item_hawkeye_turret_bonus_attack_speed"					"+$attack"
@@ -3110,7 +3110,7 @@
 		// 鹰眼战机
 		"DOTA_Tooltip_Ability_item_hawkeye_fighter"										"鹰眼战机"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_Description"							"<h1><font color='#FFFF00'>主动: 人形战斗机</font></h1>激活战机模式，获得高空视野和极高的机动性。持续%active_duration%秒内，获得%active_movement_speed_pct%%%移速加成，变为飞行单位，无视地形移动，无视单位碰撞，无视移速上限，并施加弱驱散效果。<br><br>冷却时间：%AbilityCooldown%秒<br><br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>"
-		"DOTA_Tooltip_ability_item_hawkeye_fighter_Lore"								"化身战机,翱翔天际,无人能及。 — by RN"
+		"DOTA_Tooltip_ability_item_hawkeye_fighter_Lore"								"化身战机,翱翔天际,无人能及。"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_bonus_all_stats"						"+$all"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_bonus_movement_speed"				"+移动速度（可叠加）"
 		"DOTA_Tooltip_ability_item_hawkeye_fighter_bonus_movement_speed_pct"			"%+$move_speed"
@@ -3122,7 +3122,7 @@
 		// 禁忌法锤 Forbidden Staff
 		"DOTA_Tooltip_Ability_item_forbidden_staff"										"<font color='#8B008B'>禁忌法锤</font>"
 		"DOTA_Tooltip_ability_item_forbidden_staff_Description"							"<h1><font color='#8B008B'>主动：禁忌领域</font></h1>在目标区域施放禁忌领域,对范围内所有敌人施放死灵冲击，闪电风暴和变羊术。<br><br>死灵冲击：降低敌人 %blast_magic_resist%%% 点的魔法抗性（固定值），造成%necrolyte_att_multiplier%x[你的全属性]点魔法伤害,并将目标变成小动物%sheep_duration%秒<br><br>闪电风暴：造成%lightning_damage%点魔法伤害<br><br>额外效果：清除范围内敌方的侦查守卫和岗哨守卫<br><br>作用范围：%radius_tooltip%"
-		"DOTA_Tooltip_ability_item_forbidden_staff_Lore"								"禁忌的力量,不可轻易触碰。 — by RN"
+		"DOTA_Tooltip_ability_item_forbidden_staff_Lore"								"禁忌的力量,不可轻易触碰。"
 		"DOTA_Tooltip_ability_item_forbidden_staff_Note0"								"死灵冲击会将目标变成无害的小动物,无法攻击，施法或使用物品。"
 		"DOTA_Tooltip_ability_item_forbidden_staff_bonus_aoe"							"+$aoe_bonus"
 		"DOTA_Tooltip_ability_item_forbidden_staff_bonus_hp"							"+$health"
@@ -3138,7 +3138,7 @@
 		// 禁忌战刃
 		"DOTA_Tooltip_Ability_item_forbidden_blade"										"<font color='#8B008B'>禁忌战刃</font>"
 		"DOTA_Tooltip_ability_item_forbidden_blade_Description"							"<h1><font color='#8B008B'>主动：忌炼杀狱</font></h1>在目标区域施放忌炼杀狱,对%radius%范围内所有敌人施放一闪，闪电风暴和毁灭终曲。<br><br>一闪眩晕时间：%stun_duration%秒<br>一闪伤害：%active_damage_base%+%active_damage_multi%x[你的主属性](纯粹伤害)<br>闪电风暴伤害：%lightning_damage%<br>毁灭终曲持续时间：%mute_duration%秒<br><br>作用范围：%radius%"
-		"DOTA_Tooltip_ability_item_forbidden_blade_Lore"								"禁忌之刃,斩断一切。 — by RN"
+		"DOTA_Tooltip_ability_item_forbidden_blade_Lore"								"禁忌之刃,斩断一切。"
 		"DOTA_Tooltip_ability_item_forbidden_blade_Note0"								"一闪效果造成纯粹伤害,无视魔法免疫。"
 		"DOTA_Tooltip_ability_item_forbidden_blade_bonus_strength"						"+$str"
 		"DOTA_Tooltip_ability_item_forbidden_blade_bonus_agility"						"+$agi"
@@ -3160,14 +3160,14 @@
 		"DOTA_Tooltip_ability_item_switchable_crit_blade_bonus_damage_percent"			"%+基础伤害"
 		"DOTA_Tooltip_ability_item_switchable_crit_blade_Note0"							"克敌机先: 攻击无视闪避"
 		"DOTA_Tooltip_ability_item_switchable_crit_blade_Note1"							"继承黄金大核荣耀的基础暴击效果"
-		"DOTA_Tooltip_ability_item_switchable_crit_blade_Lore"							"破浪：潮初起时刃轻扬<br>断流：潮横断处月凝霜<br>归海：潮归瀚海刀义藏 — by RN"
+		"DOTA_Tooltip_ability_item_switchable_crit_blade_Lore"							"破浪：潮初起时刃轻扬<br>断流：潮横断处月凝霜<br>归海：潮归瀚海刀义藏"
 		"DOTA_Tooltip_modifier_item_switchable_crit_blade"								"刀势"
 		"DOTA_Tooltip_modifier_item_switchable_crit_blade_Description"					"1=初式·破浪 2=二式·断流 3=终式·归海"
 
 		// 魔龙狂舞
 		"DOTA_Tooltip_Ability_item_magic_crit_blade"									"<font color='#A74ABD'>魔龙狂舞</font>"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_Description"						"<h1><font color='#FF0000'>被动：神圣斧</font></h1>使下次攻击具有克敌机先效果，并且会施加毒素，持续%slow_duration%秒，减缓%slow%%%移动速度，并且每秒造成%int_damage_multiplier%倍智力值的伤害。<br><br>攻击会降低敌人%active_mres_reduction%%%魔法抗性，持续%passive_cooldown%秒。<br><br>所有攻击都具有克敌机先效果。\n<h1><font color='#A74ABD'>主动：龙息爆发</font></h1>使用后%active_duration%秒内，获得%spell_amp_multiplier%倍被智力法术增强。<br><br>冷却时间：%active_cooldown%秒<br>魔法消耗：%AbilityManaCost%\n<h1><font color='#0096FF'>被动：幻影暴击</font></h1>每次攻击有%crit_chance%%%几率造成额外的魔法伤害，数值为攻击伤害的%crit_multiplier%%%。"
-		"DOTA_Tooltip_ability_item_magic_crit_blade_Lore"								"魔龙狂舞，焚天灭地。魔焰龙息席卷万物，法术爆发摧枯拉朽。 — by RN"
+		"DOTA_Tooltip_ability_item_magic_crit_blade_Lore"								"魔龙狂舞，焚天灭地。魔焰龙息席卷万物，法术爆发摧枯拉朽。"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_bonus_intellect"					"+$int"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_bonus_damage"						"+$damage"
 		"DOTA_Tooltip_ability_item_magic_crit_blade_spell_amp_per_int"					"%+每点智力法术增强"
@@ -3198,7 +3198,7 @@
 		// 德古拉面罩/生命之盔
 		"DOTA_Tooltip_Ability_item_dracula_mask"										"<font color='#8B0000'>生命之盔</font>"
 		"DOTA_Tooltip_ability_item_dracula_mask_Description"							"<h1><font color='#90EE90'>主动：吸血盛宴</font></h1>驱散所有负面效果,并在%active_duration%秒内获得:<br>%lifesteal_active%%%物理吸血<br>%spell_lifesteal_active%%%法术吸血<br>+%bonus_attack_speed_active%攻击速度<br>+%bonus_movement_speed_active%%%移动速度<br>%damage_reduction%%%减伤<br>免疫减速<br><br>生命值低于%hp_threshold%%%时自动触发。<br><br>驱散类型：<span class=\"GameplayValues GameplayVariable\">弱驱散</span>"
-		"DOTA_Tooltip_ability_item_dracula_mask_Lore"									"饱含生命之力的头盔,赋予佩戴者永恒的生命力。 — by RN"
+		"DOTA_Tooltip_ability_item_dracula_mask_Lore"									"饱含生命之力的头盔,赋予佩戴者永恒的生命力。"
 		"DOTA_Tooltip_ability_item_dracula_mask_bonus_strength"							"+$str"
 		"DOTA_Tooltip_ability_item_dracula_mask_bonus_health"							"+$health"
 		"DOTA_Tooltip_ability_item_dracula_mask_bonus_damage"							"+$damage"
@@ -3216,7 +3216,7 @@
 		// 暗影裁决
 		"DOTA_Tooltip_Ability_item_shadow_judgment"										"<font color='#8A2BE2'>暗影裁决</font>"
 		"DOTA_Tooltip_ability_item_shadow_judgment_Description"							"<h1>主动：暗影审判</h1>对目标施加暗影审判，融合一闪，苍蓝幻想和变态辣的所有debuff效果。<br><br>一闪：瞬移到目标身后，眩晕%stun_duration%秒，造成%active_damage_base%+%active_damage_multi%x[主属性]点纯粹伤害<br>苍蓝幻想：持续驱散增益，%mute_duration%秒禁用装备和被动，减速%slow_pct%%%，攻击速度减少%attack_slow%，每秒造成%max_hp_dmg_pct%%%最大生命值的纯粹伤害，降低%hp_regen_reduction%%%生命恢复<br>变态辣：沉默%silence_duration%秒，结束时造成期间受到伤害的%silence_damage_percent%%%作为额外魔法伤害<br><br>施法距离：%abilitycastrange%"
-		"DOTA_Tooltip_ability_item_shadow_judgment_Lore"								"暗影的裁决，无人可逃。 — by RN"
+		"DOTA_Tooltip_ability_item_shadow_judgment_Lore"								"暗影的裁决，无人可逃。"
 		"DOTA_Tooltip_ability_item_shadow_judgment_bonus_strength"						"+$str"
 		"DOTA_Tooltip_ability_item_shadow_judgment_bonus_agility"						"+$agi"
 		"DOTA_Tooltip_ability_item_shadow_judgment_bonus_intellect"						"+$int"
@@ -3239,7 +3239,7 @@
 		// 暗影咒灭
 		"DOTA_Tooltip_Ability_item_shadow_impact"										"<font color='#C77DFF'>暗影咒灭</font>"
 		"DOTA_Tooltip_ability_item_shadow_impact_Description"							"<h1>主动：暗影湮灭</h1>对目标施放暗影湮灭。<br><br>纯粹伤害：%absolute_damage%点<br>魔法伤害：%dagon_damage%点<br>虚灵冲击：造成%blast_damage_base%+%blast_agility_multiplier%x[主属性]点魔法伤害,并使目标进入虚灵状态%ethereal_duration%秒,减速%blast_movement_slow%%%<br>死灵冲击：降低敌人 %blast_magic_resist%%% 点的魔法抗性（固定值），造成%necrolyte_att_multiplier%x[全属性]点魔法伤害,并变羊%sheep_duration%秒<br><br>施法距离：%abilitycastrange%"
-		"DOTA_Tooltip_ability_item_shadow_impact_Lore"									"暗影的冲击,毁灭一切。 — by RN"
+		"DOTA_Tooltip_ability_item_shadow_impact_Lore"									"暗影的冲击,毁灭一切。"
 		"DOTA_Tooltip_ability_item_shadow_impact_bonus_intellect"						"+$int"
 		"DOTA_Tooltip_ability_item_shadow_impact_bonus_strength"						"+$str"
 		"DOTA_Tooltip_ability_item_shadow_impact_bonus_agility"							"+$agi"
@@ -3268,7 +3268,7 @@
 
 		"DOTA_Tooltip_Ability_item_ten_thousand_swords"									"万剑归宗"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_Description"						"<h1><font color='#FFFF00'>被动：剑之极致</font></h1>集四把神器对剑之力于一身，大幅提升全属性，状态抗性，攻击速度，移动速度，生命恢复，魔法恢复和技能增强。攻击附带魔法伤害。"
-		"DOTA_Tooltip_ability_item_ten_thousand_swords_Lore"							"万剑归宗，天下无敌。四把神器对剑的力量汇聚于此，铸就无上神兵。 — by RN"
+		"DOTA_Tooltip_ability_item_ten_thousand_swords_Lore"							"万剑归宗，天下无敌。四把神器对剑的力量汇聚于此，铸就无上神兵。"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_bonus_strength"					"+$str"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_bonus_agility"					"+$agi"
 		"DOTA_Tooltip_ability_item_ten_thousand_swords_bonus_intellect"					"+$int"
@@ -3282,7 +3282,7 @@
 
 		"DOTA_Tooltip_Ability_item_time_gem"											"时间宝石"
 		"DOTA_Tooltip_ability_item_time_gem_Description"								"<h1><font color='#FFFF00'>主动：时间重置</font></h1>重置所有物品和技能的冷却时间。<br><br>冷却时间：%AbilityCooldown%秒\n<h1>被动：时间加速</h1>降低所有技能和物品%bonus_cooldown%%%的冷却时间。"
-		"DOTA_Tooltip_ability_item_time_gem_Lore"										"掌控时间的神秘宝石，能让使用者操纵时间的流速。 — by RN"
+		"DOTA_Tooltip_ability_item_time_gem_Lore"										"掌控时间的神秘宝石，能让使用者操纵时间的流速。"
 		"DOTA_Tooltip_ability_item_time_gem_Note0"										"时间重置不会刷新刷新球系列物品（刷新球，刷新核心，时间宝石）。"
 		"DOTA_Tooltip_ability_item_time_gem_Note1"										"与其他刷新球系列物品共享冷却时间。"
 		"DOTA_Tooltip_ability_item_time_gem_bonus_cooldown"								"%+$cooldown_reduction"
@@ -3300,7 +3300,7 @@
 		"DOTA_Tooltip_ability_item_beast_shield_Description"							"<h1>主动：人形肉盾</h1>获得减益免疫状态。进入防御姿态，所有被动属性加成提升%active_bonus_multiplier_tooltip%%%，移动速度固定为%active_movespeed%，持续%active_duration%秒。<br>提供%magic_resist%%%魔法抗性加成，并且免疫纯粹和反弹伤害。持续时间内敌方技能的负面效果不会生效。\n<h1>被动：游泳</h1>受到敌人的技能伤害在减免前的%mana_restore_pct%%%会转化为自身的魔法。\n<h1>被动：强袭光环</h1>为附近友军提供%aura_positive_armor%点护甲和%aura_attack_speed%点攻击速度。降低附近敌军%aura_negative_armor%点护甲。<br><br>作用范围：%aura_radius%"
 		"DOTA_Tooltip_modifier_item_beast_shield_resist_stack"							"潜水服"
 		"DOTA_Tooltip_modifier_item_beast_shield_resist_stack_Description"				"每层增加%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%魔法抗性。"
-		"DOTA_Tooltip_ability_item_beast_shield_Lore"									"融合了兽化符文力量的终极防御装备，能让使用者化身为不可摧毁的堡垒。 — by RN"
+		"DOTA_Tooltip_ability_item_beast_shield_Lore"									"融合了兽化符文力量的终极防御装备，能让使用者化身为不可摧毁的堡垒。"
 		"DOTA_Tooltip_ability_item_beast_shield_passive_bonus_strength"					"+$str"
 		"DOTA_Tooltip_ability_item_beast_shield_passive_bonus_health"					"+$health"
 		"DOTA_Tooltip_ability_item_beast_shield_passive_bonus_armor"					"+$armor"
@@ -3320,7 +3320,7 @@
 		// item_beast_armor 兽化甲
 		"DOTA_Tooltip_Ability_item_beast_armor"											"兽化甲"
 		"DOTA_Tooltip_ability_item_beast_armor_Description"								"<h1>主动：不粘锅</h1>发出极寒冲击波，对%blast_radius%范围内敌人造成%blast_damage%点魔法伤害，降低%movement_slow%%%移动速度和%attack_slow%攻击速度，降低%spell_resist_reduction%%%魔法抗性。<br>同时反弹%active_reflection_pct%%%所有伤害并反弹指向性技能，持续%active_duration%秒。\n<h1>被动：伤害反弹</h1>每次受到攻击时，反弹%passive_reflection_constant% + 所受攻击伤害的%passive_reflection_pct%%%。<br><br>每%block_cooldown%秒被动抵挡一次指向性法术。\n<h1>被动：辉耀灼烧</h1>每秒对%aura_radius%范围内敌军造成%aura_damage%点魔法伤害，并使其物理攻击有%blind_pct%%%几率不会命中。"
-		"DOTA_Tooltip_ability_item_beast_armor_Lore"									"集四大神器之力于一身的终极护甲，兽化符文赋予了它无与伦比的防御和反击能力。 — by RN"
+		"DOTA_Tooltip_ability_item_beast_armor_Lore"									"集四大神器之力于一身的终极护甲，兽化符文赋予了它无与伦比的防御和反击能力。"
 		"DOTA_Tooltip_ability_item_beast_armor_Note0"									"反弹的均为减免前的伤害。"
 		"DOTA_Tooltip_ability_item_beast_armor_Note1"									"伤害反弹不会反弹来自其他刃甲的伤害。"
 		"DOTA_Tooltip_ability_item_beast_armor_Note2"									"反弹伤害的类型与受到时相同。"
@@ -3343,7 +3343,7 @@
 		// item_magic_sword 魔渊剑
 		"DOTA_Tooltip_Ability_item_magic_sword"											"魔渊剑"
 		"DOTA_Tooltip_Ability_item_magic_sword_Description"								"<h1>主动：<font color='#A74ABD'>一念成佛</font></h1>持续 %active_duration% 秒内，你造成的物理伤害的 %convert_pct%%% 会转化为额外纯粹伤害。\n<h1>被动：斩断世界线</h1>普通攻击时对目标周围最远 %cleave_distance% 距离的锥形区域内敌人造成 %cleave_damage_percent%%% 物理伤害。对非英雄单位造成 %cleave_damage_percent_creep%%% 物理伤害。（仅近战有效）\n<h1>被动：魔渊腐蚀</h1>攻击时对目标施加腐蚀效果，持续 %debuff_duration% 秒：<br>- 护甲降低 %corruption_armor%<br>- 攻击速度降低 %attack_slow%<br>- 移动速度降低 %slow_pct%%%<br>- 生命回复和治疗效果降低 %hp_regen_reduction_pct%%%"
-		"DOTA_Tooltip_Ability_item_magic_sword_Lore"									"佛曰：一念成佛，一念成魔。 — by RN"
+		"DOTA_Tooltip_Ability_item_magic_sword_Lore"									"佛曰：一念成佛，一念成魔。"
 		"DOTA_Tooltip_Ability_item_magic_sword_bonus_damage_passive"					"+$damage"
 		"DOTA_Tooltip_Ability_item_magic_sword_bonus_all_stats"							"+$all"
 		"DOTA_Tooltip_Ability_item_magic_sword_bonus_health_regen"						"+$hp_regen"
@@ -3357,11 +3357,11 @@
 
 		"DOTA_Tooltip_Ability_item_tome_of_ability_reset"								"能力重置书"
 		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Description"					"<h1>使用：能力重置</h1>打开能力重置界面，可以移除已学习的技能并学习新技能。<br>移除技能时会返还技能点。<br><br>一本书只能选择一个技能进行重置。\n\n可以分享给队友"
-		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。 — by RN"
+		"DOTA_Tooltip_ability_item_tome_of_ability_reset_Lore"							"重新规划你的能力路线。"
 
 		"DOTA_Tooltip_ability_item_skill_reset"											"技能洗点书"
 		"DOTA_Tooltip_ability_item_skill_reset_Description"								"<h1>使用：洗点</h1>重置英雄技能等级并返还已花费的技能点。主动技能清零，被动、攻击触发及开关型技能保留至1级。"
-		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。 — by RN"
+		"DOTA_Tooltip_ability_item_skill_reset_Lore"									"后悔药，人手一颗。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note0"									"最高等级只有1级的先天技能不受影响。"
 		"DOTA_Tooltip_ability_item_skill_reset_Note1"									"被动、攻击触发及开关型技能会保留至1级（不清零），避免出现冷却异常等问题。"
 

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -170,7 +170,7 @@
 		"LevelsBetweenUpgrades"			"6"
 		"LinkedAbility"					"axe_culling_blade"	// 与大招淘汰之刃双向联动同步升级
 		"AbilityCharges"				"3"
-		"AbilityChargeRestoreTime"		"6"
+		"AbilityChargeRestoreTime"		"10"
 	}
 
 	// 死灵法师 竭心光环-觉醒
@@ -363,7 +363,8 @@
 
 		"AbilityValues"
 		{
-			"search_radius"		"300"
+			"search_radius"			"300"
+			"spell_amp_ratio_pct"	"50"
 		}
 
 		"Modifiers"
@@ -380,9 +381,10 @@
 				{
 					"RunScript"
 					{
-						"ScriptFile"	"abilities/special_bonus_unique_witch_doctor_upgrade"
-						"Function"		"OnAbilityExecuted"
-						"search_radius"		"%search_radius"
+						"ScriptFile"			"abilities/special_bonus_unique_witch_doctor_upgrade"
+						"Function"				"OnAbilityExecuted"
+						"search_radius"			"%search_radius"
+						"spell_amp_ratio_pct"	"%spell_amp_ratio_pct"
 					}
 				}
 			}

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -170,7 +170,7 @@
 		"LevelsBetweenUpgrades"			"6"
 		"LinkedAbility"					"axe_culling_blade"	// 与大招淘汰之刃双向联动同步升级
 		"AbilityCharges"				"3"
-		"AbilityChargeRestoreTime"		"3"
+		"AbilityChargeRestoreTime"		"6"
 	}
 
 	// 死灵法师 竭心光环-觉醒

--- a/game/scripts/npc/npc_abilities_custom_lottery.txt
+++ b/game/scripts/npc/npc_abilities_custom_lottery.txt
@@ -906,17 +906,17 @@
 			"multicast_delay"	"0.6"
 			"multicast_2_times"
 			{
-				"value"		"75 80 85 90"
+				"value"		"75 75 75 75"
 			}
 
 			"multicast_3_times"
 			{
-				"value"		"15 30 45 60"
+				"value"		"15 20 25 30"
 			}
 
 			"multicast_4_times"
 			{
-				"value"		"5 10 15 20"
+				"value"		"0 5 10 15"
 			}
 		}
 	}

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -10680,17 +10680,17 @@
 		{
 			"multicast_2_times"
 			{
-				"value"		"75 80 85 90"
+				"value"		"75 75 75 75"
 			}
 
 			"multicast_3_times"
 			{
-				"value"		"15 30 45 60"
+				"value"		"15 20 25 30"
 			}
 
 			"multicast_4_times"
 			{
-				"value"		"5 10 15 20"
+				"value"		"0 5 10 15"
 			}
 			"strength_for_one_pct"
 			{

--- a/game/scripts/npc/npc_items_artifact.txt
+++ b/game/scripts/npc/npc_items_artifact.txt
@@ -644,10 +644,6 @@
 		"ItemKillable"					"0"
 		"ItemSellable"					"1"
 		"ItemShareability"				"ITEM_FULLY_SHAREABLE"
-		"ItemInitialStockTime"			"0"
-		"ItemStockInitial"				"1"
-		"ItemStockMax"					"3"
-		"ItemStockTime"					"180"
 
 		"AbilityValues"
 		{
@@ -685,10 +681,6 @@
 		"ItemKillable"					"0"
 		"ItemSellable"					"1"
 		"ItemShareability"				"ITEM_FULLY_SHAREABLE"
-		"ItemInitialStockTime"			"0"
-		"ItemStockInitial"				"1"
-		"ItemStockMax"					"3"
-		"ItemStockTime"					"180"
 
 		"AbilityValues"
 		{

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -5398,7 +5398,7 @@
 		"ItemPermanent"				"1"
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"
@@ -5424,7 +5424,7 @@
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
 		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_NEVER"	// 添加:不可拆解
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"
@@ -5449,7 +5449,7 @@
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
 		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_NEVER"	// 添加:不可拆解
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"
@@ -5474,7 +5474,7 @@
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
 		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_NEVER"	// 添加:不可拆解
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"
@@ -5499,7 +5499,7 @@
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
 		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_NEVER"	// 添加:不可拆解
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"
@@ -5524,7 +5524,7 @@
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
 		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_NEVER"	// 添加:不可拆解
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"
@@ -5549,7 +5549,7 @@
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
 		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_NEVER"	// 添加:不可拆解
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"
@@ -5574,7 +5574,7 @@
 		"ItemDroppable"				"1"		// 添加:允许丢弃
 		"ItemStackable"				"0"		// 添加:不可堆叠
 		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_NEVER"	// 添加:不可拆解
-		"ItemInitialStockTime"		"600"	// 9分钟买
+		"ItemInitialStockTime"		"240"	// 3分钟买
 		"ItemStockInitial"			"0"
 		"ItemStockMax"				"3"
 		"ItemStockTime"				"180"

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -107,6 +107,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["enigma_demonic_conversion"] = true, -- 谜团 恶魔转化
     ["furion_force_of_nature"] = true,    -- 先知 自然之力
     ["zuus_cloud"] = true,                -- 宙斯 雷云
+    ["venomancer_plague_ward"] = true,    -- 剧毒术士 瘟疫守卫
 
     -- ========================================
     -- 持续施法/引导类技能

--- a/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
+++ b/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
@@ -100,6 +100,7 @@ no_support_abilitys = {
 	enchantress_bunny_hop = 1,                      -- 魅惑魔女 跳跃（Sproink，神杖技能）
 	tidehunter_anchor_smash = 1,                    -- 潮汐猎人 锚击
 	ability_fate_roulette = 1,                     -- 命运轮盘（重复施放只会刷新自身状态）
+	venomancer_plague_ward = 1,                     -- 剧毒术士 瘟疫守卫
 }
 no_support_items = {
 	-- 消耗品

--- a/game/scripts/vscripts/abilities/special_bonus_unique_witch_doctor_upgrade.lua
+++ b/game/scripts/vscripts/abilities/special_bonus_unique_witch_doctor_upgrade.lua
@@ -13,7 +13,7 @@ function OnAbilityExecuted(params)
     if spell_amp <= 0 then
         return
     end
-    local mult = 1 + spell_amp
+    local mult = 1 + spell_amp * (params.spell_amp_ratio_pct / 100)
 
     -- 延迟一帧等守卫生成
     Timers:CreateTimer(0.1, function()

--- a/game/scripts/vscripts/items/item_swift_glove.lua
+++ b/game/scripts/vscripts/items/item_swift_glove.lua
@@ -254,6 +254,7 @@ function modifier_item_swift_glove_chain_lightning:OnAttackLanded(params)
     if not params.target or params.target:IsNull() then return end
     if params.target:IsBuilding() then return end
     if params.target:GetTeamNumber() == self:GetParent():GetTeamNumber() then return end
+    if params.target:IsMagicImmune() then return end
 
     local now = GameRules:GetGameTime()
     if now < self.last_proc_time + (self.current_cooldown or self.chain_cooldown) then return end
@@ -303,7 +304,7 @@ function modifier_item_swift_glove_chain_lightning:FireChainLightning(first_targ
         local next_target = nil
         local enemies = FindUnitsInRadius(caster:GetTeamNumber(), current_target:GetAbsOrigin(), nil, self.chain_radius,
             DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC,
-            DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
+            DOTA_UNIT_TARGET_FLAG_NONE, FIND_CLOSEST, false)
         for _, enemy in pairs(enemies) do
             if enemy and not enemy:IsNull() and not enemy:IsBuilding() and not hit_targets[enemy:entindex()] then
                 next_target = enemy

--- a/src/vscripts/ai/build-item/hero-build-config.ts
+++ b/src/vscripts/ai/build-item/hero-build-config.ts
@@ -81,7 +81,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     template: HeroTemplate.Agility,
     targetItemsByTier: {
       [ItemTier.T1]: [
-        'item_hand_of_midas', // 点金手
         'item_phase_boots', // 相位鞋
         'item_wraith_band', // 怨灵细带
         'item_vanguard', // 先锋盾
@@ -136,7 +135,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_wraith_band', // 怨灵细带
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 点金手
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
         'item_vanguard', // 先锋盾
       ],
@@ -193,7 +191,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_wraith_band', // 怨灵系带
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_mask_of_madness', // 疯狂面具
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
@@ -252,7 +249,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_power_treads', // 动力鞋
         'item_wraith_band', // 怨灵系带
         'item_mask_of_madness', // 疯狂面具
-        'item_hand_of_midas', // 迈达斯之手
         'item_magic_wand', // 魔杖
         'item_lesser_crit', // 水晶剑
         'item_blood_grenade', // 血腥榴弹
@@ -326,7 +322,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_power_treads', // 动力鞋
         'item_wraith_band', // 怨灵系带
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_hyperstone', // 振奋宝石
         'item_lesser_crit', // 水晶剑
         'item_blood_grenade', // 血腥榴弹
@@ -402,7 +397,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_falcon_blade', // 猎鹰战刃
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
         'item_blood_grenade', // 血腥榴弹
         'item_lesser_crit', // 水晶剑
@@ -476,7 +470,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_mask_of_madness', // 疯狂面具
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_blood_grenade', // 血腥榴弹
         'item_lesser_crit', // 水晶剑
       ],
@@ -550,7 +543,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_falcon_blade', // 猎鹰战刃
         'item_wraith_band', // 怨灵系带
-        'item_hand_of_midas', // 迈达斯之手
         'item_magic_wand', // 魔杖
         'item_lesser_crit', // 水晶剑
       ],
@@ -619,7 +611,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       [ItemTier.T1]: [
         'item_power_treads', // 动力鞋
         'item_wraith_band', // 怨灵细带
-        'item_hand_of_midas', // 点金手
         'item_falcon_blade', // 猎鹰战刃
         'item_mask_of_madness', // 疯狂面具
         'item_magic_wand', // 魔杖
@@ -680,7 +671,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_wraith_band', // 怨灵系带
         'item_mask_of_madness', // 疯狂面具
         'item_hyperstone', // 振奋宝石
-        'item_hand_of_midas', // 迈达斯之手
         'item_magic_wand', // 魔杖
         'item_lesser_crit', // 水晶剑
         'item_blood_grenade', // 血腥榴弹
@@ -750,7 +740,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 点金手
         'item_mask_of_madness', // 疯狂面具
       ],
       [ItemTier.T2]: [
@@ -923,7 +912,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_wraith_band', // 怨灵细带
         'item_magic_wand', // 魔杖
         'item_vanguard', // 先锋盾
-        'item_hand_of_midas', // 点金手
         'item_veil_of_discord', // 纷争面纱
         'item_orb_of_corrosion', // 腐蚀之珠
       ],
@@ -1222,7 +1210,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     targetItemsByTier: {
       [ItemTier.T1]: [
         'item_arcane_boots', // 奥术鞋
-        'item_hand_of_midas', // 迈达斯之手
         'item_null_talisman', // 空灵挂件
         'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
@@ -1295,7 +1282,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     targetItemsByTier: {
       [ItemTier.T1]: [
         'item_null_talisman', // 空灵挂件
-        'item_hand_of_midas', // 迈达斯之手
         'item_blood_grenade', // 血腥榴弹
         'item_arcane_boots', // 奥术鞋
         'item_magic_wand', // 魔杖
@@ -1507,7 +1493,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_soul_ring', // 灵魂之戒
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_falcon_blade', // 猎鹰战刃
-        'item_hand_of_midas', // 点金手
       ],
       [ItemTier.T2]: [
         'item_hand_of_group', // 团队之手
@@ -1552,7 +1537,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     template: HeroTemplate.Strength,
     targetItemsByTier: {
       [ItemTier.T1]: [
-        'item_hand_of_midas', // 点金手
         'item_phase_boots', // 相位鞋
         'item_bracer', // 护腕
         'item_vanguard', // 先锋盾
@@ -1607,7 +1591,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_bracer', // 护腕
         'item_vanguard', // 先锋盾
         'item_phase_boots', // 相位鞋
-        'item_hand_of_midas', // 迈达斯之手
         'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
         'item_hyperstone', // 振奋宝石
@@ -1679,7 +1662,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_bracer', // 护腕
         'item_mask_of_madness', // 疯狂面具
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_lesser_crit', // 水晶剑
         'item_hyperstone', // 振奋宝石
         'item_falcon_blade', // 猎鹰战刃
@@ -1754,7 +1736,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 点金手
       ],
       [ItemTier.T2]: [
         'item_sange_and_yasha', // 散夜对剑
@@ -1809,7 +1790,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_power_treads', // 动力鞋
         'item_bracer', // 护腕
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 点金手
         'item_lesser_crit', // 水晶剑
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
         'item_vanguard', // 先锋盾
@@ -1868,7 +1848,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_power_treads', // 动力鞋
         'item_bracer', // 护腕
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 点金手
         'item_vanguard', // 先锋盾
         'item_soul_ring', // 灵魂之戒
         'item_falcon_blade', // 猎鹰战刃
@@ -1930,7 +1909,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_falcon_blade', // 猎鹰战刃
         'item_lesser_crit', // 水晶剑
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_blood_grenade', // 血腥榴弹
       ],
       [ItemTier.T2]: [
@@ -2075,7 +2053,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_magic_wand', // 魔杖
         'item_buckler', // 玄冥盾牌
         'item_hyperstone', // 振奋宝石
-        'item_hand_of_midas', // 迈达斯之手
         'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
@@ -2139,7 +2116,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_soul_ring', // 灵魂之戒
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_blood_grenade', // 血腥榴弹
       ],
       [ItemTier.T2]: [
@@ -2508,7 +2484,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_bracer', // 护腕
         'item_magic_wand', // 魔杖
         'item_falcon_blade', // 猎鹰战刃
-        'item_hand_of_midas', // 迈达斯之手
         'item_blood_grenade', // 血腥榴弹
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
       ],
@@ -2571,7 +2546,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_arcane_boots', // 奥术鞋
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_hyperstone', // 振奋宝石
         'item_bracer', // 护腕
         'item_ancient_janggo', // 韧鼓
@@ -2643,7 +2617,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_null_talisman', // 空灵挂件
         'item_arcane_boots', // 奥术鞋
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_hyperstone', // 振奋宝石
         'item_blood_grenade', // 血腥榴弹
         'item_veil_of_discord', // 纷争面纱
@@ -2717,7 +2690,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_null_talisman', // 空灵挂件
         'item_magic_wand', // 魔杖
         'item_vanguard', // 先锋盾
-        'item_hand_of_midas', // 点金手
         'item_soul_ring', // 灵魂之戒
         'item_falcon_blade', // 猎鹰战刃
       ],
@@ -2777,7 +2749,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_arcane_boots', // 奥术鞋
         'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_headdress', // 恢复头巾
         'item_mekansm', // 梅肯斯姆
         'item_vanguard', // 先锋盾
@@ -2838,7 +2809,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       [ItemTier.T1]: [
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
         'item_magic_wand', // 魔杖
-        'item_hand_of_midas', // 迈达斯之手
         'item_blood_grenade', // 血腥榴弹
         'item_power_treads', // 动力鞋
         'item_vanguard', // 先锋盾

--- a/src/vscripts/modules/event/game-end/game-end-point.test.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.test.ts
@@ -46,7 +46,7 @@ describe('GameEndPoint', () => {
         towerKills: 9,
       });
       const score = GameEndPoint.CalculatePlayerScore(player);
-      expect(score).toBe(36);
+      expect(score).toBe(37);
     });
 
     it('应该正确计算团队玩家的分数', () => {
@@ -73,7 +73,7 @@ describe('GameEndPoint', () => {
         towerKills: 11,
       });
       const score = GameEndPoint.CalculatePlayerScore(player);
-      expect(score).toBe(143);
+      expect(score).toBe(151);
     });
   });
 

--- a/src/vscripts/modules/event/game-end/game-end-point.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.ts
@@ -9,7 +9,7 @@ export class GameEndPoint {
     const deathScore = -Math.sqrt(player.deaths) * 0.6;
     const assistScore = Math.sqrt(player.assists) * 1.8;
     const damageScore = Math.min(40, Math.sqrt(player.heroDamage) / 200);
-    const damageTakenScore = Math.min(40, Math.sqrt(player.damageTaken) / 100);
+    const damageTakenScore = Math.min(40, Math.sqrt(player.damageTaken) / 80);
     const healingScore = Math.min(40, Math.sqrt(player.healing) / 50);
     const towerKillScore = Math.sqrt(player.towerKills) * 3;
 
@@ -79,7 +79,7 @@ export class GameEndPoint {
       case 7:
         return 2.3;
       case 8:
-        return 2.5;
+        return 2.4;
       default:
         // 自定义模式
         return this.GetCustomModeMultiplier(option);

--- a/src/vscripts/modules/filter/gold-xp-filter.test.ts
+++ b/src/vscripts/modules/filter/gold-xp-filter.test.ts
@@ -22,9 +22,9 @@ describe('GoldFilter', () => {
     });
 
     it('should reduce the multiplier correctly when it is greater than 1', () => {
-      expect(goldFilter.filterHeroKillGoldByMultiplier(1.5)).toBe(1.25);
-      expect(goldFilter.filterHeroKillGoldByMultiplier(2)).toBe(1.5);
-      expect(goldFilter.filterHeroKillGoldByMultiplier(10)).toBeCloseTo(5.5, 1);
+      expect(goldFilter.filterHeroKillGoldByMultiplier(1.5)).toBe(1.2);
+      expect(goldFilter.filterHeroKillGoldByMultiplier(2)).toBe(1.4);
+      expect(goldFilter.filterHeroKillGoldByMultiplier(10)).toBeCloseTo(4.6, 1);
     });
   });
 

--- a/src/vscripts/modules/filter/gold-xp-filter.ts
+++ b/src/vscripts/modules/filter/gold-xp-filter.ts
@@ -5,7 +5,7 @@ import { PlayerHelper } from '../helper/player-helper';
 export class GoldXPFilter {
   private readonly REDUCE_RATE_3_MIN = 0.6;
   private readonly REDUCE_RATE_6_MIN = 0.8;
-  private readonly REDUCE_RATE_HERO_KILL = 0.5;
+  private readonly REDUCE_RATE_HERO_KILL = 0.4;
 
   constructor() {
     GameRules.GetGameModeEntity().SetModifyGoldFilter((args) => this.filterGold(args), this);

--- a/src/vscripts/modules/lottery/item/lottery-items.ts
+++ b/src/vscripts/modules/lottery/item/lottery-items.ts
@@ -85,9 +85,6 @@ export const itemTiers: Tier[] = [
   {
     level: 1,
     names: [
-      'item_foragers_stats', // 铁树坚果
-      'item_foragers_mana', // 托莫干伞盖
-      'item_foragers_health', // 活力伞菌
       'item_bracer', // 护腕
       'item_wraith_band', // 系带
       'item_null_talisman', // 挂件


### PR DESCRIPTION
## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.42[/b]

- 光暗组件购买无CD，符文购买时间提前
```

```
[b]Gameplay update v5.42[/b]

- Light/Dark Parts can now be purchased without a stock cooldown, and Fusion Runes go on sale earlier.
```
