### PR TITLE
Add spellblock to Crystal Maiden awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1294,10 +1294,12 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff_Description"	"Strength increased by %dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS% and Attack Speed by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%."
 
 		// 水晶室女 极寒领域-觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade"					"<font color='#d000ff'>Freezing Field Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"		"Grants <font color='#FFCC66'>Magic Immunity</font> while channeling Freezing Field, lost immediately when the channel ends."
-		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade"					"<font color='#d000ff'>Freezing Field Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"		"Grants <font color='#FFCC66'>Magic Immunity</font> while channeling Freezing Field, lost immediately when the channel ends."
+		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>Freezing Field Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"			"Casting Freezing Field grants <font color='#FFCC66'>Magic Immunity</font>.<br><br>Also grants <font color='#FFFFFF'>Spellblock</font> for <font color='#FFFFFF'><b>10</b></font> seconds, consumed after blocking one enemy targeted spell."
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>Freezing Field Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"			"Casting Freezing Field grants <font color='#FFCC66'>Magic Immunity</font>.<br><br>Also grants <font color='#FFFFFF'>Spellblock</font> for <font color='#FFFFFF'><b>10</b></font> seconds, consumed after blocking one enemy targeted spell."
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield"				"Freezing Field Awakened"
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield_Description"	"Grants <font color='#FFFFFF'>Spellblock</font>, blocking one enemy targeted spell."
 
 		// 小小 抓树-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_tiny_upgrade"					"<font color='#d000ff'>Tree Grab Awakened</font>"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1292,10 +1292,12 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff_Description"	"力量提升%dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS%点，攻击速度提升%dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%点。"
 
 		// 水晶室女 极寒领域-觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade"					"<font color='#d000ff'>极寒领域 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"		"引导极寒领域期间获得<font color='#FFCC66'>技能免疫</font>，引导结束时立即失去。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade"					"<font color='#d000ff'>极寒领域 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"		"引导极寒领域期间获得<font color='#FFCC66'>技能免疫</font>，引导结束时立即失去。"
+		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>极寒领域 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"			"施放极寒领域获得<font color='#FFCC66'>技能免疫</font>。<br><br>同时获得<font color='#FFFFFF'>法术抵抗</font>，持续<font color='#FFFFFF'><b>10</b></font>秒，抵挡一次敌方指向性法术后消失。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>极寒领域 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"			"施放极寒领域获得<font color='#FFCC66'>技能免疫</font>。<br><br>同时获得<font color='#FFFFFF'>法术抵抗</font>，持续<font color='#FFFFFF'><b>10</b></font>秒，抵挡一次敌方指向性法术后消失。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield"				"极寒领域 觉醒"
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield_Description"	"获得<font color='#FFFFFF'>法术抵抗</font>，抵挡一次敌方指向性法术。"
 
 		// 小小 抓树-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_tiny_upgrade"					"<font color='#d000ff'>抓树 觉醒</font>"

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_crystal_maiden_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_crystal_maiden_upgrade.ts
@@ -1,3 +1,4 @@
+import { IsEnemyTeam } from '../../modules/helper/unit-helper';
 import {
   BaseAbility,
   BaseModifier,
@@ -7,7 +8,7 @@ import {
 import { applyAwakenMagicImmunity } from './shared/awaken-magic-immunity';
 
 /**
- * 水晶室女 极寒领域-觉醒：引导期间获得技能免疫。
+ * 水晶室女 极寒领域-觉醒：引导期间获得技能免疫，并附带一次指向性技能免疫。
  * 引导时长远超真 BKB 上限，故收回时只 Destroy 本次拿到的句柄，不能凭剩余时间判断（会误删真 BKB）。
  */
 @registerAbility('special_bonus_unique_crystal_maiden_upgrade')
@@ -48,7 +49,15 @@ export class modifier_special_bonus_unique_crystal_maiden_upgrade extends BaseMo
     const duration = event.ability.GetChannelTime();
     if (duration <= 0) return;
 
-    this.immunity = applyAwakenMagicImmunity(this.GetParent(), ability, duration);
+    const parent = this.GetParent();
+    this.immunity = applyAwakenMagicImmunity(parent, ability, duration);
+    // 引导被打断也不收回，让引导结束后的脆弱期同样有一次保护
+    parent.AddNewModifier(
+      parent,
+      ability,
+      modifier_special_bonus_unique_crystal_maiden_upgrade_shield.name,
+      { duration },
+    );
   }
 
   OnAbilityEndChannel(event: ModifierAbilityEvent): void {
@@ -66,5 +75,47 @@ export class modifier_special_bonus_unique_crystal_maiden_upgrade extends BaseMo
       event.unit === this.GetParent() &&
       event.ability.GetAbilityName() === 'crystal_maiden_freezing_field'
     );
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_crystal_maiden_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_crystal_maiden_upgrade_shield extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return 'item_sphere';
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ABSORB_SPELL];
+  }
+
+  GetAbsorbSpell(event: ModifierAbilityEvent): 0 | 1 {
+    if (!IsServer()) return 0;
+
+    const parent = this.GetParent();
+    if (!IsEnemyTeam(event.ability.GetCaster(), parent)) return 0;
+
+    const particle = ParticleManager.CreateParticle(
+      'particles/items_fx/immunity_sphere.vpcf',
+      ParticleAttachment.ABSORIGIN_FOLLOW,
+      parent,
+    );
+    ParticleManager.ReleaseParticleIndex(particle);
+    parent.EmitSound('DOTA_Item.LinkensSphere.Activate');
+
+    this.Destroy();
+    return 1;
   }
 }


### PR DESCRIPTION
## Checklist

- [ ] I have tested the changes works well.
- [x] 在 Dota Tools 中验证法术抵抗能正确抵挡敌方指向性法术（如末日、羊刀），且不吃队友增益
- [x] 在 Dota Tools 中验证觉醒 buff 图标（林肯球）显示正常
- [x] 在 Dota Tools 中验证极寒领域被打断后法术抵抗仍保留剩余时长

## Release Note

```
[b]游戏性更新 v5.46[/b]

- 新增水晶室女觉醒：极寒领域期间获得技能免疫，并获得法术抵抗，可抵挡一次敌方指向性法术
```

```
[b]Gameplay update v5.46[/b]

- Added a Crystal Maiden awakening: gains Magic Immunity during Freezing Field, and Spellblock that blocks one enemy targeted spell.
```
