### PR TITLE
Rebalance bot hero item build candidates and weights

### DIFF
--- a/src/vscripts/ai/build-item/hero-build-config-template.ts
+++ b/src/vscripts/ai/build-item/hero-build-config-template.ts
@@ -108,9 +108,9 @@ const AgilityTemplate: HeroTemplateConfig = {
     [ItemTier.T3]: [
       'item_wasp_callous', // 大核荣耀冷酷
       'item_satanic', // 撒旦之邪力
+      'item_monkey_king_bar_2', // 定海神针
     ],
     [ItemTier.T4]: [
-      'item_monkey_king_bar_2', // 金箍棒2（tier 归属修正：真实价格属于 T4）
       'item_black_king_bar_2', // 黑皇杖2
       'item_wasp_golden', // 黄金大核荣耀
       'item_infernal_desolator', // 绝对破防之刃

--- a/src/vscripts/ai/build-item/hero-build-config.ts
+++ b/src/vscripts/ai/build-item/hero-build-config.ts
@@ -37,6 +37,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
         'item_falcon_blade', // 猎鹰战刃
+        'item_magic_wand', // 魔杖
       ],
       [ItemTier.T2]: [
         'item_sange_and_yasha', // 散夜对剑
@@ -44,8 +45,8 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_black_king_bar', // 黑皇杖
         'item_desolator', // 黯灭
         'item_bfury', // 狂战斧
-        'item_manta', // 幻影斧
         'item_hand_of_group', // 团队之手
+        { item: 'item_echo_sabre_2', weight: 2 }, // 音速战刃
       ],
       [ItemTier.T3]: [
         'item_wasp_callous', // 大核荣耀冷酷
@@ -55,15 +56,16 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_angels_demise', // 天使陨落
         'item_sacred_trident', // 圣三叉戟
         'item_armlet_pro_max', // 臂章·终极
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_blue_fantasy', // 苍蓝幻想
         'item_sange_and_yasha_1', // 神器散夜
-        'item_monkey_king_bar_2', // 定海神针
         'item_black_king_bar_2', // 真·BKB
         'item_infernal_desolator', // 绝对破防之刃
         'item_wasp_golden', // 黄金大核荣耀
         'item_excalibur', // EX咖喱棒
+        { item: 'item_abyssal_blade_v2', weight: 2 }, // 一闪
       ],
       [ItemTier.T5]: [
         'item_rapier_ultra_bot_1', // 圣剑终极版
@@ -105,10 +107,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_butterfly', // 蝴蝶刀
         'item_dodo_desolator', // 黯灭头
         'item_sacred_trident', // 三叉戟
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_blue_fantasy', // 苍蓝幻想
-        'item_monkey_king_bar_2', // 定海神针
         'item_abyssal_blade_v2', // 一闪
         'item_infernal_desolator', // 绝对破防之刃
         'item_wasp_golden', // 黄金大核荣耀
@@ -155,9 +157,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_sacred_trident', // 三叉戟
         'item_radiance_2', // 圣焰之光
         'item_satanic', // 撒旦之邪力
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
-        'item_monkey_king_bar_2', // 定海神针
         'item_infernal_desolator', // 绝对破防之刃
         'item_blue_fantasy', // 苍蓝幻想
         'item_sange_and_yasha_1', // 神器·散夜对剑
@@ -211,19 +213,19 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_sacred_trident', // 三叉戟
         'item_hydras_breath', // 怪蛇之息
         'item_greater_crit', // 代达罗斯之殇
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_black_king_bar_2', // 天神杖
         'item_infernal_desolator', // 绝对破防之刃
         'item_abyssal_blade_v2', // 一闪
         'item_wasp_golden', // 黄金大核荣耀
-        'item_jump_jump_jump', // 跳！跳！跳！刀
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
         'item_excalibur', // EX咖喱棒
         'item_bfury_ultra', // 救世狂战
         'item_sacred_six_vein', // 六脉神剑
         'item_refresh_core', // 熔火核心
         'item_sange_and_yasha_1', // 神器·散夜对剑
-        'item_monkey_king_bar_2', // 定海神针
         'item_saint_orb', // 圣女白莲
       ],
       [ItemTier.T5]: [
@@ -248,7 +250,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_mask_of_madness', // 疯狂面具
         'item_magic_wand', // 魔杖
         'item_lesser_crit', // 水晶剑
-        'item_blood_grenade', // 血腥榴弹
         'item_vanguard', // 先锋盾
       ],
       [ItemTier.T2]: [
@@ -266,7 +267,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_force_staff', // 原力法杖
       ],
       [ItemTier.T3]: [
-        'item_hurricane_pike_2', // 黄金魔龙枪 Ultimate
+        { item: 'item_hurricane_pike_2', weight: 2 }, // 黄金魔龙枪 Ultimate
         'item_wasp_callous', // 大核荣耀冷酷
         'item_dodo_desolator', // 黯灭头
         'item_shotgun_v2', // 三管霰弹枪
@@ -277,11 +278,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_mjollnir', // 雷神之锤
         'item_greater_crit', // 代达罗斯之殇
         'item_vladmir_2', // 强袭祭品
-        'item_aeon_pendant', // 咸鱼之王
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_infernal_desolator', // 绝对破防之刃
-        'item_monkey_king_bar_2', // 定海神针（tier 归属修正：真实价格属于 T4）
         'item_wasp_golden', // 黄金大核荣耀
         'item_satanic_2', // 真·撒旦
         'item_skadi_2', // 大冰眼
@@ -316,10 +316,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_power_treads', // 动力鞋
         'item_wraith_band', // 怨灵系带
         'item_magic_wand', // 魔杖
-        'item_hyperstone', // 振奋宝石
         'item_lesser_crit', // 水晶剑
-        'item_blood_grenade', // 血腥榴弹
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
+        { item: 'item_mask_of_madness', weight: 2 }, // 疯狂面具
       ],
       [ItemTier.T2]: [
         'item_hand_of_group', // 团队之手
@@ -331,23 +330,22 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_specialists_array', // 行家阵列
         'item_sange_and_yasha', // 散夜对剑
         'item_force_staff', // 原力法杖
-        'item_eagle', // 鹰歌弓
         'item_aether_lens_2', // 以太透镜2
         'item_octarine_core', // 玲珑心
       ],
       [ItemTier.T3]: [
-        'item_hurricane_pike_2', // 黄金魔龙枪 Ultimate
+        { item: 'item_hurricane_pike_2', weight: 2 }, // 黄金魔龙枪 Ultimate
         'item_shotgun_v2', // 三管霰弹枪
         'item_dodo_desolator', // 黯灭头
         'item_mjollnir', // 雷神之锤
         'item_hydras_breath', // 怪蛇之息
         'item_wasp_callous', // 大核荣耀冷酷
-        'item_eternal_shroud_ultra', // 法师泳衣
         'item_sacred_trident', // 三叉戟
         'item_greater_crit', // 代达罗斯之殇
         'item_butterfly', // 蝴蝶
         'item_skadi', // 斯嘉蒂之眼
         'item_revenants_brooch_ultra', // 神器·魔武双修
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_infernal_desolator', // 绝对破防之刃
@@ -355,7 +353,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_wasp_golden', // 黄金大核荣耀
         'item_excalibur', // EX咖喱棒
         'item_black_king_bar_2', // 天神杖
-        'item_monkey_king_bar_2', // 定海神针
         'item_hydras_breath_2', // 神器·千年毒蛟之息
         'item_skadi_2', // 粘妈之眼
         'item_refresh_core', // 熔火核心
@@ -388,13 +385,12 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_magic_wand', // 魔杖
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
-        'item_blood_grenade', // 血腥榴弹
         'item_lesser_crit', // 水晶剑
       ],
       [ItemTier.T2]: [
-        'item_desolator', // 黯灭
+        { item: 'item_desolator', weight: 2 }, // 黯灭
         'item_bfury', // 狂战斧
-        'item_basher', // 碎颅锤
+        { item: 'item_basher', weight: 2 }, // 碎颅锤
         'item_echo_sabre', // 回音战刃
         'item_hand_of_group', // 团队之手
         'item_black_king_bar', // 黑皇杖
@@ -402,7 +398,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_monkey_king_bar', // 金箍棒
         'item_sange_and_yasha', // 散夜对剑
         'item_octarine_core', // 玲珑心
-        'item_aether_lens', // 以太透镜
         'item_crellas_crozier', // 克莱拉牧杖
       ],
       [ItemTier.T3]: [
@@ -416,8 +411,8 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_aeon_pendant', // 咸鱼之王
         'item_adi_king_plus', // 阿迪王plus
         'item_greater_crit', // 代达罗斯之殇
-        'item_eternal_shroud_ultra', // 法师泳衣
         'item_rapier', // 圣剑
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_infernal_desolator', // 绝对破防之刃
@@ -427,7 +422,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_satanic_2', // 真红·撒旦之邪力
         'item_excalibur', // EX咖喱棒
         'item_bfury_ultra', // 救世狂战
-        'item_monkey_king_bar_2', // 定海神针
         'item_skadi_2', // 粘妈之眼
         'item_sacred_six_vein', // 六脉神剑
         'item_wasp_golden', // 黄金大核荣耀
@@ -458,7 +452,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_mask_of_madness', // 疯狂面具
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_blood_grenade', // 血腥榴弹
         'item_lesser_crit', // 水晶剑
       ],
       [ItemTier.T2]: [
@@ -486,13 +479,12 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_mjollnir', // 雷神之锤
         'item_greater_crit', // 代达罗斯之殇
         'item_satanic', // 撒旦之邪力
-        'item_aeon_pendant', // 咸鱼之王
         'item_vladmir_2', // 强袭祭品
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_black_king_bar_2', // 天神杖
         'item_infernal_desolator', // 绝对破防之刃
-        'item_monkey_king_bar_2', // 定海神针
         'item_wasp_golden', // 黄金大核荣耀
         'item_arcane_blink', // 爱因斯坦闪光
         'item_skadi_2', // 粘妈之眼
@@ -534,8 +526,8 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       ],
       [ItemTier.T2]: [
         'item_hand_of_group', // 团队之手
-        'item_bfury', // 狂战斧
-        'item_basher', // 碎颅锤
+        { item: 'item_bfury', weight: 2 }, // 狂战斧
+        { item: 'item_basher', weight: 2 }, // 碎颅锤
         'item_sange_and_yasha', // 散夜对剑
         'item_blink', // 闪烁匕首
         'item_echo_sabre', // 回音战刃
@@ -558,7 +550,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_wasp_despotic', // 大核荣耀暴虐
         'item_adi_king_plus', // 阿迪王plus
         'item_greater_crit', // 代达罗斯之殇
-        'item_eternal_shroud_ultra', // 法师泳衣
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_bfury_ultra', // 救世狂战
@@ -566,13 +558,13 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_excalibur', // EX咖喱棒
         'item_refresh_core', // 熔火核心
         'item_sacred_six_vein', // 六脉神剑
-        'item_monkey_king_bar_2', // 定海神针
         'item_black_king_bar_2', // 天神杖
         'item_sange_and_yasha_1', // 神器·散夜对剑
         'item_blue_fantasy', // 苍蓝幻想
         'item_skadi_2', // 粘妈之眼
         'item_abyssal_blade_v2', // 一闪
         'item_arcane_octarine_core', // 奥术之心
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
       ],
       [ItemTier.T5]: [
         'item_magic_sword', // 魔渊剑
@@ -619,9 +611,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_wasp_callous', // 大核荣耀冷酷
         'item_mjollnir', // 雷神之锤
         'item_sacred_trident', // 三叉戟
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
+        { item: 'item_silver_edge_2', weight: 2 }, // 无敌之刃
       ],
       [ItemTier.T4]: [
-        'item_monkey_king_bar_2', // 定海神针（tier 归属修正：真实价格属于 T4）
         'item_excalibur', // 圣剑
         'item_satanic_2', // 真·撒旦
         'item_black_king_bar_2', // 真·BKB
@@ -652,10 +645,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_power_treads', // 动力鞋
         'item_wraith_band', // 怨灵系带
         'item_mask_of_madness', // 疯狂面具
-        'item_hyperstone', // 振奋宝石
         'item_magic_wand', // 魔杖
         'item_lesser_crit', // 水晶剑
-        'item_blood_grenade', // 血腥榴弹
+        'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
         'item_sange_and_yasha', // 散夜对剑
@@ -664,7 +656,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_desolator', // 黯灭
         'item_monkey_king_bar', // 金箍棒
         'item_specialists_array', // 行家阵列
-        'item_eagle', // 鹰歌弓
         'item_force_staff', // 原力法杖
         'item_black_king_bar', // 黑皇杖
         'item_hurricane_pike', // 飓风长戟
@@ -680,9 +671,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_butterfly', // 蝴蝶
         'item_sacred_trident', // 三叉戟
         'item_rapier', // 圣剑
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
-        'item_monkey_king_bar_2', // 定海神针（tier 归属修正：真实价格属于 T4）
         'item_satanic_2', // 真·撒旦
         'item_black_king_bar_2', // 真·BKB
         'item_infernal_desolator', // 绝对破防之刃
@@ -740,9 +731,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_sacred_trident', // 三叉戟
         'item_radiance_2', // 圣焰之光
         'item_mjollnir', // 雷神之锤
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
-        'item_monkey_king_bar_2', // 定海神针
         'item_black_king_bar_2', // 天神杖
         'item_wasp_golden', // 黄金大核荣耀
         'item_refresh_core', // 熔火核心
@@ -795,9 +786,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_hydras_breath', // 怪蛇之息
         'item_mjollnir', // 雷神之锤
         'item_sacred_trident', // 三叉戟
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
-        'item_monkey_king_bar_2', // 定海神针
         'item_infernal_desolator', // 绝对破防之刃
         'item_black_king_bar_2', // 天神杖
         'item_wasp_golden', // 黄金大核荣耀
@@ -851,11 +842,11 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_shotgun_v2', // 三管霰弹枪
         'item_sacred_trident', // 三叉戟
         'item_satanic', // 撒旦之邪力
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_infernal_desolator', // 绝对破防之刃
         'item_black_king_bar_2', // 天神杖
-        'item_monkey_king_bar_2', // 定海神针
         'item_wasp_golden', // 黄金大核荣耀
         'item_skadi_2', // 粘妈之眼
         'item_excalibur', // EX咖喱棒
@@ -910,7 +901,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_undying_heart', // 不朽之心
         'item_blue_fantasy', // 苍蓝幻想
         'item_shivas_guard_2', // 雅典娜的守护
-        'item_jump_jump_jump', // 跳！跳！跳！刀
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
         'item_satanic_2', // 真红·撒旦之邪力
         'item_saint_orb', // 圣女白莲
         'item_sacred_six_vein', // 六脉神剑
@@ -992,7 +983,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_arcane_boots', // 奥术鞋
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 迈达斯之手
-        'item_blood_grenade', // 血腥榴弹
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
         'item_soul_ring', // 灵魂之戒
@@ -1002,13 +992,12 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_glimmer_cape', // 微光披风
         'item_hand_of_group', // 团队之手
         'item_blink', // 闪烁匕首
-        'item_force_staff', // 原力法杖
-        'item_aether_lens_2', // 以太透镜2
+        { item: 'item_force_staff', weight: 2 }, // 原力法杖
+        { item: 'item_aether_lens_2', weight: 2 }, // 以太透镜2
         'item_travel_boots', // 远行鞋
         'item_octarine_core', // 玲珑心
         'item_yasha_and_kaya', // 慧夜对剑
         'item_black_king_bar', // 黑皇杖
-        'item_aether_lens', // 以太透镜
         'item_maelstrom', // 漩涡
       ],
       [ItemTier.T3]: [
@@ -1057,7 +1046,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       [ItemTier.T1]: [
         'item_arcane_boots', // 奥术鞋
         'item_null_talisman', // 空灵挂件
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 迈达斯之手
         'item_vanguard', // 先锋盾
@@ -1066,9 +1054,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       ],
       [ItemTier.T2]: [
         'item_holy_locket', // 圣洁吊坠
-        'item_glimmer_cape', // 微光披风
+        { item: 'item_glimmer_cape', weight: 2 }, // 微光披风
         'item_force_staff', // 原力法杖
-        'item_aether_lens_2', // 以太透镜2
+        { item: 'item_aether_lens_2', weight: 2 }, // 以太透镜2
         'item_blink', // 闪烁匕首
         'item_hand_of_group', // 团队之手
         'item_octarine_core', // 玲珑心
@@ -1175,21 +1163,19 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       [ItemTier.T1]: [
         'item_arcane_boots', // 奥术鞋
         'item_null_talisman', // 空灵挂件
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
         'item_lesser_crit', // 水晶剑
         'item_soul_ring', // 灵魂之戒
         'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
-        'item_aether_lens_2', // 以太透镜2
+        { item: 'item_aether_lens_2', weight: 2 }, // 以太透镜2
         'item_hand_of_group', // 团队之手
         'item_octarine_core', // 玲珑心
         'item_refresher', // 刷新球
-        'item_glimmer_cape', // 微光披风
+        { item: 'item_glimmer_cape', weight: 2 }, // 微光披风
         'item_hurricane_pike', // 飓风长戟
         'item_kaya_and_sange', // 散慧对剑
-        'item_aether_lens', // 以太透镜
         'item_specialists_array', // 行家阵列
         'item_black_king_bar', // 黑皇杖
         'item_maelstrom', // 漩涡
@@ -1242,7 +1228,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     targetItemsByTier: {
       [ItemTier.T1]: [
         'item_null_talisman', // 空灵挂件
-        'item_blood_grenade', // 血腥榴弹
         'item_arcane_boots', // 奥术鞋
         'item_magic_wand', // 魔杖
         'item_soul_ring', // 灵魂之戒
@@ -1250,11 +1235,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_vanguard', // 先锋盾
       ],
       [ItemTier.T2]: [
-        'item_aether_lens_2', // 以太透镜2
-        'item_blink', // 闪烁匕首
+        { item: 'item_aether_lens_2', weight: 2 }, // 以太透镜2
+        { item: 'item_blink', weight: 2 }, // 闪烁匕首
         'item_glimmer_cape', // 微光披风
         'item_hand_of_group', // 团队之手
-        'item_aether_lens', // 以太透镜
         'item_yasha_and_kaya', // 慧夜对剑
         'item_octarine_core', // 玲珑心
         'item_gungir', // 缚灵索
@@ -1308,7 +1292,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       [ItemTier.T1]: [
         'item_arcane_boots', // 奥术鞋
         'item_null_talisman', // 空灵挂件
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 迈达斯之手
         'item_soul_ring', // 灵魂之戒
@@ -1324,7 +1307,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_octarine_core', // 玲珑心
         'item_refresher', // 刷新球
         'item_hurricane_pike', // 飓风长戟
-        'item_aether_lens', // 以太透镜
         'item_gungir', // 缚灵索
         'item_yasha_and_kaya', // 慧夜对剑
         'item_specialists_array', // 行家阵列
@@ -1375,7 +1357,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     template: HeroTemplate.Intelligence,
     targetItemsByTier: {
       [ItemTier.T1]: [
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 迈达斯之手
         'item_arcane_boots', // 奥术鞋
@@ -1388,7 +1369,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_holy_locket', // 圣洁吊坠
         'item_rod_of_atos', // 阿托斯之棍
         'item_glimmer_cape', // 微光披风
-        'item_aether_lens', // 以太透镜
         'item_force_staff', // 原力法杖
         'item_refresher', // 刷新球
         'item_aether_lens_2', // 以太透镜2
@@ -1469,7 +1449,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_insight_armor', // 洞察护甲
         'item_black_king_bar_2', // 真·BKB
         'item_undying_heart', // 不朽之心
-        'item_jump_jump_jump', // 跳跳跳刀
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳跳跳刀
         'item_refresh_core', // 熔火核心
       ],
       [ItemTier.T5]: [
@@ -1513,7 +1493,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_armlet_pro_max', // 臂章·终极
       ],
       [ItemTier.T4]: [
-        'item_jump_jump_jump', // 跳跳跳刀（tier 归属修正：从 T5 移入，真实价格属于 T4）
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳跳跳刀（tier 归属修正：从 T5 移入，真实价格属于 T4）
         'item_insight_armor', // 洞察护甲
         'item_black_king_bar_2', // 真·BKB
         'item_abyssal_blade_v2', // 一闪
@@ -1540,10 +1520,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_bracer', // 护腕
         'item_vanguard', // 先锋盾
         'item_phase_boots', // 相位鞋
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
-        'item_hyperstone', // 振奋宝石
         'item_veil_of_discord', // 纷争面纱
+        'item_soul_ring', // 灵魂之戒
       ],
       [ItemTier.T2]: [
         'item_blink', // 闪烁匕首
@@ -1555,7 +1534,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_octarine_core', // 玲珑心
         'item_black_king_bar', // 黑皇杖
         'item_sange_and_yasha', // 散夜对剑
-        'item_aether_lens', // 以太透镜
         'item_consecrated_wraps', // 圣化护服
         'item_armlet', // 莫尔迪基安的臂章
       ],
@@ -1609,12 +1587,11 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_mask_of_madness', // 疯狂面具
         'item_magic_wand', // 魔杖
         'item_lesser_crit', // 水晶剑
-        'item_hyperstone', // 振奋宝石
         'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
-        'item_armlet', // 莫尔迪基安的臂章
-        'item_blink', // 闪烁匕首
+        { item: 'item_armlet', weight: 2 }, // 莫尔迪基安的臂章
+        { item: 'item_blink', weight: 2 }, // 闪烁匕首
         'item_heavens_halberd', // 天堂之戟
         'item_sange_and_yasha', // 散夜对剑
         'item_hand_of_group', // 团队之手
@@ -1638,12 +1615,12 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_armlet_pro_max', // 小鸡臂章Pro Max
         'item_heart', // 恐鳌之心
         'item_radiance_2', // 圣焰之光
-        'item_eternal_shroud_ultra', // 法师泳衣
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_black_king_bar_2', // 天神杖
         'item_wasp_golden', // 黄金大核荣耀
-        'item_jump_jump_jump', // 跳！跳！跳！刀
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
         'item_satanic_2', // 真红·撒旦之邪力
         'item_infernal_desolator', // 绝对破防之刃
         'item_sacred_six_vein', // 六脉神剑
@@ -1651,7 +1628,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_refresh_core', // 熔火核心
         'item_hydras_breath_2', // 神器·千年毒蛟之息
         'item_sange_and_yasha_1', // 神器·散夜对剑
-        'item_monkey_king_bar_2', // 定海神针
         'item_arcane_octarine_core', // 奥术之心
       ],
       [ItemTier.T5]: [
@@ -1701,10 +1677,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_sacred_trident', // 三叉戟
         'item_heart', // 恐鳌之心
         'item_satanic', // 撒旦之邪力
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_black_king_bar_2', // 天神杖
-        'item_monkey_king_bar_2', // 定海神针
         'item_infernal_desolator', // 绝对破防之刃
         'item_wasp_golden', // 黄金大核荣耀
         'item_undying_heart', // 不朽之心
@@ -1750,9 +1726,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_sange_and_yasha', // 散夜对剑
       ],
       [ItemTier.T3]: [
-        'item_greater_crit', // 代达罗斯之殇
+        { item: 'item_greater_crit', weight: 2 }, // 代达罗斯之殇
         'item_vladmir_2', // 强袭祭品
-        'item_silver_edge_2', // 无敌之刃
+        { item: 'item_silver_edge_2', weight: 2 }, // 无敌之刃
         'item_wasp_despotic', // 大核荣耀暴虐
         'item_bloodstone', // 血精神石
         'item_dodo_desolator', // 黯灭头
@@ -1798,10 +1774,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
-        'item_armlet', // 莫尔迪基安的臂章
+        { item: 'item_armlet', weight: 2 }, // 莫尔迪基安的臂章
         'item_sange_and_yasha', // 散夜对剑
         'item_echo_sabre_2', // 音速战刃
-        'item_basher', // 碎颅锤
+        { item: 'item_basher', weight: 2 }, // 碎颅锤
         'item_echo_sabre', // 回音战刃
         'item_hand_of_group', // 团队之手
         'item_black_king_bar', // 黑皇杖
@@ -1853,11 +1829,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_falcon_blade', // 猎鹰战刃
         'item_lesser_crit', // 水晶剑
         'item_magic_wand', // 魔杖
-        'item_blood_grenade', // 血腥榴弹
       ],
       [ItemTier.T2]: [
-        'item_blink', // 闪烁匕首
-        'item_echo_sabre', // 回音战刃
+        { item: 'item_blink', weight: 2 }, // 闪烁匕首
+        { item: 'item_echo_sabre', weight: 2 }, // 回音战刃
         'item_hand_of_group', // 团队之手
         'item_echo_sabre_2', // 音速战刃
         'item_sange_and_yasha', // 散夜对剑
@@ -1881,19 +1856,18 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_heart', // 恐鳌之心
         'item_radiance_2', // 圣焰之光
         'item_blade_mail_2', // 刃甲2
-        'item_eternal_shroud_ultra', // 法师泳衣
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
         'item_black_king_bar_2', // 天神杖
         'item_wasp_golden', // 黄金大核荣耀
         'item_undying_heart', // 不朽之心
-        'item_jump_jump_jump', // 跳！跳！跳！刀
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
         'item_excalibur', // EX咖喱棒
         'item_infernal_desolator', // 绝对破防之刃
         'item_sacred_six_vein', // 六脉神剑
         'item_refresh_core', // 熔火核心
         'item_bfury_ultra', // 救世狂战
-        'item_monkey_king_bar_2', // 定海神针
         'item_arcane_octarine_core', // 奥术之心
         'item_saint_orb', // 圣女白莲
       ],
@@ -1921,17 +1895,16 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_bracer', // 护腕
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 迈达斯之手
-        'item_blood_grenade', // 血腥榴弹
         'item_vanguard', // 先锋盾
         'item_soul_ring', // 灵魂之戒
         'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
-        'item_blink', // 闪烁匕首
+        { item: 'item_blink', weight: 2 }, // 闪烁匕首
         'item_force_staff', // 原力法杖
         'item_blade_mail', // 刃甲
         'item_heavens_halberd', // 天堂之戟
-        'item_echo_sabre_2', // 音速战刃
+        { item: 'item_echo_sabre_2', weight: 2 }, // 音速战刃
         'item_octarine_core', // 玲珑心
         'item_hand_of_group', // 团队之手
         'item_black_king_bar', // 黑皇杖
@@ -1959,7 +1932,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_refresh_core', // 熔火核心
         'item_abyssal_blade_v2', // 一闪
         'item_undying_heart', // 不朽之心
-        'item_jump_jump_jump', // 跳！跳！跳！刀
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
         'item_arcane_octarine_core', // 奥术之心
         'item_black_king_bar_2', // 天神杖
         'item_yasha_and_kaya_1', // 神器·慧夜对剑
@@ -1992,12 +1965,11 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
         'item_magic_wand', // 魔杖
         'item_buckler', // 玄冥盾牌
-        'item_hyperstone', // 振奋宝石
         'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
-        'item_armlet', // 莫尔迪基安的臂章
-        'item_blink', // 闪烁匕首
+        { item: 'item_armlet', weight: 2 }, // 莫尔迪基安的臂章
+        { item: 'item_blink', weight: 2 }, // 闪烁匕首
         'item_echo_sabre', // 回音战刃
         'item_heavens_halberd', // 天堂之戟
         'item_sange_and_yasha', // 散夜对剑
@@ -2017,10 +1989,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_sacred_trident', // 三叉戟
         'item_vladmir_2', // 强袭祭品
         'item_eternal_shroud_ultra', // 法师泳衣
+        { item: 'item_monkey_king_bar_2', weight: 2 }, // 定海神针
       ],
       [ItemTier.T4]: [
-        'item_jump_jump_jump', // 跳！跳！跳！刀
-        'item_monkey_king_bar_2', // 定海神针
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
         'item_blue_fantasy', // 苍蓝幻想
         'item_infernal_desolator', // 绝对破防之刃
         'item_excalibur', // EX咖喱棒
@@ -2056,11 +2028,10 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_soul_ring', // 灵魂之戒
         'item_falcon_blade', // 猎鹰战刃
         'item_magic_wand', // 魔杖
-        'item_blood_grenade', // 血腥榴弹
       ],
       [ItemTier.T2]: [
-        'item_blade_mail', // 刃甲
-        'item_echo_sabre', // 回音战刃
+        { item: 'item_blade_mail', weight: 2 }, // 刃甲
+        { item: 'item_echo_sabre', weight: 2 }, // 回音战刃
         'item_echo_sabre_2', // 音速战刃
         'item_consecrated_wraps', // 圣化护服
         'item_lotus_orb', // 清莲宝珠
@@ -2137,7 +2108,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_guardian_greaves', // 卫士胫甲
         'item_shivas_guard', // 希瓦的守护
         'item_blink', // 闪烁匕首
-        'item_aether_lens', // 以太透镜
+        { item: 'item_aether_lens_2', weight: 2 }, // 以太透镜2
       ],
       [ItemTier.T3]: [
         'item_sheepstick', // 邪恶镰刀
@@ -2174,7 +2145,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       [ItemTier.T1]: [
         'item_null_talisman', // 空灵挂件
         'item_tranquil_boots', // 静谧之鞋
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 迈达斯之手
         'item_vanguard', // 先锋盾
@@ -2292,7 +2262,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_arcane_boots', // 奥术鞋
         'item_null_talisman', // 空灵挂件
         'item_magic_wand', // 魔杖
-        'item_blood_grenade', // 血腥榴弹
         'item_hand_of_midas', // 迈达斯之手
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
@@ -2300,9 +2269,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       ],
       [ItemTier.T2]: [
         'item_blink', // 闪烁匕首
-        'item_holy_locket', // 圣洁吊坠
+        { item: 'item_holy_locket', weight: 2 }, // 圣洁吊坠
         'item_glimmer_cape', // 微光披风
-        'item_aether_lens_2', // 以太透镜2
+        { item: 'item_aether_lens_2', weight: 2 }, // 以太透镜2
         'item_force_staff', // 原力法杖
         'item_hand_of_group', // 团队之手
         'item_octarine_core', // 玲珑心
@@ -2351,20 +2320,18 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     targetItemsByTier: {
       [ItemTier.T1]: [
         'item_arcane_boots', // 奥术鞋
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
         'item_hand_of_midas', // 迈达斯之手
-        'item_hyperstone', // 振奋宝石
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
         'item_soul_ring', // 灵魂之戒
       ],
       [ItemTier.T2]: [
-        'item_holy_locket', // 圣洁吊坠
+        { item: 'item_holy_locket', weight: 2 }, // 圣洁吊坠
         'item_blink', // 闪烁匕首
         'item_rod_of_atos', // 阿托斯之棍
         'item_glimmer_cape', // 微光披风
-        'item_force_staff', // 原力法杖
+        { item: 'item_force_staff', weight: 2 }, // 原力法杖
         'item_hand_of_group', // 团队之手
         'item_aether_lens_2', // 以太透镜2
         'item_octarine_core', // 玲珑心
@@ -2416,7 +2383,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_bracer', // 护腕
         'item_magic_wand', // 魔杖
         'item_falcon_blade', // 猎鹰战刃
-        'item_blood_grenade', // 血腥榴弹
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
       ],
       [ItemTier.T2]: [
@@ -2475,10 +2441,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_arcane_boots', // 奥术鞋
         'item_orb_of_corrosion', // 腐蚀之珠
         'item_magic_wand', // 魔杖
-        'item_hyperstone', // 振奋宝石
         'item_bracer', // 护腕
         'item_ancient_janggo', // 韧鼓
-        'item_blood_grenade', // 血腥榴弹
+        'item_soul_ring', // 灵魂之戒
       ],
       [ItemTier.T2]: [
         'item_hand_of_group', // 团队之手
@@ -2488,7 +2453,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_blink', // 闪烁匕首
         'item_octarine_core', // 玲珑心
         'item_refresher', // 刷新球
-        'item_aether_lens', // 以太透镜
         'item_kaya_and_sange', // 散慧对剑
         'item_black_king_bar', // 黑皇杖
         'item_yasha_and_kaya', // 慧夜对剑
@@ -2544,10 +2508,9 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_null_talisman', // 空灵挂件
         'item_arcane_boots', // 奥术鞋
         'item_magic_wand', // 魔杖
-        'item_hyperstone', // 振奋宝石
-        'item_blood_grenade', // 血腥榴弹
         'item_veil_of_discord', // 纷争面纱
         'item_essence_distiller', // 精之灵器
+        'item_hand_of_midas', // 迈达斯之手
       ],
       [ItemTier.T2]: [
         'item_holy_locket', // 圣洁吊坠
@@ -2619,8 +2582,8 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_falcon_blade', // 猎鹰战刃
       ],
       [ItemTier.T2]: [
-        'item_aether_lens_2', // 以太透镜2
-        'item_force_staff', // 原力法杖
+        { item: 'item_aether_lens_2', weight: 2 }, // 以太透镜2
+        { item: 'item_force_staff', weight: 2 }, // 原力法杖
         'item_glimmer_cape', // 微光披风
         'item_cyclone', // Eul的神圣法杖
         'item_hand_of_group', // 团队之手
@@ -2669,12 +2632,11 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
     targetItemsByTier: {
       [ItemTier.T1]: [
         'item_arcane_boots', // 奥术鞋
-        'item_blood_grenade', // 血腥榴弹
         'item_magic_wand', // 魔杖
-        'item_headdress', // 恢复头巾
         'item_mekansm', // 梅肯斯姆
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
+        'item_soul_ring', // 灵魂之戒
       ],
       [ItemTier.T2]: [
         'item_holy_locket', // 圣洁吊坠
@@ -2684,7 +2646,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_hand_of_group', // 团队之手
         'item_guardian_greaves', // 卫士胫甲
         'item_octarine_core', // 玲珑心
-        'item_aether_lens', // 以太透镜
       ],
       [ItemTier.T3]: [
         'item_orb_of_the_brine', // 苍洋魔珠
@@ -2726,7 +2687,6 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
       [ItemTier.T1]: [
         'item_quelling_blade_2_datadriven', // 毒瘤之刃
         'item_magic_wand', // 魔杖
-        'item_blood_grenade', // 血腥榴弹
         'item_power_treads', // 动力鞋
         'item_vanguard', // 先锋盾
         'item_falcon_blade', // 猎鹰战刃
@@ -2765,7 +2725,7 @@ export const HeroBuilds: Record<string, HeroBuildConfig> = {
         'item_black_king_bar_2', // 天神杖
         'item_refresh_core', // 熔火核心
         'item_undying_heart', // 不朽之心
-        'item_jump_jump_jump', // 跳！跳！跳！刀
+        { item: 'item_jump_jump_jump', weight: 2 }, // 跳！跳！跳！刀
         'item_arcane_octarine_core', // 奥术之心
         'item_hallowed_scepter', // 仙云法杖
         'item_saint_orb', // 圣女白莲


### PR DESCRIPTION
## Summary

- Rebalance hero item build candidates across tiers.
- Add weighted selections for frequently preferred items.
- Remove outdated or lower-priority candidates and correct tier placement.

## Testing

- Not run (not requested)