### PR TITLE
Sync hero ability balance overrides with Dota 7.41e patch

### DIFF
--- a/.claude/skills/update-abilities-override/SKILL.md
+++ b/.claude/skills/update-abilities-override/SKILL.md
@@ -18,6 +18,8 @@ description: >-
 
 判断某技能当前实际生效的数值（如蓝耗）时，**不能只看 docs/reference 原版，也不能只看顶层字段**——override 常把数值写成 `AbilityValues` 内的嵌套子块（如 `AbilityManaCost { "value" "9 10 11 12 13" }`）而非顶层字段。例：`drow_ranger_frost_arrows` 原版 0 蓝，本图 override 里实际是 `AbilityValues` 嵌套的 9-13 蓝/箭，只 grep 顶层 `AbilityManaCost` 会误判为 0 蓝。先精确读该技能整段（到下一个顶层技能名前），同时检查顶层字段和 `AbilityValues` 嵌套块；override 未覆盖时才回落原版。
 
+依据"官方公告但尚未正式上线"的改动清单维护时（`docs/reference` 尚未包含该次改动），判定改不改、改成什么应始终以用户给出的官方改动文本（旧值→新值）为准，不要直接拿 `docs/reference` 当前显示的数值当基准去反推新旧——同一份 reference 快照里不同技能的抓取时间点可能不一致，个别技能可能已经混入了比其余技能更新的数值。若发现 reference 显示的值与改动文本描述的"旧值"对不上，先向用户确认 reference 版本状态，不要自行假设。
+
 ## 技能范围
 
 用户未指定技能时，从参考 `npc_heroes.txt` 读取槽位：
@@ -73,6 +75,8 @@ description: >-
     - 旧格式有 `RequiresScepter "1"` 等辅助键，新格式无此键 → 直接删除辅助键，**无需询问**
     - 子键在参考中已完全消失（非结构迁移）→ **直接删除，无需询问**
 - 版本更新后键名改变（如旧版 `foo_tooltip` → 新版 `foo`）：删旧键名，按新键名走正常 P1/P2/P3 流程
+- **天赋（`special_bonus_unique_*`）改动前必须核实 key 仍然有效**：处理任何涉及天赋的改动前，先去参考文件 `npc_heroes.txt` 中该英雄的 `Ability10-17` 列表核实该天赋 key 是否仍存在——版本更新可能把某个天赋整体替换成另一个 key（甚至换成完全不同的机制），仅凭数值重算发现不了这种情况。key 已不存在则视为被替换，按新 key 重新处理，不要继续在旧 key 上做数值调整
+- **数值内嵌在天赋名里的通用天赋（如 `special_bonus_cast_range_125`、`special_bonus_attack_damage_15`）是引擎原生实现，不需要写任何 KV**：只需在 `Ability10-17` / `Bot.Build` 里正确引用天赋名即可，不要为其新增 `AbilityValues` 块
 
 ### P2 差分与 MaxLevel 扩展
 

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -559,7 +559,7 @@
 				}
 				"damage_per_second"
 				{
-					"value"			"24 36 48 60 72"	// 12 18 24 30 x2
+					"value"			"24 32 40 48 56"	// 12 16 20 24 x2
 				}
 		}
 	}
@@ -800,11 +800,11 @@
 			"boar_total_damage_tooltip"
 			{
 				"value"										"60 90 120 150 180"	// 30 45 60 75 x2
-				"special_bonus_unique_beastmaster_2"		"+60"	// 30 x2
+				"special_bonus_unique_beastmaster_2"		"+50"	// 25 x2
 			}
 			"boar_bonus_damage"
 			{
-				"special_bonus_unique_beastmaster_2"		"+60"	// 30 x2
+				"special_bonus_unique_beastmaster_2"		"+50"	// 25 x2
 			}
 			"boar_base_xp_bounty"				"60 70 80 90 100"
 			"boar_base_movespeed"				"320 340 360 380 400"	// 320 330 340 350 差值20
@@ -836,7 +836,7 @@
 			"dive_damage"
 			{
 				"value"		"60 95 130 165 200"
-				"special_bonus_unique_beastmaster_2"	"+60"	// 30 x2
+				"special_bonus_unique_beastmaster_2"	"+50"	// 25 x2
 			}
 			"dive_root_duration"			"0.4 0.6 0.8 1.0 1.2"
 		}
