### PR TITLE
Add fountain anti-camp debuff for human heroes

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1152,7 +1152,7 @@
 		"DOTA_Tooltip_ability_fountain_anti_camp"							"Fountain Sanction"
 		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Enemy human-controlled heroes near the fountain's attack range are sanctioned."
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"Fountain Sanction"
-		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"Unable to use items, active abilities, or passive abilities. Health and mana cannot be restored. Movement speed is forcibly restricted, and immunity-granting protections are removed."
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"Unable to attack, use items, active abilities, or passive abilities. Health and mana cannot be restored. Movement speed is forcibly restricted, and immunity-granting protections are removed."
 
 		///////////////////////////////////////////////////
 		//

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1148,10 +1148,10 @@
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_magic_resistance"	"MAGIC RESISTANCE:"
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_attributes"		"ATTRIBUTES:"
 
-		// Fountain Anti-Camp
-		"DOTA_Tooltip_ability_fountain_anti_camp"							"Anti-Camp Warning"
-		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Enemy human-controlled heroes near the fountain's attack range are afflicted with an anti-camp effect."
-		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"Anti-Camp Lock"
+		// Fountain Sanction
+		"DOTA_Tooltip_ability_fountain_anti_camp"							"Fountain Sanction"
+		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Enemy human-controlled heroes near the fountain's attack range are sanctioned."
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"Fountain Sanction"
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"Unable to use items, active abilities, or passive abilities. Health and mana cannot be restored. Movement speed is forcibly restricted, and immunity-granting protections are removed."
 
 		///////////////////////////////////////////////////

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1148,6 +1148,12 @@
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_magic_resistance"	"MAGIC RESISTANCE:"
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_attributes"		"ATTRIBUTES:"
 
+		// Fountain Anti-Camp
+		"DOTA_Tooltip_ability_fountain_anti_camp"							"Anti-Camp Warning"
+		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Enemy human-controlled heroes near the fountain's attack range are afflicted with an anti-camp effect."
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"Anti-Camp Lock"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"Unable to use items, active abilities, or passive abilities. Health and mana cannot be restored. Movement speed is forcibly restricted, and immunity-granting protections are removed."
+
 		///////////////////////////////////////////////////
 		//
 		// 					Awaken Abilities 觉醒技能

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1152,7 +1152,7 @@
 		"DOTA_Tooltip_ability_fountain_anti_camp"							"Fountain Sanction"
 		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Enemy human-controlled heroes near the fountain's attack range are sanctioned."
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"Fountain Sanction"
-		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"Unable to attack, use items, active abilities, or passive abilities. Health and mana cannot be restored. Movement speed is forcibly restricted, and immunity-granting protections are removed."
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"Unable to attack, use items, active abilities, or passive abilities. Health and mana cannot be restored. Movement speed is forcibly restricted, and buffs are forcibly dispelled."
 
 		///////////////////////////////////////////////////
 		//

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1143,6 +1143,12 @@
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_magic_resistance"	"魔抗："
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_attributes"		"全属性："
 
+		// 泉水 反蹲警戒
+		"DOTA_Tooltip_ability_fountain_anti_camp"							"反蹲警戒"
+		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"敌方人类玩家英雄靠近泉水攻击范围时会被施加反蹲效果。"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"反蹲封锁"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"无法使用装备、主动技能和被动技能，无法恢复生命和魔法，移动速度被强制限制，且免疫类保护效果被强制解除。"
+
 		///////////////////////////////////////////////////
 		//
 		// 					Awaken Abilities 觉醒技能

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1147,7 +1147,7 @@
 		"DOTA_Tooltip_ability_fountain_anti_camp"							"泉水制裁"
 		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"敌方人类玩家英雄靠近泉水攻击范围时会被制裁。"
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"泉水制裁"
-		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"无法使用装备、主动技能和被动技能，无法恢复生命和魔法，移动速度被强制限制，且免疫类保护效果被强制解除。"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"无法攻击，无法使用装备、主动技能和被动技能，无法恢复生命和魔法，移动速度被强制限制，且免疫类保护效果被强制解除。"
 
 		///////////////////////////////////////////////////
 		//

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1143,10 +1143,10 @@
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_magic_resistance"	"魔抗："
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_attributes"		"全属性："
 
