### PR TITLE
Add Warlock Infernal Immolation awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -150,7 +150,7 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade"					"<font color='#D000FF'>Infernal Immolation Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade_Description"	"Increases Infernal's Permanent Immolation damage per second by the sum of Warlock's current Health Regeneration and Mana Regeneration, multiplied by %regen_to_damage_pct%%%."
 		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade"			"<font color='#D000FF'>Infernal Immolation Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"Increases Infernal's Permanent Immolation damage per second by 150% of the sum of Warlock's current Health Regeneration and Mana Regeneration."
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"Increases Infernal's Permanent Immolation damage per second by <font color='#FFFFFF'><b>150%%</b></font> of the sum of Warlock's current Health Regeneration and Mana Regeneration."
 
 		///////////////////////////////////////////////////
 		//

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -146,6 +146,12 @@
 		"PauseDemo_Button"							"Pause"
 		"QuitDemo_Button"							"Quit"
 
+		// 术士 地狱火献祭-觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade"					"<font color='#D000FF'>Infernal Immolation Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade_Description"	"Increases Infernal's Permanent Immolation damage per second by the sum of Warlock's current Health Regeneration and Mana Regeneration, multiplied by %regen_to_damage_pct%%%."
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade"			"<font color='#D000FF'>Infernal Immolation Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"Increases Infernal's Permanent Immolation damage per second by 150% of the sum of Warlock's current Health Regeneration and Mana Regeneration."
+
 		///////////////////////////////////////////////////
 		//
 		//            Data panel

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -110,6 +110,12 @@
 		"PauseDemo_Button"							"Пауза"
 		"QuitDemo_Button"							"Выход"
 
+		// 术士 地狱火献祭-觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade"					"<font color='#D000FF'>Адское пламя: пробуждение</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade_Description"	"Увеличивает урон в секунду от Постоянного пламени Адского пламени на сумму текущих восстановления здоровья и маны Чернокнижника, умноженную на %regen_to_damage_pct%%%."
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade"			"<font color='#D000FF'>Адское пламя: пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"Увеличивает урон в секунду от Постоянного пламени Адского пламени на 150% суммы текущих восстановления здоровья и маны Чернокнижника."
+
 		///////////////////////////////////////////////////
 		//
 		//            Data panel

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -114,7 +114,7 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade"					"<font color='#D000FF'>Адское пламя: пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade_Description"	"Увеличивает урон в секунду от Постоянного пламени Адского пламени на сумму текущих восстановления здоровья и маны Чернокнижника, умноженную на %regen_to_damage_pct%%%."
 		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade"			"<font color='#D000FF'>Адское пламя: пробуждение</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"Увеличивает урон в секунду от Постоянного пламени Адского пламени на 150% суммы текущих восстановления здоровья и маны Чернокнижника."
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"Увеличивает урон в секунду от Постоянного пламени Адского пламени на <font color='#FFFFFF'><b>150%%</b></font> суммы текущих восстановления здоровья и маны Чернокнижника."
 
 		///////////////////////////////////////////////////
 		//

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -150,7 +150,7 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade"					"<font color='#D000FF'>地狱火献祭 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade_Description"	"地狱火的永恒献祭每秒伤害提高，数值等于术士当前生命恢复与魔法恢复之和的%regen_to_damage_pct%%%。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade"			"<font color='#D000FF'>地狱火献祭 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"地狱火的永恒献祭每秒伤害提高，数值等于术士当前生命恢复与魔法恢复之和的150%。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"地狱火的永恒献祭每秒伤害提高，数值等于术士当前生命恢复与魔法恢复之和的<font color='#FFFFFF'><b>150%%</b></font>。"
 
 		///////////////////////////////////////////////////
 		//

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -146,6 +146,12 @@
 		"PauseDemo_Button"							"暂停"
 		"QuitDemo_Button"							"退出"
 
