### PR TITLE
Restrict fountain sanction to team games; fix auto-duel illusions

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1156,7 +1156,9 @@
 
 		// Fountain Sanction
 		"DOTA_Tooltip_ability_fountain_anti_camp"							"Fountain Sanction"
-		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Enemy human-controlled heroes near the fountain's attack range are sanctioned."
+		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Enemy human-controlled heroes near the fountain's attack range are sanctioned. Only active in team mode."
+		"DOTA_Tooltip_modifier_fountain_anti_camp_stack"				"Fountain Sanction Warning"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_stack_Description"	"Stacks once per second while near the fountain. Reaching 3 stacks triggers the sanction."
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"Fountain Sanction"
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"Unable to attack, use items, active abilities, or passive abilities. Health and mana cannot be restored. Movement speed is forcibly restricted, and buffs are forcibly dispelled."
 

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1151,7 +1151,9 @@
 
 		// 泉水 制裁
 		"DOTA_Tooltip_ability_fountain_anti_camp"							"泉水制裁"
-		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"敌方人类玩家英雄靠近泉水攻击范围时会被制裁。"
+		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"敌方人类玩家英雄靠近泉水攻击范围时会被制裁。仅组队模式下生效。"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_stack"				"泉水制裁警告"
+		"DOTA_Tooltip_modifier_fountain_anti_camp_stack_Description"	"靠近泉水时每秒叠加一层，叠满3层后将进入制裁状态。"
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock"					"泉水制裁"
 		"DOTA_Tooltip_modifier_fountain_anti_camp_lock_Description"		"无法攻击，无法使用装备、主动技能和被动技能，无法恢复生命和魔法，移动速度被强制限制，且增益被强制驱散。"
 

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -3267,11 +3267,11 @@
 		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
 		"AbilityTextureName"			"action_lockenemytower"
 		"MaxLevel"						"1"
-		"AbilityCastRange"				"2200"
+		"AbilityCastRange"				"2000"
 
 		"AbilityValues"
 		{
-			"radius"					"2200"
+			"radius"					"2000"
 			"move_speed"				"300"
 		}
 	}

--- a/src/vscripts/abilities/ts_abilities/axe_auto_culling_blade.ts
+++ b/src/vscripts/abilities/ts_abilities/axe_auto_culling_blade.ts
@@ -40,7 +40,7 @@ export class AxeAutoCullingBlade extends AutoCastAbility {
       caster,
       getFullCastRange(caster, culling),
       UnitTargetType.HERO,
-      true,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
     );
 
     // 斩杀线 = 原版固定阈值，吃技能增强

--- a/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
+++ b/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
@@ -7,9 +7,11 @@ import {
 } from '../../utils/dota_ts_adapter';
 
 const WATCHER_MODIFIER_NAME = 'modifier_fountain_anti_camp_watcher';
+const STACK_MODIFIER_NAME = 'modifier_fountain_anti_camp_stack';
 const LOCK_MODIFIER_NAME = 'modifier_fountain_anti_camp_lock';
 const POLL_INTERVAL = 1;
-const LOCK_DURATION = 3;
+const DEBUFF_DURATION = 3;
+const LOCK_STACK_THRESHOLD = 3;
 
 @registerAbility('fountain_anti_camp')
 export class AbilityFountainAntiCamp extends BaseAbility {
@@ -36,6 +38,7 @@ export class modifier_fountain_anti_camp_watcher extends BaseModifier {
   OnCreated(): void {
     if (!IsServer()) return;
     if (this.GetParent().GetTeamNumber() !== DotaTeam.BADGUYS) return;
+    if (PlayerHelper.GetHumamPlayerCount() < 2) return;
     this.StartIntervalThink(POLL_INTERVAL);
   }
 
@@ -60,7 +63,50 @@ export class modifier_fountain_anti_camp_watcher extends BaseModifier {
 
     for (const hero of enemies) {
       if (!hero.IsRealHero() || !PlayerHelper.IsHumanPlayer(hero)) continue;
-      hero.AddNewModifier(fountain, ability, LOCK_MODIFIER_NAME, { duration: LOCK_DURATION });
+
+      const stack = hero.AddNewModifier(fountain, ability, STACK_MODIFIER_NAME, {
+        duration: DEBUFF_DURATION,
+      });
+
+      if (stack.GetStackCount() >= LOCK_STACK_THRESHOLD) {
+        hero.AddNewModifier(fountain, ability, LOCK_MODIFIER_NAME, {
+          duration: DEBUFF_DURATION,
+        });
+      }
+    }
+  }
+}
+
+@registerModifier('abilities/ts_abilities/fountain_anti_camp')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_fountain_anti_camp_stack extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return 'action_lockenemytower';
+  }
+
+  OnCreated(): void {
+    this.SetStackCount(1);
+  }
+
+  OnRefresh(): void {
+    if (this.GetStackCount() < LOCK_STACK_THRESHOLD) {
+      this.IncrementStackCount();
     }
   }
 }

