### PR TITLE
Add Dazzle Shallow Grave awakening

### DIFF
--- a/.claude/skills/awaken-ability/SKILL.md
+++ b/.claude/skills/awaken-ability/SKILL.md
@@ -67,7 +67,13 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
   }
   ```
 
-- **`ScriptFile` 实现选型** → 见 `custom-ability` skill，觉醒不另立规则。被动觉醒标准写法：`GetIntrinsicModifierName()` 返回一个隐藏内置 modifier，无需学习即生效，所有可调值从 KV `AbilityValues` 读取。源码放 `src/vscripts/abilities/`，KV `ScriptFile` 指向编译产物 `abilities/ts_abilities/<name>`（参考斧王 `axe_auto_culling_blade`、宙斯 `special_bonus_unique_zuus_upgrade`）。
+- **`ScriptFile` 实现选型** → 见 `custom-ability` skill，觉醒不另立规则。被动觉醒标准写法：`GetIntrinsicModifierName()` 返回一个内置 modifier，无需学习即生效，所有可调值从 KV `AbilityValues` 读取。源码放 `src/vscripts/abilities/`，KV `ScriptFile` 指向编译产物 `abilities/ts_abilities/<name>`（参考斧王 `axe_auto_culling_blade`、宙斯 `special_bonus_unique_zuus_upgrade`）。
+
+- **觉醒状态必须在游戏内可见** → 觉醒是玩家花积分换来的永久改造，进游戏后必须能确认自己已觉醒。**技能栏可见**与**常驻 buff 图标**二选一，两者都隐藏 = 玩家零感知，视为未完成：
+  - 技能栏可见：`AbilityBehavior` 不加 `DOTA_ABILITY_BEHAVIOR_HIDDEN`。主动技觉醒天然满足（参考 PA `special_bonus_unique_phantom_assassin_upgrade`、军团 `legion_commander_auto_duel`）。
+  - 常驻 buff 图标：技能加 `HIDDEN` 不占技能栏，另挂一个**非隐藏**的常驻 modifier —— TS 里 `IsHidden()` 返回 `false`，DataDriven 写 `"IsHidden" "0"`（参考发条 `special_bonus_unique_rattletrap_upgrade`、斯温 `special_bonus_unique_sven_upgrade`）。细节见进阶 6。
+
+  走 buff 图标这条时 `GetTexture()` 和 `DOTA_Tooltip_modifier_<modifier_name>` / `_Description` 都要补齐，否则图标是紫块、悬停无说明。**只写了 tooltip 文案却把 modifier 设成隐藏**是最容易漏的组合——文案在文件里躺着，游戏里永远看不到。
 
 - **图标** → 引用 Dota2 原版技能名则不放 png；自定义图标才复制同名 png 到 `game/resource/flash3/images/spellicons/<name>.png`。`AbilityTextureName` 也可直接填**至宝/变体 texture 路径**（如 `necrolyte/apostle_of_decay_icons/necrolyte_heartstopper_aura`、`drow_ranger/immortal/drow_ranger_wave_of_silence`、`zuus_static_field_alt1`），引擎直接引用，同样无需放 png。
 

--- a/.claude/skills/awaken-ability/references/advanced-techniques.md
+++ b/.claude/skills/awaken-ability/references/advanced-techniques.md
@@ -85,6 +85,8 @@ ApplyAwakenMagicImmunity(unit, ability, duration)
 
 **TS 代码优先用已有的 TS 封装**：`src/vscripts/abilities/ts_abilities/shared/awaken-magic-immunity.ts` 导出的 `applyAwakenMagicImmunity(unit, ability, duration)` 是同一逻辑的原生 TS 实现（同样借用 `modifier_black_king_bar_immune` 且不顶替真 BKB），直接 `import` 复用即可，不要再 `declare function` 绑定 Lua 全局。它与 Lua 版的差异是返回值：施加成功返回该 modifier 的句柄（`CDOTA_Buff`），跳过时返回 `undefined`（Lua 版返回布尔值）。
 
+**魔抗必须在自己技能 KV 写 `spell_reduce`**：`modifier_black_king_bar_immune` 自带的只有减益免疫，魔抗数值是引擎从**施加它的那个 ability** 上读 `spell_reduce` 字段（原版即 `item_black_king_bar` 的 `AbilityValues`，值为 `60`）。借到觉醒技能上时，觉醒技能 KV 若没有这个字段，玩家只拿到减益免疫、**魔抗为 0**——不报错、不打日志，只能靠实机看数值发现。字段名须与 `item_black_king_bar` 一致，写进觉醒技能自己的 `AbilityValues`（符合进阶 10），不要塞进原版技能的 override。
+
 **前摇加魔免要防取消刷新**：魔免绑在 `ON_ABILITY_START`（前摇开始）触发时，玩家可在前摇结束前取消再施法反复刷新（取消不进 CD、不耗蓝）。防法：仅当 `ApplyAwakenMagicImmunity` 返回 true 才启动取消检测；`StartIntervalThink` 轮询 `IsInAbilityPhase()`，前摇结束后若 `GetCooldownTimeRemaining() <= 0`（被取消）则移除；**移除前判据**——仅当 `modifier_black_king_bar_immune` 剩余 ≤ 本次魔免时长才 `Destroy()`，**绝不无条件 `RemoveModifierByName`**（同名 modifier 区分不了来源，会误删真 BKB）。
 
 > 参考：影魔 `special_bonus_unique_nevermore_upgrade.lua` 的 `OnIntervalThink` 取消检测；PA 闪烁/匕首魔免。

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3493,6 +3493,15 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_Description"		"Increases Chain Frost's projectile speed and bounce range, and extends the duration of its slow and Frostbound.<br><br>Hits on a hero or Roshan deal bonus magical damage equal to <font color='#FFFFFF'><b>0.75x</b></font> Intelligence and apply a stack of Frost Calamity lasting <font color='#FFFFFF'><b>8</b></font> seconds, detonating automatically at <font color='#FFFFFF'><b>3</b></font> stacks; casting Frost Blast on a marked enemy also detonates it early. Detonation deals magical damage in a <font color='#FFFFFF'><b>350</b></font> radius equal to <font color='#FFFFFF'><b>0.75x</b></font> Intelligence per stack consumed and <font color='#2DD5E4'>Stuns</font> enemies for <font color='#FFFFFF'><b>0.6</b></font> seconds.<br><br>If Ice Spire is already learned, hitting the only enemy hero nearby with Chain Frost casts Ice Spire at that hero automatically."
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"Frost Calamity"
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"At 3 stacks, triggers a Frost Calamity detonation. Lich can also detonate it early with Frost Blast."
+		// 戴泽 薄葬觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>Shallow Grave Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance for the duration of Shallow Grave."
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Shallow Grave Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance for the duration of Shallow Grave."
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave"			"Shallow Grave Awakened"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave_Description"	"Gains <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance until Shallow Grave ends."
+		"DOTA_Tooltip_modifier_dazzle_shallow_grave"		"Shallow Grave"
+		"DOTA_Tooltip_modifier_dazzle_shallow_grave_Description"		"Health cannot fall below 1 while Shallow Grave is active.<br><font color='#d000ff'>Awakened:</font> Also grants <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance."
 
 	}
 }

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1239,7 +1239,7 @@
 
 		// Legion Commander Auto Duel - Awakened
 		"DOTA_Tooltip_ability_legion_commander_auto_duel"									"<font color='#d000ff'>Auto Duel · Awakened</font>"
-		"DOTA_Tooltip_ability_legion_commander_auto_duel_Description"						"<font color='#00CED1'>Autocast:</font> While enabled and Duel is ready, automatically casts Duel on the nearest visible enemy hero within Duel's cast range plus %bonus_cast_range%. Illusions are ignored, and it only triggers when there's a high chance of killing the target without leaving Legion Commander critically low on health.<br><br>Auto Duel ignores and consumes the target's passive spell block and reflection effects.<br><br>During Duel, Legion Commander gains Black King Bar's spell immunity, and the target cannot be selected."
+		"DOTA_Tooltip_ability_legion_commander_auto_duel_Description"						"<font color='#00CED1'>Autocast:</font> While enabled and Duel is ready, automatically casts Duel on the nearest visible enemy hero within Duel's cast range plus %bonus_cast_range%. Illusions are ignored, and it only triggers when there's a high chance of killing the target without leaving Legion Commander critically low on health.<br><br>Auto Duel ignores and consumes the target's passive spell block and reflection effects.<br><br>During Duel, Legion Commander gains the <font color='#FFCC66'>Black King Bar</font> effect, and the target cannot be selected."
 		"DOTA_Tooltip_ability_legion_commander_auto_duel_Lore"							"Honor needs no invitation; the nearest enemy will do."
 		"DOTA_Tooltip_ability_legion_commander_auto_duel_bonus_cast_range"				"BONUS AUTO DUEL RANGE:"
 		"DOTA_Tooltip_modifier_legion_commander_auto_duel_target_unselectable"	"Auto Duel: Unselectable"
@@ -1261,7 +1261,7 @@
 
 		// Phantom Assassin Phantom Strike - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade"				"<font color='#d000ff'>Phantom Strike Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_Description"	"Phantom Assassin blinks to a target unit, gaining bonus attack speed and <font color='#FFCC66'>magic immunity</font> briefly, then automatically attacks.<br><br>Stifling Dagger's projectile speed is increased. Casting Stifling Dagger grants brief <font color='#FFCC66'>magic immunity</font>."
+		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_Description"	"Phantom Assassin blinks to a target unit, gaining bonus attack speed and the <font color='#FFCC66'>Black King Bar</font> effect briefly, then automatically attacks.<br><br>Stifling Dagger's projectile speed is increased. Casting Stifling Dagger briefly grants the <font color='#FFCC66'>Black King Bar</font> effect."
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_bonus_attack_speed"	"Bonus Attack Speed:"
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_untargetable_duration"	"Duration:"
 
@@ -1273,9 +1273,9 @@
 
 		// Shadow Fiend Requiem Guard - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>Requiem of Souls Guard Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade_Description"		"During Requiem of Souls' cast animation, Shadow Fiend gains <font color='#FFCC66'>magic immunity</font>, preventing his cast from being interrupted by disables.<br><br>Necromastery grants <font color='#FFFFFF'><b>10</b></font> souls per hero kill and <font color='#FFFFFF'><b>3</b></font> souls per unit kill.<br><br>Increases cast speed by <font color='#FFFFFF'><b>50%%</b></font>, reducing the cast point of Shadowraze and Requiem of Souls."
+		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade_Description"		"During Requiem of Souls' cast animation, Shadow Fiend gains the <font color='#FFCC66'>Black King Bar</font> effect, preventing his cast from being interrupted by disables.<br><br>Necromastery grants <font color='#FFFFFF'><b>10</b></font> souls per hero kill and <font color='#FFFFFF'><b>3</b></font> souls per unit kill.<br><br>Increases cast speed by <font color='#FFFFFF'><b>50%%</b></font>, reducing the cast point of Shadowraze and Requiem of Souls."
 		"DOTA_Tooltip_modifier_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>Requiem of Souls Guard Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_nevermore_upgrade_Description"		"During Requiem of Souls' cast animation, Shadow Fiend gains <font color='#FFCC66'>magic immunity</font>, preventing his cast from being interrupted by disables.<br><br>Necromastery grants <font color='#FFFFFF'><b>10</b></font> souls per hero kill and <font color='#FFFFFF'><b>3</b></font> souls per unit kill.<br><br>Increases cast speed by <font color='#FFFFFF'><b>50%%</b></font>, reducing the cast point of Shadowraze and Requiem of Souls."
+		"DOTA_Tooltip_modifier_special_bonus_unique_nevermore_upgrade_Description"		"During Requiem of Souls' cast animation, Shadow Fiend gains the <font color='#FFCC66'>Black King Bar</font> effect, preventing his cast from being interrupted by disables.<br><br>Necromastery grants <font color='#FFFFFF'><b>10</b></font> souls per hero kill and <font color='#FFFFFF'><b>3</b></font> souls per unit kill.<br><br>Increases cast speed by <font color='#FFFFFF'><b>50%%</b></font>, reducing the cast point of Shadowraze and Requiem of Souls."
 
 		// Drow Ranger Splinter Shot
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>Splinter Shot Awakened</font>"
@@ -1295,9 +1295,9 @@
 
 		// Monkey King Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_monkey_king_upgrade"					"<font color='#d000ff'>Monkey King Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_monkey_king_upgrade_Description"		"Boundless Strike gains <font color='#FFFFFF'><b>200</b></font> bonus damage and <font color='#FFFFFF'><b>700</b></font> cast range.<br>Can cast Defy while disabled.<br>When casting Defy, gains <font color='#FFCC66'>Magic Immunity</font> until the ability ends."
+		"DOTA_Tooltip_ability_special_bonus_unique_monkey_king_upgrade_Description"		"Boundless Strike gains <font color='#FFFFFF'><b>200</b></font> bonus damage and <font color='#FFFFFF'><b>700</b></font> cast range.<br>Can cast Defy while disabled.<br>When casting Defy, gains the <font color='#FFCC66'>Black King Bar</font> effect until the ability ends."
 		"DOTA_Tooltip_modifier_special_bonus_unique_monkey_king_upgrade"					"<font color='#d000ff'>Monkey King Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_monkey_king_upgrade_Description"		"Boundless Strike gains <font color='#FFFFFF'><b>200</b></font> bonus damage and <font color='#FFFFFF'><b>700</b></font> cast range.<br>Can cast Defy while disabled.<br>When casting Defy, gains <font color='#FFCC66'>Magic Immunity</font> until the ability ends."
+		"DOTA_Tooltip_modifier_special_bonus_unique_monkey_king_upgrade_Description"		"Boundless Strike gains <font color='#FFFFFF'><b>200</b></font> bonus damage and <font color='#FFFFFF'><b>700</b></font> cast range.<br>Can cast Defy while disabled.<br>When casting Defy, gains the <font color='#FFCC66'>Black King Bar</font> effect until the ability ends."
 
 		// Winter Wyvern Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_winter_wyvern_upgrade"					"<font color='#d000ff'>Winter's Curse Awakened</font>"
@@ -1312,9 +1312,9 @@
 
 		// Clockwerk Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>Power Cogs Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade_Description"		"Casting Power Cogs grants <font color='#FFCC66'>Magic Immunity</font> for <font color='#FFFFFF'><b>3</b></font> seconds, reducing damage taken by <font color='#FFFFFF'><b>60%%</b></font> during that time."
+		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade_Description"		"Casting Power Cogs grants the <font color='#FFCC66'>Black King Bar</font> effect for <font color='#FFFFFF'><b>3</b></font> seconds, reducing damage taken by <font color='#FFFFFF'><b>60%%</b></font> during that time."
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>Power Cogs Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_Description"		"Casting Power Cogs grants <font color='#FFCC66'>Magic Immunity</font> for <font color='#FFFFFF'><b>3</b></font> seconds, reducing damage taken by <font color='#FFFFFF'><b>60%%</b></font> during that time."
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_Description"		"Casting Power Cogs grants the <font color='#FFCC66'>Black King Bar</font> effect for <font color='#FFFFFF'><b>3</b></font> seconds, reducing damage taken by <font color='#FFFFFF'><b>60%%</b></font> during that time."
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"Power Cogs Awakened"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"Damage taken is reduced by %dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%."
 
@@ -1328,17 +1328,17 @@
 		"DOTA_Tooltip_modifier_doom_bringer_doom_awakened_carrier_Description"	"Enemies within %dMODIFIER_PROPERTY_TOOLTIP% range are continuously Doomed."
 		// Sven Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>Sven Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade_Description"		"Casting Storm Hammer grants <font color='#FFCC66'>Magic Immunity</font> for %duration% seconds, increasing Strength by %strength_bonus% and Attack Speed by %attackspeed_bonus% during that time."
+		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade_Description"		"Casting Storm Hammer grants the <font color='#FFCC66'>Black King Bar</font> effect for %duration% seconds, increasing Strength by %strength_bonus% and Attack Speed by %attackspeed_bonus% during that time."
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>Sven Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_Description"		"Casting Storm Hammer grants <font color='#FFCC66'>Magic Immunity</font> and briefly increases Strength and Attack Speed."
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_Description"		"Casting Storm Hammer grants the <font color='#FFCC66'>Black King Bar</font> effect and briefly increases Strength and Attack Speed."
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff"				"Sven Awakened"
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff_Description"	"Strength increased by %dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS% and Attack Speed by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%."
 
 		// 水晶室女 极寒领域-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>Freezing Field Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"			"Casting Freezing Field grants <font color='#FFCC66'>Magic Immunity</font>.<br><br>Also grants <font color='#FFFFFF'>Spellblock</font> for <font color='#FFFFFF'><b>10</b></font> seconds, consumed after blocking one enemy targeted spell."
+		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"			"Casting Freezing Field grants the <font color='#FFCC66'>Black King Bar</font> effect.<br><br>Also grants <font color='#FFFFFF'>Spellblock</font> for <font color='#FFFFFF'><b>10</b></font> seconds, consumed after blocking one enemy targeted spell."
 		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>Freezing Field Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"			"Casting Freezing Field grants <font color='#FFCC66'>Magic Immunity</font>.<br><br>Also grants <font color='#FFFFFF'>Spellblock</font> for <font color='#FFFFFF'><b>10</b></font> seconds, consumed after blocking one enemy targeted spell."
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"			"Casting Freezing Field grants the <font color='#FFCC66'>Black King Bar</font> effect.<br><br>Also grants <font color='#FFFFFF'>Spellblock</font> for <font color='#FFFFFF'><b>10</b></font> seconds, consumed after blocking one enemy targeted spell."
 		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield"				"Freezing Field Awakened"
 		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield_Description"	"Grants <font color='#FFFFFF'>Spellblock</font>, blocking one enemy targeted spell."
 
@@ -3495,13 +3495,9 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"At 3 stacks, triggers a Frost Calamity detonation. Lich can also detonate it early with Frost Blast."
 		// 戴泽 薄葬觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>Shallow Grave Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance for the duration of Shallow Grave."
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Shallow Grave Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance for the duration of Shallow Grave."
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave"			"Shallow Grave Awakened"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave_Description"	"Gains <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance until Shallow Grave ends."
-		"DOTA_Tooltip_modifier_dazzle_shallow_grave"		"Shallow Grave"
-		"DOTA_Tooltip_modifier_dazzle_shallow_grave_Description"		"Health cannot fall below 1 while Shallow Grave is active.<br><font color='#d000ff'>Awakened:</font> Also grants <font color='#FFCC66'>Debuff Immunity</font> and <font color='#FFFFFF'><b>60%</b></font> Magic Resistance."
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
 
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -524,7 +524,7 @@
 
 		// Legion Commander Auto Duel - Awakened
 		"DOTA_Tooltip_ability_legion_commander_auto_duel"									"<font color='#d000ff'>Автоматическая дуэль · Пробуждение</font>"
-		"DOTA_Tooltip_ability_legion_commander_auto_duel_Description"						"<font color='#00CED1'>Автоприменение:</font> Если включено и Duel готова, способность автоматически применяется к ближайшему видимому вражескому герою в радиусе применения Duel плюс %bonus_cast_range%. Иллюзии игнорируются.<br><br>Автоматическая дуэль игнорирует и расходует пассивные эффекты блока и отражения заклинаний цели.<br><br>Длительность Duel фиксирована и не зависит от сопротивления эффектам.<br><br>Во время Duel Legion Commander получает невосприимчивость к эффектам без дополнительного сопротивления магии, а цель нельзя выбрать."
+		"DOTA_Tooltip_ability_legion_commander_auto_duel_Description"						"<font color='#00CED1'>Автоприменение:</font> Если включено и Duel готова, способность автоматически применяется к ближайшему видимому вражескому герою в радиусе применения Duel плюс %bonus_cast_range%. Иллюзии игнорируются.<br><br>Автоматическая дуэль игнорирует и расходует пассивные эффекты блока и отражения заклинаний цели.<br><br>Длительность Duel фиксирована и не зависит от сопротивления эффектам.<br><br>Во время Duel Legion Commander получает эффект <font color='#FFCC66'>Black King Bar</font>, а цель нельзя выбрать."
 		"DOTA_Tooltip_ability_legion_commander_auto_duel_Lore"							"Честь не требует приглашения — ближайший враг станет соперником."
 		"DOTA_Tooltip_ability_legion_commander_auto_duel_bonus_cast_range"				"ДОПОЛНИТЕЛЬНАЯ ДАЛЬНОСТЬ АВТОМАТИЧЕСКОЙ ДУЭЛИ:"
 		"DOTA_Tooltip_modifier_legion_commander_auto_duel_target_unselectable"	"Автоматическая дуэль: цель нельзя выбрать"
@@ -568,13 +568,9 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_tiny_upgrade_Description"		"Захваченное дерево больше не разрушается, когда заканчиваются его атаки.<br>Grow больше не снижает скорость атаки."
 		// 戴泽 薄葬觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии на время действия Shallow Grave."
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии на время действия Shallow Grave."
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave"			"Пробуждение Shallow Grave"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave_Description"	"Цель получает <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии до окончания Shallow Grave."
-		"DOTA_Tooltip_modifier_dazzle_shallow_grave"		"Shallow Grave"
-		"DOTA_Tooltip_modifier_dazzle_shallow_grave_Description"		"Во время действия Shallow Grave здоровье не может опуститься ниже 1.<br><font color='#d000ff'>Пробуждение:</font> также даёт <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии."
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -566,6 +566,15 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_tiny_upgrade_Description"		"Захваченное дерево больше не разрушается, когда заканчиваются его атаки.<br>Grow больше не снижает скорость атаки."
 		"DOTA_Tooltip_modifier_special_bonus_unique_tiny_upgrade"					"<font color='#d000ff'>Пробуждение Tiny</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_tiny_upgrade_Description"		"Захваченное дерево больше не разрушается, когда заканчиваются его атаки.<br>Grow больше не снижает скорость атаки."
+		// 戴泽 薄葬觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии на время действия Shallow Grave."
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии на время действия Shallow Grave."
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave"			"Пробуждение Shallow Grave"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave_Description"	"Цель получает <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии до окончания Shallow Grave."
+		"DOTA_Tooltip_modifier_dazzle_shallow_grave"		"Shallow Grave"
+		"DOTA_Tooltip_modifier_dazzle_shallow_grave_Description"		"Во время действия Shallow Grave здоровье не может опуститься ниже 1.<br><font color='#d000ff'>Пробуждение:</font> также даёт <font color='#FFCC66'>иммунитет к отрицательным эффектам</font> и <font color='#FFFFFF'><b>60%</b></font> сопротивления магии."
 
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1235,7 +1235,7 @@
 
 		// 军团指挥官 自动决斗-觉醒
 		"DOTA_Tooltip_ability_legion_commander_auto_duel"									"<font color='#d000ff'>自动决斗·觉醒</font>"
-		"DOTA_Tooltip_ability_legion_commander_auto_duel_Description"						"<font color='#00CED1'>自动施法：</font>开启后，若决斗可以施放，则自动对决斗施法距离外额外%bonus_cast_range%范围内最近的可见敌方英雄施放决斗。不会选择幻象，只有大概率能击杀目标、且不会让自身陷入残血时才会触发。<br><br>自动决斗会无视并消耗目标的被动法术格挡与反弹效果。<br><br>决斗期间，军团指挥官获得黑皇杖的魔法免疫效果，目标无法被选中。"
+		"DOTA_Tooltip_ability_legion_commander_auto_duel_Description"						"<font color='#00CED1'>自动施法：</font>开启后，若决斗可以施放，则自动对决斗施法距离外额外%bonus_cast_range%范围内最近的可见敌方英雄施放决斗。不会选择幻象，只有大概率能击杀目标、且不会让自身陷入残血时才会触发。<br><br>自动决斗会无视并消耗目标的被动法术格挡与反弹效果。<br><br>决斗期间，军团指挥官获得<font color='#FFCC66'>黑皇杖</font>效果，目标无法被选中。"
 		"DOTA_Tooltip_ability_legion_commander_auto_duel_Lore"							"荣誉无需邀约，最近的敌人就是对手。"
 		"DOTA_Tooltip_ability_legion_commander_auto_duel_bonus_cast_range"				"额外自动决斗范围："
 		"DOTA_Tooltip_modifier_legion_commander_auto_duel_target_unselectable"	"自动决斗：无法选中"
@@ -1258,7 +1258,7 @@
 
 		// 幻影刺客 幻影突袭-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade"				"<font color='#d000ff'>幻影突袭 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_Description"	"幻影刺客闪烁到一个目标单位身旁，获得短暂的攻击速度加成和<font color='#FFCC66'>魔法免疫</font>，并自动发起攻击。<br><br>窒碍短匕弹道速度提升。施放窒碍短匕后获得短暂<font color='#FFCC66'>魔法免疫</font>。"
+		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_Description"	"幻影刺客闪烁到一个目标单位身旁，获得短暂的攻击速度加成和<font color='#FFCC66'>黑皇杖</font>效果，并自动发起攻击。<br><br>窒碍短匕弹道速度提升。施放窒碍短匕后获得短暂<font color='#FFCC66'>黑皇杖</font>效果。"
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_bonus_attack_speed"	"攻击速度加成："
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_untargetable_duration"	"持续时间："
 		"DOTA_Tooltip_ability_special_bonus_unique_phantom_assassin_upgrade_Lore"						"RN: 这下敢B上去了吧"
@@ -1271,9 +1271,9 @@
 
 		// 影魔 安魂曲护体-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>魂之挽歌护体 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade_Description"		"释放魂之挽歌的施法前摇期间，影魔获得<font color='#FFCC66'>魔法免疫</font>，避免被控制打断。<br><br>支配死灵击杀英雄获得<font color='#FFFFFF'><b>10</b></font>个灵魂，击杀小兵获得<font color='#FFFFFF'><b>3</b></font>个灵魂。<br><br>提升施法速度<font color='#FFFFFF'><b>50%%</b></font>，降低暗影压制与魂之挽歌的施法抬手时间。"
+		"DOTA_Tooltip_ability_special_bonus_unique_nevermore_upgrade_Description"		"释放魂之挽歌的施法前摇期间，影魔获得<font color='#FFCC66'>黑皇杖</font>效果，避免被控制打断。<br><br>支配死灵击杀英雄获得<font color='#FFFFFF'><b>10</b></font>个灵魂，击杀小兵获得<font color='#FFFFFF'><b>3</b></font>个灵魂。<br><br>提升施法速度<font color='#FFFFFF'><b>50%%</b></font>，降低暗影压制与魂之挽歌的施法抬手时间。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_nevermore_upgrade"					"<font color='#d000ff'>魂之挽歌护体 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_nevermore_upgrade_Description"		"释放魂之挽歌的施法前摇期间，影魔获得<font color='#FFCC66'>魔法免疫</font>，避免被控制打断。<br><br>支配死灵击杀英雄获得<font color='#FFFFFF'><b>10</b></font>个灵魂，击杀小兵获得<font color='#FFFFFF'><b>3</b></font>个灵魂。<br><br>提升施法速度<font color='#FFFFFF'><b>50%%</b></font>，降低暗影压制与魂之挽歌的施法抬手时间。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nevermore_upgrade_Description"		"释放魂之挽歌的施法前摇期间，影魔获得<font color='#FFCC66'>黑皇杖</font>效果，避免被控制打断。<br><br>支配死灵击杀英雄获得<font color='#FFFFFF'><b>10</b></font>个灵魂，击杀小兵获得<font color='#FFFFFF'><b>3</b></font>个灵魂。<br><br>提升施法速度<font color='#FFFFFF'><b>50%%</b></font>，降低暗影压制与魂之挽歌的施法抬手时间。"
 
 		// 卓尔游侠 裂影箭
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_upgrade"					"<font color='#d000ff'>裂影箭 觉醒</font>"
@@ -1293,9 +1293,9 @@
 
 		// 齐天大圣-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_monkey_king_upgrade"					"<font color='#d000ff'>齐天大圣 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_monkey_king_upgrade_Description"		"棒击大地额外伤害提升<font color='#FFFFFF'><b>200</b></font>，施法距离提升<font color='#FFFFFF'><b>700</b></font>。<br>可以在被控制状态下施放斗战胜佛。<br>施放斗战胜佛时获得<font color='#FFCC66'>技能免疫</font>，持续到大招结束。"
+		"DOTA_Tooltip_ability_special_bonus_unique_monkey_king_upgrade_Description"		"棒击大地额外伤害提升<font color='#FFFFFF'><b>200</b></font>，施法距离提升<font color='#FFFFFF'><b>700</b></font>。<br>可以在被控制状态下施放斗战胜佛。<br>施放斗战胜佛时获得<font color='#FFCC66'>黑皇杖</font>效果，持续到大招结束。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_monkey_king_upgrade"					"<font color='#d000ff'>齐天大圣 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_monkey_king_upgrade_Description"		"棒击大地额外伤害提升<font color='#FFFFFF'><b>200</b></font>，施法距离提升<font color='#FFFFFF'><b>700</b></font>。<br>可以在被控制状态下施放斗战胜佛。<br>施放斗战胜佛时获得<font color='#FFCC66'>技能免疫</font>，持续到大招结束。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_monkey_king_upgrade_Description"		"棒击大地额外伤害提升<font color='#FFFFFF'><b>200</b></font>，施法距离提升<font color='#FFFFFF'><b>700</b></font>。<br>可以在被控制状态下施放斗战胜佛。<br>施放斗战胜佛时获得<font color='#FFCC66'>黑皇杖</font>效果，持续到大招结束。"
 
 		// 寒冬飞龙-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_winter_wyvern_upgrade"					"<font color='#d000ff'>寒冬诅咒 觉醒</font>"
@@ -1310,9 +1310,9 @@
 
 		// 发条技师-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>发条 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade_Description"		"施放能量齿轮后获得<font color='#FFCC66'>技能免疫</font>，持续<font color='#FFFFFF'><b>3</b></font>秒，期间受到的伤害降低<font color='#FFFFFF'><b>60%%</b></font>。"
+		"DOTA_Tooltip_ability_special_bonus_unique_rattletrap_upgrade_Description"		"施放能量齿轮后获得<font color='#FFCC66'>黑皇杖</font>效果，持续<font color='#FFFFFF'><b>3</b></font>秒，期间受到的伤害降低<font color='#FFFFFF'><b>60%%</b></font>。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade"					"<font color='#d000ff'>发条 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_Description"		"施放能量齿轮后获得<font color='#FFCC66'>技能免疫</font>，持续<font color='#FFFFFF'><b>3</b></font>秒，期间受到的伤害降低<font color='#FFFFFF'><b>60%%</b></font>。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_Description"		"施放能量齿轮后获得<font color='#FFCC66'>黑皇杖</font>效果，持续<font color='#FFFFFF'><b>3</b></font>秒，期间受到的伤害降低<font color='#FFFFFF'><b>60%%</b></font>。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"发条 觉醒"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"受到的伤害降低%dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%。"
 
@@ -1326,17 +1326,17 @@
 		"DOTA_Tooltip_modifier_doom_bringer_doom_awakened_carrier_Description"	"%dMODIFIER_PROPERTY_TOOLTIP%范围内的敌人持续受到末日效果。"
 		// 斯温-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>斯温 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade_Description"		"施放风暴之拳后获得<font color='#FFCC66'>技能免疫</font>，持续%duration%秒，期间力量提升%strength_bonus%点，攻击速度提升%attackspeed_bonus%点。"
+		"DOTA_Tooltip_ability_special_bonus_unique_sven_upgrade_Description"		"施放风暴之拳后获得<font color='#FFCC66'>黑皇杖</font>效果，持续%duration%秒，期间力量提升%strength_bonus%点，攻击速度提升%attackspeed_bonus%点。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade"					"<font color='#d000ff'>斯温 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_Description"		"施放风暴之拳后获得<font color='#FFCC66'>技能免疫</font>，并短暂提升力量与攻击速度。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_Description"		"施放风暴之拳后获得<font color='#FFCC66'>黑皇杖</font>效果，并短暂提升力量与攻击速度。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff"				"斯温 觉醒"
 		"DOTA_Tooltip_modifier_special_bonus_unique_sven_upgrade_buff_Description"	"力量提升%dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS%点，攻击速度提升%dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%点。"
 
 		// 水晶室女 极寒领域-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>极寒领域 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"			"施放极寒领域获得<font color='#FFCC66'>技能免疫</font>。<br><br>同时获得<font color='#FFFFFF'>法术抵抗</font>，持续<font color='#FFFFFF'><b>10</b></font>秒，抵挡一次敌方指向性法术后消失。"
+		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_upgrade_Description"			"施放极寒领域获得<font color='#FFCC66'>黑皇杖</font>效果。<br><br>同时获得<font color='#FFFFFF'>法术抵抗</font>，持续<font color='#FFFFFF'><b>10</b></font>秒，抵挡一次敌方指向性法术后消失。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade"						"<font color='#d000ff'>极寒领域 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"			"施放极寒领域获得<font color='#FFCC66'>技能免疫</font>。<br><br>同时获得<font color='#FFFFFF'>法术抵抗</font>，持续<font color='#FFFFFF'><b>10</b></font>秒，抵挡一次敌方指向性法术后消失。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_Description"			"施放极寒领域获得<font color='#FFCC66'>黑皇杖</font>效果。<br><br>同时获得<font color='#FFFFFF'>法术抵抗</font>，持续<font color='#FFFFFF'><b>10</b></font>秒，抵挡一次敌方指向性法术后消失。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield"				"极寒领域 觉醒"
 		"DOTA_Tooltip_modifier_special_bonus_unique_crystal_maiden_upgrade_shield_Description"	"获得<font color='#FFFFFF'>法术抵抗</font>，抵挡一次敌方指向性法术。"
 
@@ -3502,13 +3502,9 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"达到3层时触发寒灾冰爆；巫妖也可使用寒霜爆发提前引爆。"
 		// 戴泽 薄葬觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>薄葬 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>法术抗性。"
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>薄葬 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>法术抗性。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave"			"薄葬 觉醒"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave_Description"	"获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>法术抗性，持续至薄葬结束。"
-		"DOTA_Tooltip_modifier_dazzle_shallow_grave"		"薄葬"
-		"DOTA_Tooltip_modifier_dazzle_shallow_grave_Description"		"薄葬期间生命值不会低于1。<br><font color='#d000ff'>觉醒：</font>同时获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>魔法抗性。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
 
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3500,6 +3500,15 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_Description"		"提升连环霜冻的弹道速度与跳跃范围，并延长减速和霜缚的持续时间。<br><br>命中英雄或肉山时额外造成相当于智力<font color='#FFFFFF'><b>0.75</b></font>倍的魔法伤害，并叠加1层寒灾印记，持续<font color='#FFFFFF'><b>8</b></font>秒，叠满<font color='#FFFFFF'><b>3</b></font>层后自动引爆；也可对已叠加印记的敌人施放寒霜爆发提前引爆。引爆会在<font color='#FFFFFF'><b>350</b></font>范围内造成相当于智力<font color='#FFFFFF'><b>0.75</b></font>倍乘以当前印记层数的魔法伤害，并<font color='#2DD5E4'>眩晕</font>敌人<font color='#FFFFFF'><b>0.6</b></font>秒。<br><br>若已学会寒冰尖柱，连环霜冻命中附近唯一的敌方英雄时会自动在其位置施放寒冰尖柱。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"寒灾印记"
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"达到3层时触发寒灾冰爆；巫妖也可使用寒霜爆发提前引爆。"
+		// 戴泽 薄葬觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>薄葬 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>法术抗性。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>薄葬 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>法术抗性。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave"			"薄葬 觉醒"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_shallow_grave_Description"	"获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>法术抗性，持续至薄葬结束。"
+		"DOTA_Tooltip_modifier_dazzle_shallow_grave"		"薄葬"
+		"DOTA_Tooltip_modifier_dazzle_shallow_grave_Description"		"薄葬期间生命值不会低于1。<br><font color='#d000ff'>觉醒：</font>同时获得<font color='#FFCC66'>减益免疫</font>和<font color='#FFFFFF'><b>60%</b></font>魔法抗性。"
 
 	}
 }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -1027,6 +1027,8 @@
 			"cast_range"			"650"
 			"stun_duration"			"1 1.1 1.2 1.3 1.4"
 			"immunity_duration"		"3.0"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"			"60"
 			"AbilityCooldown"
 			{
 				"value"				"12"
@@ -2908,6 +2910,8 @@
 		"AbilityValues"
 		{
 			"damage_reduction"			"-50 -60 -70 -80"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"				"60"
 			"duration"
 			{
 				"value"						"5.0"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -855,4 +855,18 @@
 			}
 		}
 	}
+	// 戴泽 觉醒
+	"special_bonus_unique_dazzle_upgrade"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_dazzle_upgrade"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"dazzle_shallow_grave"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"magic_resistance"			"60"
+		}
+	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -288,6 +288,8 @@
 		"AbilityValues"
 		{
 			"bonus_cast_range"			"200"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"				"60"
 		}
 	}
 
@@ -421,6 +423,8 @@
 				"special_bonus_unique_phantom_assassin_6"	"+200"
 			}
 			"AbilityCooldown"				"14 12 10 8 6"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"					"60"
 		}
 
 		"OnSpellStart"
@@ -522,6 +526,8 @@
 		{
 			"invulnerability_duration"	"1.67"
 			"cast_speed_pct"			"50"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"				"60"
 		}
 	}
 
@@ -635,6 +641,8 @@
 		{
 			"duration"				"3"
 			"damage_reduction_pct"	"-60"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"			"60"
 		}
 
 		"Modifiers"
@@ -702,6 +710,8 @@
 			"duration"				"2"
 			"strength_bonus"		"20 40 60 80 100"
 			"attackspeed_bonus"	"20 40 60 80 100"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"			"60"
 		}
 
 		"Modifiers"
@@ -832,6 +842,12 @@
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
 		"AbilityTextureName"			"crystal_maiden_freezing_field"
 		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"				"60"
+		}
 	}
 
 	// 小小 觉醒
@@ -866,7 +882,8 @@
 
 		"AbilityValues"
 		{
-			"magic_resistance"			"60"
+			// modifier_black_king_bar_immune 的魔抗
+			"spell_reduce"				"60"
 		}
 	}
 }

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -22,10 +22,12 @@ const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boo
   {
     heroName: 'npc_dota_hero_elder_titan',
     abilityName: 'elder_titan_ancestral_spirit_awaken',
+    freeTrial: true,
   },
   {
     heroName: 'npc_dota_hero_techies',
     abilityName: 'techies_squees_scope',
+    freeTrial: true,
   },
   {
     heroName: 'npc_dota_hero_undying',

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_dazzle',
+    abilityName: 'special_bonus_unique_dazzle_upgrade',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_elder_titan',
     abilityName: 'elder_titan_ancestral_spirit_awaken',
   },

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_dazzle_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_dazzle_upgrade.ts
@@ -4,12 +4,11 @@ import {
   registerAbility,
   registerModifier,
 } from '../../utils/dota_ts_adapter';
+import { applyAwakenMagicImmunity } from './shared/awaken-magic-immunity';
 
 const SHALLOW_GRAVE_ABILITY = 'dazzle_shallow_grave';
-const BKB_EFFECT_PARTICLE = 'particles/items_fx/black_king_bar_avatar.vpcf';
-const BKB_ACTIVATE_SOUND = 'DOTA_Item.BlackKingBar.Activate';
 
-/** 戴泽觉醒：薄葬期间为目标附加减益免疫与魔法抗性。 */
+/** 戴泽 薄葬-觉醒：薄葬期间目标获得魔免。 */
 @registerAbility('special_bonus_unique_dazzle_upgrade')
 export class SpecialBonusUniqueDazzleUpgrade extends BaseAbility {
   GetIntrinsicModifierName(): string {
@@ -21,7 +20,7 @@ export class SpecialBonusUniqueDazzleUpgrade extends BaseAbility {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class modifier_special_bonus_unique_dazzle_upgrade extends BaseModifier {
   IsHidden(): boolean {
-    return true;
+    return false;
   }
 
   IsPurgable(): boolean {
@@ -57,68 +56,6 @@ export class modifier_special_bonus_unique_dazzle_upgrade extends BaseModifier {
     const duration = ability.GetSpecialValueFor('duration');
     if (duration <= 0) return;
 
-    target.AddNewModifier(
-      parent,
-      awakenAbility,
-      modifier_special_bonus_unique_dazzle_upgrade_shallow_grave.name,
-      { duration },
-    );
-  }
-}
-
-@registerModifier('abilities/ts_abilities/special_bonus_unique_dazzle_upgrade')
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export class modifier_special_bonus_unique_dazzle_upgrade_shallow_grave extends BaseModifier {
-  IsHidden(): boolean {
-    return true;
-  }
-
-  IsDebuff(): boolean {
-    return false;
-  }
-
-  IsBuff(): boolean {
-    return true;
-  }
-
-  IsPurgable(): boolean {
-    return false;
-  }
-
-  GetTexture(): string {
-    return SHALLOW_GRAVE_ABILITY;
-  }
-
-  OnCreated(): void {
-    if (!IsServer()) return;
-
-    const parent = this.GetParent();
-    const particle = ParticleManager.CreateParticle(
-      BKB_EFFECT_PARTICLE,
-      ParticleAttachment.ABSORIGIN_FOLLOW,
-      parent,
-    );
-    this.AddParticle(particle, false, false, -1, false, false);
-    parent.EmitSound(BKB_ACTIVATE_SOUND);
-  }
-
-  OnRefresh(): void {
-    if (!IsServer()) return;
-
-    this.GetParent().EmitSound(BKB_ACTIVATE_SOUND);
-  }
-
-  CheckState(): Partial<Record<ModifierState, boolean>> {
-    return {
-      [ModifierState.DEBUFF_IMMUNE]: true,
-    };
-  }
-
-  DeclareFunctions(): ModifierFunction[] {
-    return [ModifierFunction.MAGICAL_RESISTANCE_BONUS];
-  }
-
-  GetModifierMagicalResistanceBonus(): number {
-    return this.GetAbility()?.GetSpecialValueFor('magic_resistance') ?? 0;
+    applyAwakenMagicImmunity(target, awakenAbility, duration);
   }
 }

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_dazzle_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_dazzle_upgrade.ts
@@ -1,0 +1,124 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const SHALLOW_GRAVE_ABILITY = 'dazzle_shallow_grave';
+const BKB_EFFECT_PARTICLE = 'particles/items_fx/black_king_bar_avatar.vpcf';
+const BKB_ACTIVATE_SOUND = 'DOTA_Item.BlackKingBar.Activate';
+
+/** 戴泽觉醒：薄葬期间为目标附加减益免疫与魔法抗性。 */
+@registerAbility('special_bonus_unique_dazzle_upgrade')
+export class SpecialBonusUniqueDazzleUpgrade extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_dazzle_upgrade.name;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_dazzle_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_dazzle_upgrade extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return SHALLOW_GRAVE_ABILITY;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_ABILITY_FULLY_CAST];
+  }
+
+  OnAbilityFullyCast(event: ModifierAbilityEvent): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent();
+    const ability = event.ability;
+    if (event.unit !== parent || ability.GetAbilityName() !== SHALLOW_GRAVE_ABILITY) return;
+
+    const target = ability.GetCursorTarget();
+    if (!target || target.IsNull() || !target.IsAlive()) return;
+    if (target.GetTeamNumber() !== parent.GetTeamNumber()) return;
+
+    const awakenAbility = this.GetAbility();
+    if (!awakenAbility || awakenAbility.IsNull() || awakenAbility.GetLevel() <= 0) return;
+
+    const duration = ability.GetSpecialValueFor('duration');
+    if (duration <= 0) return;
+
+    target.AddNewModifier(
+      parent,
+      awakenAbility,
+      modifier_special_bonus_unique_dazzle_upgrade_shallow_grave.name,
+      { duration },
+    );
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_dazzle_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_dazzle_upgrade_shallow_grave extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsDebuff(): boolean {
+    return false;
+  }
+
+  IsBuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return SHALLOW_GRAVE_ABILITY;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent();
+    const particle = ParticleManager.CreateParticle(
+      BKB_EFFECT_PARTICLE,
+      ParticleAttachment.ABSORIGIN_FOLLOW,
+      parent,
+    );
+    this.AddParticle(particle, false, false, -1, false, false);
+    parent.EmitSound(BKB_ACTIVATE_SOUND);
+  }
+
+  OnRefresh(): void {
+    if (!IsServer()) return;
+
+    this.GetParent().EmitSound(BKB_ACTIVATE_SOUND);
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.DEBUFF_IMMUNE]: true,
+    };
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.MAGICAL_RESISTANCE_BONUS];
+  }
+
+  GetModifierMagicalResistanceBonus(): number {
+    return this.GetAbility()?.GetSpecialValueFor('magic_resistance') ?? 0;
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 戴泽 觉醒
+  {
+    heroName: 'npc_dota_hero_dazzle',
+    newAbility: 'special_bonus_unique_dazzle_upgrade',
+    newLevel: 1,
+  },
   // 上古巨神 觉醒
   {
     heroName: 'npc_dota_hero_elder_titan',
@@ -222,6 +228,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_dazzle', // 戴泽
   'npc_dota_hero_undying', // 尸王
   'npc_dota_hero_lich', // 巫妖
   'npc_dota_hero_doom_bringer', // 末日使者

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -229,6 +229,8 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  */
 export const FREE_TRIAL_HEROES: string[] = [
   'npc_dota_hero_dazzle', // 戴泽
+  'npc_dota_hero_elder_titan', // 上古巨神
+  'npc_dota_hero_techies', // 炸弹人
   'npc_dota_hero_undying', // 尸王
   'npc_dota_hero_lich', // 巫妖
   'npc_dota_hero_doom_bringer', // 末日使者


### PR DESCRIPTION
## Issue

N/A

## Summary

- Adds a Dazzle awakening that grants Debuff Immunity and 60% Magic Resistance for the duration of Shallow Grave.
- Keeps Shallow Grave as the only visible status icon and combines the original and awakened effects in its tooltip.
- Preserves the BKB-style visual effect without adding another visible modifier icon.
- Adds the awakening configuration, profile entry, KV ability, and Chinese, English, and Russian localization.

## Checklist

- [x] I have tested the changes works well.
- [x] VScripts and Panorama builds pass.
- [x] Related ESLint, localization, and diff checks pass.