+		// 术士 地狱火献祭-觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade"					"<font color='#D000FF'>地狱火献祭 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade_Description"	"地狱火的永恒献祭每秒伤害提高，数值等于术士当前生命恢复与魔法恢复之和的%regen_to_damage_pct%%%。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade"			"<font color='#D000FF'>地狱火献祭 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade_Description"	"地狱火的永恒献祭每秒伤害提高，数值等于术士当前生命恢复与魔法恢复之和的150%。"
+
 		///////////////////////////////////////////////////
 		//
 		//            Data panel

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -601,4 +601,19 @@
 			}
 		}
 	}
+	// 术士 地狱火献祭-觉醒
+	"special_bonus_unique_warlock_upgrade"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"						"abilities/ts_abilities/special_bonus_unique_warlock_upgrade"
+		"AbilityBehavior"					"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"			"warlock_rain_of_chaos"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"regen_to_damage_pct"		"150"
+		}
+	}
 }

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -14,6 +14,10 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // 新加的英雄排在前面，旧的排在后面（随机卡固定第一个，不受此列表顺序影响）
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string }[] = [
   {
+    heroName: 'npc_dota_hero_warlock',
+    abilityName: 'special_bonus_unique_warlock_upgrade',
+  },
+  {
     heroName: 'npc_dota_hero_sven',
     abilityName: 'special_bonus_unique_sven_upgrade',
   },

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_warlock_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_warlock_upgrade.ts
@@ -14,6 +14,7 @@ import {
 const PERMANENT_IMMOLATION_ABILITY = 'warlock_golem_permanent_immolation';
 const AWAKEN_MODIFIER = 'modifier_special_bonus_unique_warlock_upgrade';
 const INFERNAL_MODIFIER = 'modifier_special_bonus_unique_warlock_upgrade_infernal';
+// 地狱火刚生成时 owner/技能可能还未就绪，挂载失败后短暂重试兜底
 const INFERNAL_SPAWN_RETRY_DELAYS = [0.03, 0.1, 0.3];
 
 /** 术士觉醒 */
@@ -50,6 +51,7 @@ export class modifier_special_bonus_unique_warlock_upgrade extends BaseModifier 
       this,
     );
     this.scanExistingInfernals();
+    // 觉醒创建的同一帧内已存在的地狱火数据可能还未就绪，下一帧再补扫一次兜底
     Timers.CreateTimer(0, () => {
       if (!this.IsNull()) this.scanExistingInfernals();
     });

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_warlock_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_warlock_upgrade.ts
@@ -1,0 +1,263 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import {
+  calculateWarlockImmolationDamage,
+  isOwnedWarlockInfernalCandidate,
+  isWarlockImmolationDamageSpecial,
+  isWarlockInfernalUnitName,
+} from './warlock-awaken-math';
+
+const PERMANENT_IMMOLATION_ABILITY = 'warlock_golem_permanent_immolation';
+const AWAKEN_MODIFIER = 'modifier_special_bonus_unique_warlock_upgrade';
+const INFERNAL_MODIFIER = 'modifier_special_bonus_unique_warlock_upgrade_infernal';
+const INFERNAL_SPAWN_RETRY_DELAYS = [0.03, 0.1, 0.3];
+
+/** 术士觉醒 */
+@registerAbility('special_bonus_unique_warlock_upgrade')
+export class SpecialBonusUniqueWarlockUpgrade extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return AWAKEN_MODIFIER;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_warlock_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_warlock_upgrade extends BaseModifier {
+  private spawnListenerId: EventListenerID | undefined;
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+
+    this.spawnListenerId = ListenToGameEvent(
+      'npc_spawned',
+      (event) => this.onNpcSpawned(event),
+      this,
+    );
+    this.scanExistingInfernals();
+    Timers.CreateTimer(0, () => {
+      if (!this.IsNull()) this.scanExistingInfernals();
+    });
+  }
+
+  OnRefresh(): void {
+    if (!IsServer()) return;
+    this.scanExistingInfernals();
+  }
+
+  OnDestroy(): void {
+    if (!IsServer()) return;
+
+    if (this.spawnListenerId !== undefined) {
+      StopListeningToGameEvent(this.spawnListenerId);
+      this.spawnListenerId = undefined;
+    }
+
+    const warlock = this.GetParent();
+    if (warlock.IsNull() || !warlock.IsRealHero()) return;
+    this.forEachInfernal((infernal) => {
+      infernal.RemoveModifierByNameAndCaster(INFERNAL_MODIFIER, warlock);
+    });
+  }
+
+  private onNpcSpawned(event: GameEventProvidedProperties & NpcSpawnedEvent): void {
+    const entity = EntIndexToHScript(event.entindex) as CBaseEntity | undefined;
+    if (!entity || entity.IsNull() || !entity.IsBaseNPC()) return;
+
+    const infernal = entity as CDOTA_BaseNPC;
+    if (!isWarlockInfernalUnitName(infernal.GetUnitName())) return;
+    if (!this.tryAttachInfernalModifier(infernal)) {
+      this.retryAttachInfernalModifier(event.entindex, 0);
+    }
+  }
+
+  private retryAttachInfernalModifier(entindex: EntityIndex, retryIndex: number): void {
+    if (retryIndex >= INFERNAL_SPAWN_RETRY_DELAYS.length) return;
+
+    Timers.CreateTimer(INFERNAL_SPAWN_RETRY_DELAYS[retryIndex], () => {
+      if (this.IsNull()) return;
+
+      const entity = EntIndexToHScript(entindex) as CBaseEntity | undefined;
+      if (!entity || entity.IsNull() || !entity.IsBaseNPC()) return;
+
+      const infernal = entity as CDOTA_BaseNPC;
+      if (!isWarlockInfernalUnitName(infernal.GetUnitName())) return;
+      if (!this.tryAttachInfernalModifier(infernal)) {
+        this.retryAttachInfernalModifier(entindex, retryIndex + 1);
+      }
+    });
+  }
+
+  private scanExistingInfernals(): void {
+    this.forEachInfernal((infernal) => this.tryAttachInfernalModifier(infernal));
+  }
+
+  private forEachInfernal(callback: (infernal: CDOTA_BaseNPC) => void): void {
+    let entity = Entities.First() as CBaseEntity | undefined;
+    while (entity) {
+      const next = Entities.Next(entity);
+      if (!entity.IsNull() && entity.IsBaseNPC()) {
+        const unit = entity as CDOTA_BaseNPC;
+        if (isWarlockInfernalUnitName(unit.GetUnitName())) {
+          callback(unit);
+        }
+      }
+      entity = next;
+    }
+  }
+
+  private tryAttachInfernalModifier(infernal: CDOTA_BaseNPC): boolean {
+    const warlock = this.GetParent();
+    const awaken = this.GetAbility();
+    if (
+      this.IsNull() ||
+      infernal.IsNull() ||
+      !infernal.IsAlive() ||
+      warlock.IsNull() ||
+      !warlock.IsRealHero() ||
+      !awaken ||
+      awaken.IsNull() ||
+      awaken.GetLevel() <= 0 ||
+      !awaken.IsActivated()
+    ) {
+      return false;
+    }
+
+    const immolation = infernal.FindAbilityByName(PERMANENT_IMMOLATION_ABILITY);
+    if (!this.isOwnedInfernal(infernal, warlock, immolation !== undefined)) return false;
+
+    if (infernal.FindModifierByNameAndCaster(INFERNAL_MODIFIER, warlock)) return true;
+    if (infernal.HasModifier(INFERNAL_MODIFIER)) {
+      infernal.RemoveModifierByName(INFERNAL_MODIFIER);
+    }
+
+    return infernal.AddNewModifier(warlock, awaken, INFERNAL_MODIFIER, {}) !== undefined;
+  }
+
+  private isOwnedInfernal(
+    infernal: CDOTA_BaseNPC,
+    warlock: CDOTA_BaseNPC,
+    hasPermanentImmolation: boolean,
+  ): boolean {
+    const owner = infernal.GetOwnerEntity() as CBaseEntity | undefined;
+    const ownerEntityIndex = owner && !owner.IsNull() ? owner.GetEntityIndex() : undefined;
+    const infernalPlayerId = infernal.GetPlayerOwnerID();
+    const warlockPlayerId = warlock.GetPlayerOwnerID();
+
+    return isOwnedWarlockInfernalCandidate({
+      unitName: infernal.GetUnitName(),
+      hasPermanentImmolation,
+      ownerEntityIndex,
+      warlockEntityIndex: warlock.GetEntityIndex(),
+      unitPlayerOwnerId: PlayerResource.IsValidPlayerID(infernalPlayerId) ? infernalPlayerId : -1,
+      warlockPlayerOwnerId: PlayerResource.IsValidPlayerID(warlockPlayerId) ? warlockPlayerId : -1,
+    });
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_warlock_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_warlock_upgrade_infernal extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.OVERRIDE_ABILITY_SPECIAL,
+      ModifierFunction.OVERRIDE_ABILITY_SPECIAL_VALUE,
+    ];
+  }
+
+  GetModifierOverrideAbilitySpecial(event: ModifierOverrideAbilitySpecialEvent): 0 | 1 {
+    return this.shouldOverride(event) ? 1 : 0;
+  }
+
+  GetModifierOverrideAbilitySpecialValue(event: ModifierOverrideAbilitySpecialEvent): number {
+    const eventAbility = event.ability;
+    if (!eventAbility || eventAbility.IsNull()) return 0;
+
+    const nativeDamage = eventAbility.GetLevelSpecialValueNoOverride(
+      event.ability_special_value,
+      event.ability_special_level,
+    );
+    if (!this.shouldOverride(event)) return nativeDamage;
+
+    const warlock = this.GetCaster();
+    const awaken = this.GetAbility();
+    if (!warlock || warlock.IsNull() || !awaken || awaken.IsNull()) return nativeDamage;
+
+    return calculateWarlockImmolationDamage(
+      nativeDamage,
+      warlock.GetHealthRegen(),
+      warlock.GetManaRegen(),
+      awaken.GetSpecialValueFor('regen_to_damage_pct'),
+    );
+  }
+
+  private shouldOverride(event: ModifierOverrideAbilitySpecialEvent): boolean {
+    const parent = this.GetParent();
+    const warlock = this.GetCaster();
+    const awaken = this.GetAbility();
+    const eventAbility = event.ability;
+    if (
+      parent.IsNull() ||
+      !warlock ||
+      warlock.IsNull() ||
+      !warlock.IsRealHero() ||
+      !awaken ||
+      awaken.IsNull() ||
+      !eventAbility ||
+      eventAbility.IsNull()
+    ) {
+      return false;
+    }
+
+    const immolation = parent.FindAbilityByName(PERMANENT_IMMOLATION_ABILITY);
+    const owner = parent.GetOwnerEntity() as CBaseEntity | undefined;
+    const ownerEntityIndex = owner && !owner.IsNull() ? owner.GetEntityIndex() : undefined;
+    const parentPlayerId = parent.GetPlayerOwnerID();
+    const warlockPlayerId = warlock.GetPlayerOwnerID();
+
+    return (
+      isOwnedWarlockInfernalCandidate({
+        unitName: parent.GetUnitName(),
+        hasPermanentImmolation:
+          immolation !== undefined && immolation.GetEntityIndex() === eventAbility.GetEntityIndex(),
+        ownerEntityIndex,
+        warlockEntityIndex: warlock.GetEntityIndex(),
+        unitPlayerOwnerId: PlayerResource.IsValidPlayerID(parentPlayerId) ? parentPlayerId : -1,
+        warlockPlayerOwnerId: PlayerResource.IsValidPlayerID(warlockPlayerId)
+          ? warlockPlayerId
+          : -1,
+      }) &&
+      isWarlockImmolationDamageSpecial(
+        eventAbility.GetAbilityName(),
+        event.ability_special_value,
+      ) &&
+      warlock.HasModifier(AWAKEN_MODIFIER) &&
+      !warlock.PassivesDisabled() &&
+      awaken.GetLevel() > 0 &&
+      awaken.IsActivated()
+    );
+  }
+}

