### PR TITLE
Treasure chest lottery now rewards the whole team

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -5331,7 +5331,7 @@
 
 				"blast_movement_slow"	"-100"	//-80
 				"duration"				"1.5"		//4
-				"blast_stat_multiplier"		"1.5"	//1.0
+				"blast_stat_multiplier"		"1.0"	//1.0
 				"blast_damage_base"			"200"//50
 				"duration_ally"				"6"	//4.0
 				"ethereal_damage_bonus"	"-60"	//-30

--- a/src/vscripts/modules/treasure/treasure.test.ts
+++ b/src/vscripts/modules/treasure/treasure.test.ts
@@ -72,6 +72,16 @@ global.GameRules = {
   Lottery: { Item: { onTriggered: jest.fn() } },
 };
 
+// 单人类玩家即可覆盖 openChest 的全队广播分支，避免过度构造多玩家场景
+global.DOTA_MAX_TEAM_PLAYERS = 1;
+const fakeTeamHero = { GetUnitName: () => 'npc_dota_hero_axe' };
+global.PlayerResource = {
+  IsValidPlayer: () => true,
+  GetPlayer: () => ({}),
+  GetSteamAccountID: () => 1000,
+  GetSelectedHeroEntity: () => fakeTeamHero,
+};
+
 import { ItemLotteryPool } from '../lottery/item/item-lottery-helper';
 import { Treasure } from './treasure';
 
@@ -89,6 +99,7 @@ describe('Treasure', () => {
     mockState = global.GameState.CUSTOM_GAME_SETUP;
     (global.CreateUnitByName as jest.Mock).mockClear();
     (global.Timers.CreateTimer as jest.Mock).mockClear();
+    (global.GameRules.Lottery.Item.onTriggered as jest.Mock).mockClear();
     treasure = new Treasure();
   });
 

--- a/src/vscripts/modules/treasure/treasure.ts
+++ b/src/vscripts/modules/treasure/treasure.ts
@@ -1,12 +1,13 @@
 import { GA4TreasureTracker, TreasureTier } from '../../api/analytics/ga4/ga4-treasure-tracker';
 import { modifier_treasure_chest } from '../../modifiers/global/modifier_treasure_chest';
 import { reloadable } from '../../utils/tstl-utils';
+import { PlayerHelper } from '../helper/player-helper';
 import { ItemLotteryPool } from '../lottery/item/item-lottery-helper';
 
 @reloadable
 export class Treasure {
   static readonly UNIT_NAME = 'npc_treasure_chest';
-  static readonly RESPAWN_INTERVAL = 120;
+  static readonly RESPAWN_INTERVAL = 240;
   static readonly MAX_ACTIVE_CHESTS = 2;
   static readonly Z_SINK = 64;
   static readonly OPEN_PARTICLE = 'particles/items2_fx/hand_of_midas.vpcf';
@@ -195,7 +196,15 @@ export class Treasure {
     this.openCount++;
     const pointTier = Treasure.getPointTier(point);
     GA4TreasureTracker.SendOpen(opener, this.spawnCount, point, pointTier);
-    GameRules.Lottery.Item.onTriggered(opener, Treasure.mapToLotteryPool(this.openCount));
+
+    // 全队人类玩家各获得一次抽奖，与肉山击杀奖励逻辑一致
+    const pool = Treasure.mapToLotteryPool(this.openCount);
+    PlayerHelper.ForEachPlayer((playerId) => {
+      if (!PlayerHelper.IsHumanPlayerByPlayerId(playerId)) return;
+      const hero = PlayerResource.GetSelectedHeroEntity(playerId);
+      if (!hero) return;
+      GameRules.Lottery.Item.onTriggered(hero, pool);
+    });
   }
 
   getRandomSpawnPoint(): Vector {

--- a/src/vscripts/modules/treasure/treasure.ts
+++ b/src/vscripts/modules/treasure/treasure.ts
@@ -7,7 +7,7 @@ import { ItemLotteryPool } from '../lottery/item/item-lottery-helper';
 @reloadable
 export class Treasure {
   static readonly UNIT_NAME = 'npc_treasure_chest';
-  static readonly RESPAWN_INTERVAL = 240;
+  static readonly RESPAWN_INTERVAL = 180;
   static readonly MAX_ACTIVE_CHESTS = 2;
   static readonly Z_SINK = 64;
   static readonly OPEN_PARTICLE = 'particles/items2_fx/hand_of_midas.vpcf';


### PR DESCRIPTION
## Checklist

- [ ] I have tested the changes works well.
- [x] 在 Dota Tools 中实机验证全队抽奖是否正常触发，以及 180s 刷新间隔手感是否合适

## Release Note

```
[b]游戏性更新 v5.42[/b]

- 藏宝箱开启奖励改为全队共享：每位人类玩家各获得一次道具抽奖（与击杀肉山逻辑一致），同时刷新间隔由120秒延长至3分钟
- 削弱神器·永恒虚灵之刃虚化冲击的额外伤害加成
```

```
[b]Gameplay update v5.42[/b]

- Treasure chest rewards are now shared with the whole team: each human player gets their own item lottery draw (same as a Roshan kill), and the respawn interval is extended from 120s to 3 minutes
- Reduced the bonus damage multiplier of Eternal Ethereal Blade's active
```