@@ -862,7 +862,7 @@
 		{
 			"bonus_damage"
 			{
-				"special_bonus_unique_beastmaster_2"	"+60"	// 30 x2
+				"special_bonus_unique_beastmaster_2"	"+50"	// 25 x2
 			}
 			"bonus_attack_speed"
 			{
@@ -1051,7 +1051,7 @@
 					"value"	"30 50 70 90 110"				// 15 25 35 45 x2
 					"special_bonus_unique_centaur_3"	"+90"	// 45 x2
 				}
-				"return_damage_str"			"16 24 32 40 48"
+				"return_damage_str"			"14 21 28 35 42"
 		}
 	}
 	// 奔袭冲撞
@@ -1319,11 +1319,11 @@
 		{
 			"burn_damage"
 			{
-				"value" "30 60 90 120 150"	// 15 30 45 60 x2
+				"value" "36 68 100 132 164"	// 18 34 50 66 x2
 			}
 			"burn_damage_pct"
 			{
-				"value" "1 2 3 4 5"
+				"value" "0.5 1.75 3 4.25 5.5"
 			}
 		}
 	}
@@ -1399,7 +1399,7 @@
 			}
 			"bonus_aoe"
 			{
-				"value"				"25 50 75 100 125"
+				"value"				"30 60 90 120 150"
 			}
 		}
 	}
@@ -1421,13 +1421,14 @@
 		}
 	}
 
-	// 变龙
+	// 变龙 各级形态效果不同(非线性数值缩放)，不能改变最大等级，与原版一致维持3级
 	"dragon_knight_elder_dragon_form"
 	{
+		"AbilityCooldown"				"90"	// 100
 		"AbilityManaCost"				"50 100 150"	// 50
 		"AbilityValues"
 		{
-				"bonus_attack_damage"		"40 100 160 220"	// 0
+				"bonus_attack_damage"		"40 100 160"	// 0
 		}
 	}
 	//=================================================================================================================
@@ -1674,7 +1675,7 @@
 			"damage_per_second"
 			{
 				"value"									"160 240 320 400"	// 45 90 135 180 加成115起差值+35
-				"special_bonus_unique_earth_spirit_8"			"+50%"		// 30% +20%
+				"special_bonus_unique_earth_spirit_8"			"+45%"		// 25% +20%
 			}
 		}
 	}
@@ -3182,7 +3183,7 @@
 			}
 			"mana_burn"
 			{
-				"value"				"80 160 240 320 400"	// 40 80 120 160 x2
+				"value"				"80 150 220 290 360"	// 40 75 110 145 x2
 				"special_bonus_unique_clockwerk_2"	"+160"	// 80 x2
 			}
 			"AbilityCooldown"