--- a/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
+++ b/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
@@ -38,7 +38,8 @@ export class modifier_fountain_anti_camp_watcher extends BaseModifier {
   OnCreated(): void {
     if (!IsServer()) return;
     if (this.GetParent().GetTeamNumber() !== DotaTeam.BADGUYS) return;
-    if (PlayerHelper.GetHumamPlayerCount() < 2) return;
+    // 仅在多人游戏中生效 (开发模式下允许单人测试生效)
+    if (!IsInToolsMode() && PlayerHelper.GetHumamPlayerCount() < 2) return;
     this.StartIntervalThink(POLL_INTERVAL);
   }
 

--- a/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
+++ b/src/vscripts/abilities/ts_abilities/fountain_anti_camp.ts
@@ -65,14 +65,20 @@ export class modifier_fountain_anti_camp_watcher extends BaseModifier {
     for (const hero of enemies) {
       if (!hero.IsRealHero() || !PlayerHelper.IsHumanPlayer(hero)) continue;
 
-      const stack = hero.AddNewModifier(fountain, ability, STACK_MODIFIER_NAME, {
-        duration: DEBUFF_DURATION,
-      });
+      if (hero.HasModifier(LOCK_MODIFIER_NAME)) {
+        hero.AddNewModifier(fountain, ability, LOCK_MODIFIER_NAME, { duration: DEBUFF_DURATION });
+        continue;
+      }
 
-      if (stack.GetStackCount() >= LOCK_STACK_THRESHOLD) {
-        hero.AddNewModifier(fountain, ability, LOCK_MODIFIER_NAME, {
-          duration: DEBUFF_DURATION,
-        });
+      const stackCount = (hero.FindModifierByName(STACK_MODIFIER_NAME)?.GetStackCount() ?? 0) + 1;
+
+      if (stackCount >= LOCK_STACK_THRESHOLD) {
+        hero.RemoveModifierByName(STACK_MODIFIER_NAME);
+        hero.AddNewModifier(fountain, ability, LOCK_MODIFIER_NAME, { duration: DEBUFF_DURATION });
+      } else {
+        hero
+          .AddNewModifier(fountain, ability, STACK_MODIFIER_NAME, { duration: DEBUFF_DURATION })
+          .SetStackCount(stackCount);
       }
     }
   }
@@ -99,16 +105,6 @@ export class modifier_fountain_anti_camp_stack extends BaseModifier {
 
   GetTexture(): string {
     return 'action_lockenemytower';
-  }
-
-  OnCreated(): void {
-    this.SetStackCount(1);
-  }
-
-  OnRefresh(): void {
-    if (this.GetStackCount() < LOCK_STACK_THRESHOLD) {
-      this.IncrementStackCount();
-    }
   }
 }
 

--- a/src/vscripts/abilities/ts_abilities/legion_commander_auto_duel.ts
+++ b/src/vscripts/abilities/ts_abilities/legion_commander_auto_duel.ts
@@ -20,7 +20,8 @@ export class LegionCommanderAutoDuel extends AutoCastAbility {
       caster,
       getFullCastRange(caster, duel) + bonusCastRange,
       UnitTargetType.HERO,
-      true, // 决斗可对魔免单位施放
+      // 决斗可对魔免单位施放，排除幻象
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES + UnitTargetFlags.NOT_ILLUSIONS,
     );
     const target = enemies[0];
     if (!target) return;

--- a/src/vscripts/abilities/ts_abilities/shared/auto-cast-ability.ts
+++ b/src/vscripts/abilities/ts_abilities/shared/auto-cast-ability.ts
@@ -55,17 +55,14 @@ export function getFullCastRange(caster: CDOTA_BaseNPC, ability: CDOTABaseAbilit
   return ability.GetCastRange(caster.GetAbsOrigin(), undefined) + caster.GetCastRangeBonus();
 }
 
-/** 在 range 内找敌方单位（最近优先）。始终排除迷雾外/隐身单位；allowMagicImmune 时额外可命中魔免单位（如淘汰之刃）。 */
+/** 在 range 内找敌方单位（最近优先）。始终排除迷雾外/隐身单位；extraFlags 可叠加额外过滤（如魔免单位可命中、排除幻象）。 */
 export function findEnemiesInRange(
   caster: CDOTA_BaseNPC,
   range: number,
   targetType: UnitTargetType,
-  allowMagicImmune = false,
+  extraFlags: UnitTargetFlags = UnitTargetFlags.NONE,
 ): CDOTA_BaseNPC[] {
-  let flags = UnitTargetFlags.FOW_VISIBLE + UnitTargetFlags.NO_INVIS;
-  if (allowMagicImmune) {
-    flags = flags + UnitTargetFlags.MAGIC_IMMUNE_ENEMIES;
-  }
+  const flags = UnitTargetFlags.FOW_VISIBLE + UnitTargetFlags.NO_INVIS + extraFlags;
   return FindUnitsInRadius(
     caster.GetTeamNumber(),
     caster.GetAbsOrigin(),

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_zuus_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_zuus_upgrade.ts
@@ -33,7 +33,6 @@ export class SpecialBonusUniqueZuusUpgrade extends AutoCastAbility {
     caster: CDOTA_BaseNPC_Hero,
     ability: CDOTABaseAbility,
   ): [CDOTA_BaseNPC | undefined, boolean] {
-    // 宙斯不可对魔免单位施放，allowMagicImmune 用默认 false
     const enemies = findEnemiesInRange(
       caster,
       getFullCastRange(caster, ability),


### PR DESCRIPTION
## Issue

- [x] fix #2240

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.44a[/b]

- 泉水制裁改为仅组队模式生效，3秒后才会被制裁
- 修正军团觉醒自动决斗不再对幻象释放
```

```
[b]Gameplay update v5.44a[/b]

- Fountain Sanction now only triggers in team games and takes 3 seconds to sanction.
- Fixed Legion Commander's Auto Duel Awakened so it no longer casts on illusions.
```
