### PR TITLE
Fix Swift Glove killing heroes with Withered Spring

### DIFF
--- a/game/scripts/vscripts/items/item_swift_glove.lua
+++ b/game/scripts/vscripts/items/item_swift_glove.lua
@@ -1,6 +1,11 @@
 if item_swift_glove == nil then item_swift_glove = class({}) end
 LinkLuaModifier("modifier_item_swift_glove", "items/item_swift_glove.lua", LUA_MODIFIER_MOTION_NONE)
 LinkLuaModifier("modifier_item_swift_glove_chain_lightning", "items/item_swift_glove.lua", LUA_MODIFIER_MOTION_NONE)
+-- This Lua item must register the shared kill modifier instead of relying on Dragon Destruction loading first.
+LinkLuaModifier("modifier_ignore_invulnerable_kill", "modifiers/global/modifier_ignore_invulnerable_kill",
+    LUA_MODIFIER_MOTION_NONE)
+
+local IGNORE_INVULNERABLE_KILL_DURATION = 0.25
 
 function item_swift_glove:GetIntrinsicModifierName()
     return "modifier_item_swift_glove"
@@ -73,9 +78,12 @@ function item_swift_glove:OnSpellStart()
     ParticleManager:SetParticleControl(pfx, 1, target_pos)
     ParticleManager:ReleaseParticleIndex(pfx)
 
-    target:AddNewModifier(caster, self, "modifier_ignore_invulnerable_kill", {})
-    target:Kill(self, caster) -- 使用 Kill() 而不是 ForceKill()
-    target:RemoveModifierByName("modifier_ignore_invulnerable_kill")
+    -- Keep the bypass alive briefly because Kill() can finish its minimum-health check after this Lua call returns.
+    -- The timestamp is a synchronous fallback if the shared TS modifier has not finished registering yet.
+    target.ignore_invulnerable_kill_until = GameRules:GetGameTime() + IGNORE_INVULNERABLE_KILL_DURATION
+    target:AddNewModifier(caster, self, "modifier_ignore_invulnerable_kill",
+        { duration = IGNORE_INVULNERABLE_KILL_DURATION })
+    target:Kill(self, caster) -- Preserve standard kill credit and death rewards.
     caster:EmitSound("DOTA_Item.Hand_Of_Midas")
     caster:ModifyGoldFiltered(self_gold, true, DOTA_ModifyGold_CreepKill)
     if not caster:IsTempestDouble() then

--- a/game/scripts/vscripts/items/item_swift_glove.lua
+++ b/game/scripts/vscripts/items/item_swift_glove.lua
@@ -5,8 +5,6 @@ LinkLuaModifier("modifier_item_swift_glove_chain_lightning", "items/item_swift_g
 LinkLuaModifier("modifier_ignore_invulnerable_kill", "modifiers/global/modifier_ignore_invulnerable_kill",
     LUA_MODIFIER_MOTION_NONE)
 
-local IGNORE_INVULNERABLE_KILL_DURATION = 0.25
-
 function item_swift_glove:GetIntrinsicModifierName()
     return "modifier_item_swift_glove"
 end
@@ -78,12 +76,9 @@ function item_swift_glove:OnSpellStart()
     ParticleManager:SetParticleControl(pfx, 1, target_pos)
     ParticleManager:ReleaseParticleIndex(pfx)
 
-    -- Keep the bypass alive briefly because Kill() can finish its minimum-health check after this Lua call returns.
-    -- The timestamp is a synchronous fallback if the shared TS modifier has not finished registering yet.
-    target.ignore_invulnerable_kill_until = GameRules:GetGameTime() + IGNORE_INVULNERABLE_KILL_DURATION
-    target:AddNewModifier(caster, self, "modifier_ignore_invulnerable_kill",
-        { duration = IGNORE_INVULNERABLE_KILL_DURATION })
+    target:AddNewModifier(caster, self, "modifier_ignore_invulnerable_kill", {})
     target:Kill(self, caster) -- Preserve standard kill credit and death rewards.
+    target:RemoveModifierByName("modifier_ignore_invulnerable_kill")
     caster:EmitSound("DOTA_Item.Hand_Of_Midas")
     caster:ModifyGoldFiltered(self_gold, true, DOTA_ModifyGold_CreepKill)
     if not caster:IsTempestDouble() then

--- a/game/scripts/vscripts/items/item_withered_spring.lua
+++ b/game/scripts/vscripts/items/item_withered_spring.lua
@@ -86,7 +86,10 @@ end
 
 -- 血量下限锁在 1，伤害结算时引擎同步钳制，避免单次爆发直接秒杀绕过阈值判定
 function modifier_item_withered_spring:GetMinHealth()
-    if self:GetParent():HasModifier("modifier_ignore_invulnerable_kill") then
+    local parent = self:GetParent()
+    local ignore_kill_until = parent.ignore_invulnerable_kill_until
+    if (ignore_kill_until and ignore_kill_until >= GameRules:GetGameTime()) or
+        parent:HasModifier("modifier_ignore_invulnerable_kill") then
         return 0
     end
 

--- a/game/scripts/vscripts/items/item_withered_spring.lua
+++ b/game/scripts/vscripts/items/item_withered_spring.lua
@@ -86,10 +86,7 @@ end
 
 -- 血量下限锁在 1，伤害结算时引擎同步钳制，避免单次爆发直接秒杀绕过阈值判定
 function modifier_item_withered_spring:GetMinHealth()
-    local parent = self:GetParent()
-    local ignore_kill_until = parent.ignore_invulnerable_kill_until
-    if (ignore_kill_until and ignore_kill_until >= GameRules:GetGameTime()) or
-        parent:HasModifier("modifier_ignore_invulnerable_kill") then
+    if self:GetParent():HasModifier("modifier_ignore_invulnerable_kill") then
         return 0
     end
 


### PR DESCRIPTION
## Checklist

- [x] I have tested the changes works well.
- [x] `npm run build:vscripts`
- [x] `npm run lint -- --no-fix`
- [x] `npm test -- --runInBand`
- [x] `git diff --check`
- [x] 已完成 Dota Tools 游戏内实测

## 修改内容

- 修正无限手套“灭世响指”对敌方英雄成功判定后，生命之心的最低生命值保护仍会将目标强制保留在 1 点生命的问题。
- 无限手套在执行击杀前建立短时共享绕过状态，生命之心在该状态下不再提供最低生命值保护。
- 继续使用标准 `Kill(self, caster)` 击杀流程，保留施法者的击杀归属、金钱和经验结算。

## 影响范围

- **游戏性：** 无限手套对英雄触发成功时，可以直接击杀携带生命之心的目标。
- **击杀结算：** 保留正常击杀归属、金钱和经验结算。
- **Bot AI：** 无变化。
- **Tooltip/图标/特效/音效：** 无变化。

## 测试

- `npm run build:vscripts`
- `npm run lint -- --no-fix`
- `npm test -- --runInBand`
- `git diff --check`
- 自动测试结果：22 个测试套件、209 个测试全部通过
- 已在 Dota Tools 中确认：无限手套对英雄成功判定后，可以直接击杀携带生命之心的目标，不再强制保留 1 点生命

## Release Note

```text
[b]游戏性更新 v5.43a[/b]

- 修正无限手套无法击杀携带生命之心英雄的问题。
```

```text
[b]Gameplay update v5.43a[/b]

- Fixed Swift Glove failing to kill heroes carrying Withered Spring.
```