-		// 泉水 反蹲警戒
-		"DOTA_Tooltip_ability_fountain_anti_camp"							"反蹲警戒"
-		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"敌方人类玩家英雄靠近泉水攻击范围时会被施加反蹲效果。"
-		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"反蹲封锁"
+		// 泉水 制裁
+		"DOTA_Tooltip_ability_fountain_anti_camp"							"泉水制裁"
+		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"敌方人类玩家英雄靠近泉水攻击范围时会被制裁。"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"泉水制裁"
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"无法使用装备、主动技能和被动技能，无法恢复生命和魔法，移动速度被强制限制，且免疫类保护效果被强制解除。"
 
 		///////////////////////////////////////////////////

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1147,7 +1147,7 @@
 		"DOTA_Tooltip_ability_fountain_anti_camp"							"泉水制裁"
 		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"敌方人类玩家英雄靠近泉水攻击范围时会被制裁。"
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"泉水制裁"
-		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"无法攻击，无法使用装备、主动技能和被动技能，无法恢复生命和魔法，移动速度被强制限制，且免疫类保护效果被强制解除。"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"无法攻击，无法使用装备、主动技能和被动技能，无法恢复生命和魔法，移动速度被强制限制，且增益被强制驱散。"
 
 		///////////////////////////////////////////////////
 		//

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -3252,4 +3252,14 @@
 		}
 	}
 
+	// 泉水 反蹲警戒
+	"ability_fountain_anti_camp"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/fountain_anti_camp"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"			"bounty_hunter_track"
+		"MaxLevel"						"1"
+	}
+
 }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -3261,11 +3261,12 @@
 		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
 		"AbilityTextureName"			"action_lockenemytower"
 		"MaxLevel"						"1"
+		"AbilityCastRange"				"2000"
 
 		"AbilityValues"
 		{
-			"radius"					"1600"
-			"move_speed"				"400"
+			"radius"					"2000"
+			"move_speed"				"300"
 		}
 	}
 

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -3258,6 +3258,7 @@
 		"BaseClass"						"ability_lua"
 		"ScriptFile"					"abilities/ts_abilities/fountain_anti_camp"
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
 		"AbilityTextureName"			"action_lockenemytower"
 		"MaxLevel"						"1"
 

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -3007,6 +3007,7 @@
 		"MaxLevel"                      "5"
 		"RequiredLevel"                 "6"
 		"LevelsBetweenUpgrades"         "6"
+		"IsBreakable"					"1"
 		"AbilityValues"
 		{
 			// 基础触发概率(移速500时的概率)

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -3261,11 +3261,11 @@
 		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
 		"AbilityTextureName"			"action_lockenemytower"
 		"MaxLevel"						"1"
-		"AbilityCastRange"				"2000"
+		"AbilityCastRange"				"2200"
 
 		"AbilityValues"
 		{
-			"radius"					"2000"
+			"radius"					"2200"
 			"move_speed"				"300"
 		}
 	}

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -3252,14 +3252,20 @@
 		}
 	}
 
-	// 泉水 反蹲警戒
-	"ability_fountain_anti_camp"
+	// 泉水制裁
+	"fountain_anti_camp"
 	{
 		"BaseClass"						"ability_lua"
 		"ScriptFile"					"abilities/ts_abilities/fountain_anti_camp"
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
-		"AbilityTextureName"			"bounty_hunter_track"
+		"AbilityTextureName"			"action_lockenemytower"
 		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"radius"					"1600"
+			"move_speed"				"400"
+		}
 	}
 
 }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -2948,6 +2948,7 @@
 		"MaxLevel"              "5"
 		"RequiredLevel"         "6"
 		"LevelsBetweenUpgrades" "6"