@@ -3725,12 +3726,11 @@
 				"AbilityCooldown"
 				{
 					"value"		"18 17 16 15 14"	// 18/17/16/15
-					"special_bonus_unique_snapfire_3"	"-5"		// -4
 				}
 				"projectile_speed"		"1800"						// 1200
 				"impact_damage"
 				{
-					"value"					"75 150 225 300 375"
+					"value"					"60 130 200 270 340"
 				}
 				"impact_stun_duration"
 				{
@@ -3765,17 +3765,17 @@
 			"projectile_count"
 			{
 				"value"		"12"	// 8 x1.5
-				"special_bonus_unique_snapfire_1"	"+12"	// +8 x1.5
+				"special_bonus_unique_snapfire_1"	"+9"	// +6 x1.5
 			}
 			"projectile_speed"		"1950"	// 1300 x1.5
 			"damage_per_impact"
 			{
-				"value"		"180 270 360 450"
+				"value"		"170 250 330 410"
 			}
 			"burn_damage"
 			{
 				"value"					"160 200 240 280"	// 60 80 100
-				"special_bonus_unique_snapfire_5"	"+70"	// +35 x2
+				"special_bonus_unique_snapfire_5"	"+60"	// +30 x2
 			}
 			"move_slow_pct"
 			{
@@ -4330,7 +4330,7 @@
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 		"AbilityValues"
 		{
-			"duration"				"0.9 1.1 1.3 1.5 1.7"
+			"duration"				"0.75 1.0 1.25 1.5 1.75"
 			"flat_heal"				"30 50 70 90 110"	// 15 25 35 45 x2
 
 			"leech_damage"
@@ -4349,7 +4349,6 @@
 	{
 		"MaxLevel"						"5"
 		"AbilityCooldown"				"24 21 18 15 12"
-		"AbilityManaCost"				"65 70 75 80 85"
 		"AbilityValues"
 		{
 			"heal_per_second"
@@ -5188,12 +5187,12 @@
 	"drow_ranger_multishot"
 	{
 		"MaxLevel"						"5"
-		"AbilityManaCost"				"50 70 90 110 130"	// 50 70 90 110
+		"AbilityManaCost"				"70 85 100 115 130"	// 70 85 100 115
 		"AbilityValues"
 		{
 			"arrow_damage_pct"
 			{
-				"value"										"100 120 140 160 180"	// 100 120 140 160
+				"value"										"80 100 120 140 160"	// 80 100 120 140
 				"special_bonus_unique_drow_ranger_1"		"+40"			// 25
 			}
 			"AbilityCooldown"
@@ -5506,8 +5505,7 @@
 	"gyrocopter_homing_missile"
 	{
 		"MaxLevel"						"5"
-		"AbilityCooldown"				"24 21 18 15 12"
-		"AbilityManaCost"				"120 130 140 150 160"
+		"AbilityCooldown"				"26 22 18 14 10"
 		"AbilityValues"
 		{
 			"hits_to_kill_tooltip"		"6"				// 3
@@ -5641,7 +5639,7 @@
 	{
 		"MaxLevel"						"4"
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"	// SPELL_IMMUNITY_ENEMIES_NO
-		"AbilityManaCost"				"100 150 200 250"
+		"AbilityManaCost"				"150 200 250 300"
 		"AbilityValues"
 		{
 			"arrow_width"
@@ -5931,8 +5929,7 @@
 		{
 			"bonus_building_damage"
 			{
-				"value"													"25"	// 30
-				"special_bonus_unique_lone_druid_spirit_bear_demolish"	"+15"	// +20
+				"value"													"15"	// 20 -5
 			}
 		}
 	}
@@ -8045,7 +8042,7 @@
 		{
 			"base_damage"
 			{
-				"value"					"40 60 80 100 120"
+				"value"					"40 70 100 130 160"
 			}
 			"tick_damage"
 			{
@@ -8423,7 +8420,7 @@
 	"ancient_apparition_ice_blast"
 	{
 		"MaxLevel" "4"
-		"AbilityCooldown"				"55 50 45 40"					// 60 50 40
+		"AbilityCooldown"				"50 45 40 35"
 		"AbilityDamage"					"250 325 400 475"				// 250 325 400
 		"AbilityValues"
 		{
@@ -8499,7 +8496,7 @@
 	{
 		"MaxLevel"						"5"
 		"AbilityCastRange"				"550 600 650 700 750"
-		"AbilityDuration"				"3.5 4.0 4.5 5.0 5.5"	// 3.5 4.5 5.5 6.5 差值0.5
+		"AbilityDuration"				"3 3.5 4 4.5 5"	// 3 4 5 6 差值0.5
 		"AbilityManaCost"				"120 130 140 150 160"
 		"AbilityValues"
 		{
@@ -8528,7 +8525,7 @@
 			"AbilityCooldown"
 			{
 				"value"	"90 80 70 60"	// 120 110 100 差值10 最大值60
-				"special_bonus_scepter"	"-30"	// -45
+				"special_bonus_scepter"	"-30"	// -40
 			}
 			"illusion_count"
 			{
@@ -9983,7 +9980,7 @@
 			"mana_leak_pct"	"4.5 5 5.5 6.0 6.5"
 			"AbilityCooldown"
 			{
-				"value"			"19 16 13 10 7"
+				"value"			"18 16 14 12 10"
 			}
 		}
 	}
@@ -10640,9 +10637,9 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"				"38 36 34 32 30"
+				"value"				"36 33 30 27 24"
 			}
-			"barrier_flat"			"240 360 480 600 720"	// 120 180 240 300 x2
+			"barrier_flat"			"300 400 500 600 700"	// 150 200 250 300 x2
 			"mana_to_barrier"
 			{
 				"value"					"20"	// 12
@@ -10828,7 +10825,7 @@
 	"oracle_false_promise"
 	{
 		"MaxLevel" "4"
-		"AbilityCastRange"				"700 800 900 1000"
+		"AbilityCastRange"				"800 850 900 950"
 		"AbilityManaCost"				"100 150 200 250"
 		"AbilityValues"
 		{
@@ -10914,7 +10911,7 @@
 			}
 			"AbilityCooldown"
 			{
-				"value"								"10 9 8 7 6"
+				"value"								"12 11 10 9 8"
 			}
 		}
 	}
@@ -11070,7 +11067,7 @@
 		"MaxLevel"						"5"
 		"AbilityCastRange"				"450 500 550 600 650"
 		"AbilityCooldown"				"16 13 10 7 4"
-		"AbilityManaCost"				"100 110 120 130 140"
+		"AbilityManaCost"				"100 105 110 115 120"
 		"AbilityValues"
 		{
 			"strike_damage"
@@ -12626,7 +12623,7 @@
 		{
 			"damage"
 			{
-				"value"							"300 475 650 825"
+				"value"							"275 425 575 725"
 				"special_bonus_unique_zeus_4"		"+175"	// 75
 			}
 		}
@@ -12775,7 +12772,7 @@
 				"value"		"20 35 50 65 80"
 			}
 			"bleed_health_pct"			"3 4 5 6 7"
-			"bleed_creep_dps"			"85 90 95 100 105"
+			"bleed_creep_dps"			"60 75 90 105 120"
 			"dagger_width"				"150"	// 130
 			"dagger_vision"				"300"	// 200
 			"slow_duration"

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -1017,14 +1017,13 @@
 				"21"		""
 				"22"		""
 				"23"		"dragon_knight_wyrms_wrath"
-				"24"		"dragon_knight_elder_dragon_form"
+				"24"		"dragon_knight_wyrms_wrath"
 				"25"		"special_bonus_unique_dragon_knight"
 				"26"		"dragon_knight_wyrms_wrath"
 				"27"		"special_bonus_attack_damage_15"
 				"28"		"special_bonus_hp_300"
 				"29"		"special_bonus_unique_dragon_knight_9"
 				"30"		"special_bonus_unique_dragon_knight_wyrms_wrath_damage"
-				"31"		"dragon_knight_wyrms_wrath"
 			}
 		}
 	}

--- a/src/vscripts/ai/hero/hero-drow-ranger.ts
+++ b/src/vscripts/ai/hero/hero-drow-ranger.ts
@@ -22,7 +22,7 @@ export class DrowRangerAIModifier extends BotBaseAIModifier {
     // 数箭齐发
     if (
       ActionAbility.CastAbilityOnFindEnemyHero(this, 'drow_ranger_multishot', {
-        target: { range: { lte: attackRange * 1.75 - 200 } },
+        target: { range: { lte: attackRange + 275 } },
       })
     ) {
       return true;
@@ -36,7 +36,7 @@ export class DrowRangerAIModifier extends BotBaseAIModifier {
     // 数箭齐发
     if (
       ActionAbility.CastAbilityOnFindEnemyCreep(this, 'drow_ranger_multishot', {
-        target: { range: { lte: attackRange * 1.75 - 200 }, count: { gte: 3 } },
+        target: { range: { lte: attackRange + 275 }, count: { gte: 3 } },
       })
     ) {
       return true;

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v5.47';
+  public static readonly GAME_VERSION = 'v5.48';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数


### PR DESCRIPTION
## Issue

- [x] fix #2271

## Checklist

- [x] I have tested the changes works well.
- [ ] 在 Dota Tools 中验证本次涉及的技能数值(冷却/魔耗/伤害等)与新版本一致
- [ ] 验证卓尔游侠 bot 数箭齐发的新施法距离公式表现正常
- [ ] 验证龙骑士变龙冷却调整为 90 秒后表现正常

## Release Note

```
[b]游戏性更新 v5.48[/b]

- 同步 Dota 2 7.41e 版本的英雄技能平衡性更新。
```

```
[b]Gameplay update v5.48[/b]

- Synced hero ability balance updates from Dota 2 patch 7.41e.
```