--- a/src/vscripts/abilities/ts_abilities/warlock-awaken-math.test.ts
+++ b/src/vscripts/abilities/ts_abilities/warlock-awaken-math.test.ts
@@ -1,0 +1,109 @@
+import {
+  calculateWarlockAwakenDamagePerSecond,
+  calculateWarlockImmolationDamage,
+  isWarlockImmolationDamageSpecial,
+  isOwnedWarlockInfernalCandidate,
+  isWarlockInfernalUnitName,
+} from './warlock-awaken-math';
+
+describe('calculateWarlockAwakenDamagePerSecond', () => {
+  it('uses 150% of health and mana regeneration', () => {
+    expect(calculateWarlockAwakenDamagePerSecond(40, 20, 150)).toBe(90);
+  });
+
+  it('supports the configured conversion percentage', () => {
+    expect(calculateWarlockAwakenDamagePerSecond(40, 20, 90)).toBe(54);
+  });
+
+  it('does not produce negative damage when regeneration is negative', () => {
+    expect(calculateWarlockAwakenDamagePerSecond(-40, -20, 100)).toBe(0);
+  });
+});
+
+describe('calculateWarlockImmolationDamage', () => {
+  it('adds 150% of Warlock health and mana regeneration to the native damage', () => {
+    expect(calculateWarlockImmolationDamage(75, 40, 20, 150)).toBe(165);
+  });
+
+  it('keeps the native damage when the regeneration sum is negative', () => {
+    expect(calculateWarlockImmolationDamage(75, -40, -20, 100)).toBe(75);
+  });
+});
+
+describe('isWarlockImmolationDamageSpecial', () => {
+  it('matches only Permanent Immolation aura_damage', () => {
+    expect(
+      isWarlockImmolationDamageSpecial('warlock_golem_permanent_immolation', 'aura_damage'),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['warlock_golem_permanent_immolation', 'aura_radius'],
+    ['warlock_rain_of_chaos', 'aura_damage'],
+    ['custom_permanent_immolation', 'aura_damage'],
+  ])('rejects unrelated ability special %s.%s', (abilityName, specialName) => {
+    expect(isWarlockImmolationDamageSpecial(abilityName, specialName)).toBe(false);
+  });
+});
+
+describe('isWarlockInfernalUnitName', () => {
+  it.each([
+    'npc_dota_warlock_golem',
+    'npc_dota_warlock_golem_1',
+    'npc_dota_warlock_golem_3',
+    'npc_dota_warlock_golem_scepter_1',
+    'npc_dota_warlock_golem_scepter_3',
+  ])('accepts the runtime Warlock Infernal variant %s', (unitName) => {
+    expect(isWarlockInfernalUnitName(unitName)).toBe(true);
+  });
+
+  it('rejects unrelated units', () => {
+    expect(isWarlockInfernalUnitName('npc_dota_neutral_mud_golem')).toBe(false);
+  });
+});
+
+describe('isOwnedWarlockInfernalCandidate', () => {
+  const baseCandidate = {
+    unitName: 'npc_dota_warlock_golem_1',
+    hasPermanentImmolation: true,
+    ownerEntityIndex: 101,
+    warlockEntityIndex: 101,
+    unitPlayerOwnerId: 3,
+    warlockPlayerOwnerId: 3,
+  };
+
+  it.each([
+    'npc_dota_warlock_golem',
+    'npc_dota_warlock_golem_3',
+    'npc_dota_warlock_golem_scepter_3',
+  ])('accepts an owned Infernal variant with Permanent Immolation: %s', (unitName) => {
+    expect(isOwnedWarlockInfernalCandidate({ ...baseCandidate, unitName })).toBe(true);
+  });
+
+  it('rejects an Infernal owned by another entity even when PlayerID matches', () => {
+    expect(
+      isOwnedWarlockInfernalCandidate({
+        ...baseCandidate,
+        ownerEntityIndex: 202,
+      }),
+    ).toBe(false);
+  });
+
+  it('falls back to a valid matching PlayerID only when owner entity is unavailable', () => {
+    expect(
+      isOwnedWarlockInfernalCandidate({
+        ...baseCandidate,
+        ownerEntityIndex: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { ownerEntityIndex: undefined, unitPlayerOwnerId: -1, warlockPlayerOwnerId: -1 },
+    { ownerEntityIndex: undefined, unitPlayerOwnerId: 4, warlockPlayerOwnerId: 3 },
+    { hasPermanentImmolation: false },
+    { unitName: 'npc_dota_neutral_mud_golem' },
+  ])('rejects an invalid candidate: %o', (overrides) => {
+    expect(isOwnedWarlockInfernalCandidate({ ...baseCandidate, ...overrides })).toBe(false);
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/warlock-awaken-math.ts
+++ b/src/vscripts/abilities/ts_abilities/warlock-awaken-math.ts
@@ -1,0 +1,61 @@
+const PERMANENT_IMMOLATION_ABILITY = 'warlock_golem_permanent_immolation';
+const PERMANENT_IMMOLATION_DAMAGE_SPECIAL = 'aura_damage';
+
+export function calculateWarlockAwakenDamagePerSecond(
+  healthRegen: number,
+  manaRegen: number,
+  conversionPercent: number,
+): number {
+  if (conversionPercent <= 0) return 0;
+  return Math.max(0, healthRegen + manaRegen) * (conversionPercent / 100);
+}
+
+export function calculateWarlockImmolationDamage(
+  nativeDamage: number,
+  healthRegen: number,
+  manaRegen: number,
+  conversionPercent: number,
+): number {
+  return (
+    nativeDamage + calculateWarlockAwakenDamagePerSecond(healthRegen, manaRegen, conversionPercent)
+  );
+}
+
+export function isWarlockImmolationDamageSpecial(
+  abilityName: string,
+  specialValueName: string,
+): boolean {
+  return (
+    abilityName === PERMANENT_IMMOLATION_ABILITY &&
+    specialValueName === PERMANENT_IMMOLATION_DAMAGE_SPECIAL
+  );
+}
+
+export function isWarlockInfernalUnitName(unitName: string): boolean {
+  return unitName === 'npc_dota_warlock_golem' || unitName.startsWith('npc_dota_warlock_golem_');
+}
+
+export interface WarlockInfernalCandidate {
+  unitName: string;
+  hasPermanentImmolation: boolean;
+  ownerEntityIndex: number | undefined;
+  warlockEntityIndex: number;
+  unitPlayerOwnerId: number;
+  warlockPlayerOwnerId: number;
+}
+
+export function isOwnedWarlockInfernalCandidate(candidate: WarlockInfernalCandidate): boolean {
+  if (!isWarlockInfernalUnitName(candidate.unitName) || !candidate.hasPermanentImmolation) {
+    return false;
+  }
+
+  if (candidate.ownerEntityIndex !== undefined) {
+    return candidate.ownerEntityIndex === candidate.warlockEntityIndex;
+  }
+
+  return (
+    candidate.unitPlayerOwnerId >= 0 &&
+    candidate.warlockPlayerOwnerId >= 0 &&
+    candidate.unitPlayerOwnerId === candidate.warlockPlayerOwnerId
+  );
+}

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.43';
+  public static readonly GAME_VERSION = 'v5.44';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -16,6 +16,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 术士 觉醒
+  {
+    heroName: 'npc_dota_hero_warlock',
+    newAbility: 'special_bonus_unique_warlock_upgrade',
+    newLevel: 1,
+  },
   // 屠夫 觉醒肉钩：把原版 pudge_meat_hook 替换为射程随力量增长的觉醒版
   {
     heroName: 'npc_dota_hero_pudge',


### PR DESCRIPTION
## Issue

- None

## Changes

- Adds a Warlock awakening as a hidden passive without replacing any original ability.
- Displays an awakening status icon on Warlock.
- Adds 150% of Warlock's current Health Regeneration and Mana Regeneration to each owned Infernal's Permanent Immolation DPS.
- Applies the effect to existing and newly spawned Infernals with ownership and lifecycle guards.

## Checklist

- [x] Targeted Jest tests pass (24/24).
- [x] `npm run build:vscripts` passes.
- [x] `npm run build:panorama` passes.
- [x] `npm run lint -- --quiet` passes.
- [x] `git diff --check` passes.
- [x] Validate the 150% tuning in Dota Tools.

## Release Note

```
[b]游戏性更新 v5.44[/b]

- 新增术士觉醒：术士生命恢复与魔法恢复之和的150%会提高地狱火永恒献祭每秒伤害。
```

```
[b]Gameplay update v5.44[/b]

- Added a Warlock awakening that converts 150% of his Health and Mana Regeneration into additional Infernal Permanent Immolation damage per second.
```