+		"IsBreakable"           "1"
 
 		"AbilityValues"
 		{
@@ -2968,6 +2969,7 @@
 			"MaxLevel"              "5"
 			"RequiredLevel"         "6"
 			"LevelsBetweenUpgrades" "6"
+			"IsBreakable"           "1"
 
 		"AbilityValues"
 		{
@@ -2987,6 +2989,7 @@
 		"MaxLevel"              "5"
 		"RequiredLevel"         "6"
 		"LevelsBetweenUpgrades" "6"
+		"IsBreakable"           "1"
 		"AbilityValues"
 		{
 			// 普通技能触发概率 (每级)
@@ -3031,6 +3034,7 @@
 		"MaxLevel"                      "5"
 		"RequiredLevel"                 "6"
 		"LevelsBetweenUpgrades"         "6"
+		"IsBreakable"                   "1"
 		"AbilityValues"
 		{
 			// 反弹伤害百分比
@@ -3089,6 +3093,7 @@
 		"MaxLevel"                      "5"
 		"RequiredLevel"                 "6"
 		"LevelsBetweenUpgrades"         "6"
+		"IsBreakable"                   "1"
 		"AbilityValues"
 		{
 			"ultimate_ready_delay"      "15 12 9 7 5"  // 冷却好后缓冲时间才开始计数

--- a/game/scripts/npc/npc_units_building.txt
+++ b/game/scripts/npc/npc_units_building.txt
@@ -859,11 +859,10 @@
 	"dota_fountain"
 	{
 		// Abilities
-		"Ability1"					"ability_fountain_anti_camp"
-		"Ability2"					"tower_headshot"			// none
+		"Ability2"					"tower_headshot"
 		"Ability3"					"tower_ursa_fury_swipes"
 		"Ability4"					"tower_antimage_mana_break"
-
+		"Ability5"					"ability_fountain_anti_camp"
 		"Ability6"					"fountain_hp_aura"
 
 		"AttackDamageMin"			"390"		// 290

--- a/game/scripts/npc/npc_units_building.txt
+++ b/game/scripts/npc/npc_units_building.txt
@@ -862,7 +862,7 @@
 		"Ability2"					"tower_headshot"
 		"Ability3"					"tower_ursa_fury_swipes"
 		"Ability4"					"tower_antimage_mana_break"
-		"Ability5"					"ability_fountain_anti_camp"
+		"Ability5"					"fountain_anti_camp"
 		"Ability6"					"fountain_hp_aura"
 
 		"AttackDamageMin"			"390"		// 290

--- a/game/scripts/npc/npc_units_building.txt
+++ b/game/scripts/npc/npc_units_building.txt
@@ -859,6 +859,7 @@
 	"dota_fountain"
 	{
 		// Abilities
+		"Ability1"					"ability_fountain_anti_camp"
 		"Ability2"					"tower_headshot"			// none
 		"Ability3"					"tower_ursa_fury_swipes"
 		"Ability4"					"tower_antimage_mana_break"

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -271,6 +271,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
 
 
     ["ability_fate_roulette"] = true, -- 命运轮盘（避免蝴蝶随机开启命定之刻）
+    ["enchantress_enchant"] = true,   -- 魅惑魔女 魅惑
 }
 -- 定义需要排除的物品黑名单
 -- 这些物品不会被自动触发,避免游戏机制冲突或性能问题

--- a/game/scripts/vscripts/abilities/ability_charge_damage.lua
+++ b/game/scripts/vscripts/abilities/ability_charge_damage.lua
@@ -52,6 +52,8 @@ function modifier_ability_charge_damage_tracker:OnIntervalThink()
     local caster = self:GetParent()
     local ability = self:GetAbility()
 
+    if caster:PassivesDisabled() then return end
+
     local current_time = GameRules:GetGameTime()
     local max_times = ability:GetSpecialValueFor("max_times")
 
@@ -189,8 +191,10 @@ function modifier_ability_charge_damage_tracker:OnAbilityExecuted(keys)
         return
     end
 
-    local ability = keys.ability
     local caster = self:GetParent()
+    if caster:PassivesDisabled() then return end
+
+    local ability = keys.ability
     local ability_name = ability:GetAbilityName()
 
     if ability:IsPassive() or ability:IsItem() or ability == self:GetAbility() then

--- a/game/scripts/vscripts/abilities/ability_trigger_learned_skills.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_learned_skills.lua
@@ -55,6 +55,7 @@ function modifier_trigger_learned_skills:OnAttackLanded(params)
     local parent = self:GetParent()
 
     if attacker ~= parent then return end
+    if parent:PassivesDisabled() then return end
     if parent:IsIllusion() then return end
     if params.target:IsBuilding() then return end
 

--- a/game/scripts/vscripts/abilities/ability_trigger_on_attacked.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_attacked.lua
@@ -44,6 +44,7 @@ function modifier_trigger_on_attacked:OnAttacked(params)
 
     -- 确保是自己被攻击
     if params.target ~= parent then return end
+    if parent:PassivesDisabled() then return end
     if parent:IsIllusion() then return end
     if attacker:IsBuilding() then return end
 

--- a/game/scripts/vscripts/abilities/ability_trigger_on_cast.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_cast.lua
@@ -73,6 +73,7 @@ function modifier_trigger_on_cast:OnAbilityExecuted(params)
     local executed_ability = params.ability
 
     if caster ~= parent then return end
+    if parent:PassivesDisabled() then return end
     if parent:IsIllusion() then return end
 
     -- ✅ 全局冷却

--- a/game/scripts/vscripts/abilities/ability_trigger_on_move.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_move.lua
@@ -45,8 +45,8 @@ function modifier_trigger_on_move:OnIntervalThink()
 
     local parent = self:GetParent()
     if not parent or parent:IsNull() or not parent:IsAlive() then return end
-    if parent:IsIllusion() then return end
     if parent:PassivesDisabled() then return end
+    if parent:IsIllusion() then return end
 
     local current_position = parent:GetAbsOrigin()
     local distance = (current_position - self.last_position):Length2D()

--- a/game/scripts/vscripts/abilities/ability_trigger_on_move.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_move.lua
@@ -46,6 +46,7 @@ function modifier_trigger_on_move:OnIntervalThink()
     local parent = self:GetParent()
     if not parent or parent:IsNull() or not parent:IsAlive() then return end
     if parent:IsIllusion() then return end
+    if parent:PassivesDisabled() then return end
 
     local current_position = parent:GetAbsOrigin()
     local distance = (current_position - self.last_position):Length2D()

--- a/game/scripts/vscripts/abilities/ability_trigger_on_spell_reflect.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_spell_reflect.lua
@@ -42,6 +42,8 @@ function modifier_trigger_on_spell_reflect:OnTakeDamage(params)
     local parent = self:GetParent()
     local attacker = params.attacker
 
+    if parent:PassivesDisabled() then return end
+
     -- 检查内置冷却
     if parent:HasModifier("modifier_trigger_on_spell_reflect_cooldown") then
         --print("[SpellReflect] On cooldown, skipping")

--- a/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
+++ b/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
@@ -101,6 +101,7 @@ no_support_abilitys = {
 	tidehunter_anchor_smash = 1,                    -- 潮汐猎人 锚击
 	ability_fate_roulette = 1,                     -- 命运轮盘（重复施放只会刷新自身状态）
 	venomancer_plague_ward = 1,                     -- 剧毒术士 瘟疫守卫
+	enchantress_enchant = 1,                        -- 魅惑魔女 魅惑
 }
 no_support_items = {
 	-- 消耗品

--- a/game/scripts/vscripts/items/item_dracula_mask.lua
+++ b/game/scripts/vscripts/items/item_dracula_mask.lua
@@ -87,6 +87,7 @@ function modifier_item_dracula_mask:OnIntervalThink()
     local ability = self:GetAbility()
 
     if not ability or ability:IsNull() then return end
+    if parent:IsMuted() then return end
 
     -- 检查生命值是否低于阈值
     local hp_pct = parent:GetHealthPercent()

--- a/game/scripts/vscripts/items/item_withered_spring.lua
+++ b/game/scripts/vscripts/items/item_withered_spring.lua
@@ -86,7 +86,8 @@ end
 
 -- 血量下限锁在 1，伤害结算时引擎同步钳制，避免单次爆发直接秒杀绕过阈值判定
 function modifier_item_withered_spring:GetMinHealth()
-    if self:GetParent():HasModifier("modifier_ignore_invulnerable_kill") then
+    local parent = self:GetParent()
+    if parent:HasModifier("modifier_ignore_invulnerable_kill") or parent:IsMuted() then
         return 0
     end
 
@@ -105,6 +106,7 @@ function modifier_item_withered_spring:OnTakeDamage(event)
     if not parent:IsAlive() then return end
 
     if event.unit ~= parent then return end
+    if parent:IsMuted() then return end
 
     local ability = self:GetAbility()
     if not ability or ability:IsNull() or not ability:IsFullyCastable() then return end

--- a/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
+++ b/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
@@ -1,18 +1,17 @@
+import { PlayerHelper } from '../../modules/helper/player-helper';
 import {
   BaseAbility,
   BaseModifier,
   registerAbility,
   registerModifier,
 } from '../../utils/dota_ts_adapter';
-import { PlayerHelper } from '../../modules/helper/player-helper';
 
 const WATCHER_MODIFIER_NAME = 'modifier_fountain_anti_camp_watcher';
 const LOCK_MODIFIER_NAME = 'modifier_fountain_anti_camp_lock';
-const POLL_INTERVAL = 0.25;
-const LOCK_DURATION = 0.75;
-const LOCKED_MOVE_SPEED = 400;
+const POLL_INTERVAL = 1;
+const LOCK_DURATION = 3;
 
-@registerAbility('ability_fountain_anti_camp')
+@registerAbility('fountain_anti_camp')
 export class AbilityFountainAntiCamp extends BaseAbility {
   GetIntrinsicModifierName(): string {
     return WATCHER_MODIFIER_NAME;
@@ -36,6 +35,7 @@ export class modifier_fountain_anti_camp_watcher extends BaseModifier {
 
   OnCreated(): void {
     if (!IsServer()) return;
+    if (this.GetParent().GetTeamNumber() !== DotaTeam.BADGUYS) return;
     this.StartIntervalThink(POLL_INTERVAL);
   }
 
@@ -44,11 +44,13 @@ export class modifier_fountain_anti_camp_watcher extends BaseModifier {
 
     const fountain = this.GetParent();
     const ability = this.GetAbility();
+    if (!ability) return;
+
     const enemies = FindUnitsInRadius(
       fountain.GetTeamNumber(),
       fountain.GetAbsOrigin(),
       undefined,
-      fountain.Script_GetAttackRange(),
+      ability.GetSpecialValueFor('radius'),
       UnitTargetTeam.ENEMY,
       UnitTargetType.HERO,
       UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
@@ -83,17 +85,15 @@ export class modifier_fountain_anti_camp_lock extends BaseModifier {
   }
 
   GetTexture(): string {
-    return 'shadow_shaman_shackles';
+    return 'action_lockenemytower';
   }
 
   OnCreated(): void {
     if (!IsServer()) return;
 
     const parent = this.GetParent();
-    parent.Purge(true, false, false, false, false);
-    parent.RemoveModifierByName('modifier_black_king_bar_immune');
-    parent.RemoveModifierByName('modifier_item_beast_shield_active');
-    parent.RemoveModifierByName('modifier_item_withered_spring_active');
+    parent.Purge(true, false, false, false, true);
+    // parent.RemoveModifierByName('modifier_black_king_bar_immune');
   }
 
   CheckState(): Partial<Record<ModifierState, boolean>> {
@@ -121,6 +121,6 @@ export class modifier_fountain_anti_camp_lock extends BaseModifier {
   }
 
   GetModifierMoveSpeed_Absolute(): number {
-    return LOCKED_MOVE_SPEED;
+    return this.GetAbility()?.GetSpecialValueFor('move_speed') ?? 400;
   }
 }

--- a/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
+++ b/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
@@ -93,7 +93,7 @@ export class modifier_fountain_anti_camp_lock extends BaseModifier {
 
     const parent = this.GetParent();
     parent.Purge(true, false, false, false, true);
-    // parent.RemoveModifierByName('modifier_black_king_bar_immune');
+    parent.RemoveModifierByName('modifier_black_king_bar_immune');
   }
 
   CheckState(): Partial<Record<ModifierState, boolean>> {

--- a/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
+++ b/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
@@ -101,6 +101,7 @@ export class modifier_fountain_anti_camp_lock extends BaseModifier {
       [ModifierState.MUTED]: true,
       [ModifierState.SILENCED]: true,
       [ModifierState.PASSIVES_DISABLED]: true,
+      [ModifierState.DISARMED]: true,
     };
   }
 

--- a/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
+++ b/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
@@ -1,0 +1,126 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import { PlayerHelper } from '../../modules/helper/player-helper';
+
+const WATCHER_MODIFIER_NAME = 'modifier_fountain_anti_camp_watcher';
+const LOCK_MODIFIER_NAME = 'modifier_fountain_anti_camp_lock';
+const POLL_INTERVAL = 0.25;
+const LOCK_DURATION = 0.75;
+const LOCKED_MOVE_SPEED = 400;
+
+@registerAbility('ability_fountain_anti_camp')
+export class AbilityFountainAntiCamp extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return WATCHER_MODIFIER_NAME;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/fountain_anti_camp')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_fountain_anti_camp_watcher extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.StartIntervalThink(POLL_INTERVAL);
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer()) return;
+
+    const fountain = this.GetParent();
+    const ability = this.GetAbility();
+    const enemies = FindUnitsInRadius(
+      fountain.GetTeamNumber(),
+      fountain.GetAbsOrigin(),
+      undefined,
+      fountain.Script_GetAttackRange(),
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+
+    for (const hero of enemies) {
+      if (!hero.IsRealHero() || !PlayerHelper.IsHumanPlayer(hero)) continue;
+      hero.AddNewModifier(fountain, ability, LOCK_MODIFIER_NAME, { duration: LOCK_DURATION });
+    }
+  }
+}
+
+@registerModifier('abilities/ts_abilities/fountain_anti_camp')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_fountain_anti_camp_lock extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return 'shadow_shaman_shackles';
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent();
+    parent.Purge(true, false, false, false, false);
+    parent.RemoveModifierByName('modifier_black_king_bar_immune');
+    parent.RemoveModifierByName('modifier_item_beast_shield_active');
+    parent.RemoveModifierByName('modifier_item_withered_spring_active');
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.MUTED]: true,
+      [ModifierState.SILENCED]: true,
+      [ModifierState.PASSIVES_DISABLED]: true,
+    };
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.DISABLE_HEALING,
+      ModifierFunction.DISABLE_MANA_GAIN,
+      ModifierFunction.MOVESPEED_ABSOLUTE,
+    ];
+  }
+
+  GetDisableHealing(): 0 | 1 {
+    return 1;
+  }
+
+  GetDisableManaGain(): number {
+    return 1;
+  }
+
+  GetModifierMoveSpeed_Absolute(): number {
+    return LOCKED_MOVE_SPEED;
+  }
+}

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.43';
+  public static readonly GAME_VERSION = 'v5.44';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数


### PR DESCRIPTION
## Issue

- 无关联 Issue。

## Checklist

- [ ] I have tested the changes works well.
- [x] 在 Dota Tools 中实机验证：泉水技能栏出现新图标且 tooltip 正确、人类英雄进入泉水攻击范围后正确上锁（禁装备/主动/被动、禁回血回蓝、移速被钳制）、开着黑皇杖进入范围会被强制打断、离开范围后 debuff 自动消失

## Release Note

```
[b]游戏性更新 v5.44[/b]

- 夜魇泉水新增反虐泉机制：天辉英雄进入泉水附近会被禁止攻击与使用技能装备，无法回复生命魔法，移速降低，并强制驱散增益。
```

```
[b]Gameplay update v5.44[/b]

- Added an anti-fountain-camping effect to the Dire fountain: enemy heroes near it cannot attack, use items or abilities, or restore health/mana, have reduced movement speed, and have buffs forcibly dispelled.
```
