### PR TITLE
Resolve duplicate item IDs 10313/10314 on shadow impact

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -6470,7 +6470,7 @@
 	"item_recipe_shadow_impact"
 	{
 		"BaseClass"					"item_datadriven"
-		"ID"						"10313"
+		"ID"						"10344"
 		"Model"						"models/props_gameplay/recipe.vmdl"
 		"AbilityTextureName"		"item_recipe_shadow_impact"
 
@@ -6488,7 +6488,7 @@
 	"item_shadow_impact"
 	{
 		"BaseClass"					"item_lua"
-		"ID"						"10314"
+		"ID"						"10345"
 		"ScriptFile"				"items/item_shadow_impact"
 		"AbilityTextureName"		"shadow_impact"
 		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"


### PR DESCRIPTION
## Issue

无对应 issue。

## 背景

`game/scripts/npc/npc_items_custom.txt` 中存在两组重复的物品 ID：

| ID | 物品 A | 物品 B |
|---|---|---|
| 10313 | `item_recipe_withered_spring`（生命之心） | `item_recipe_shadow_impact`（暗影法杖） |
| 10314 | `item_withered_spring` | `item_shadow_impact` |

物品 ID 要求全局唯一（KV 注释：`Do not change this once established or it will invalidate collected stats.`）。

## 扫描结果

扫描全部 7 个 `npc_items_*.txt`（共 196 个物品定义）：

- 除 10313 / 10314 外**无其它重复**
- 原全局最大 ID 为 **10343**（`item_recipe_moon_shard_datadriven`）

## 归属判定

`git log` / `git blame` **无法**定位先后：两组物品在同一次 upstream 批量导入（`0f9daabe7` / `f18a70151`，2025-10-18）同时进入本仓库，且 `docs/reference/tenvten-0610` 与 `tenvten-0628` 两份上游快照中 10313 / 10314 就已经重复——冲突早于本项目全部历史。

改用 fusion 系列的 ID 分配结构判定（每个 `item_fusion_*` 素材恰好产出 2 件成品，各占连续区块）：

| fusion 组 | 成品 | ID 区块 |
|---|---|---|
| fusion_forbidden | forbidden_staff / forbidden_blade | 10301–10304 |
| **fusion_life** | withered_spring / dracula_mask | **10313–10316**（完整连续） |
| **fusion_shadow** | shadow_judgment / shadow_impact | 10311–10312 + **10313–10314**（越界） |
| fusion_agile | swift_glove / ten_thousand_swords | 10317–10320 |

主分配计数器认的是 fusion_life 的 10313–10316，因为下一组 fusion_agile 正好从 **10317** 续接。fusion_shadow 是 `shadow_judgment` 取了残留的 10311 / 10312 后，盲目递增撞进已被占用的 10313 / 10314。「递增撞入已占区块」是常见笔误，「向前重叠回更早的区块」不是。

## 改动

重编号 shadow_impact 组，保留 withered_spring 组 ID 不变：

- `item_recipe_shadow_impact`：10313 → **10344**
- `item_shadow_impact`：10314 → **10345**

diff 仅 2 行，tab 缩进与对齐、LF 行尾均未变动。改后重扫：196 个物品、**0 重复**，新最大 ID 为 10345。

## 引用同步

**无需同步**。全仓库搜索数字 10313 / 10314，只命中 KV 中那 4 行 `"ID"` 定义本身。所有引用点一律**按物品名**引用：

- `game/scripts/shops.txt`
- `game/itembuilds/default_*.txt`（127 个）
- `src/vscripts/ai/build-item/`、`src/vscripts/ai/item/specs/`
- `content/panorama/layout/custom_game/images_items.xml`
- `addon_schinese.txt` / `addon_english.txt`

## Checklist

- [ ] I have tested the changes works well.
- [ ] 在 Dota Tools 中验证暗影法杖（合成、主动、被动）与生命之心均正常可用
- [ ] 确认后端统计侧无按物品 ID 硬编码的映射需要跟进

## 备注

由于冲突自 2025-10-18 首次发布起就存在，10313 / 10314 上已收集的数据本身就是两件物品的混合，本次改动保证的是**此后**两者分离。`item_shadow_impact` 出现在全部 127 个英雄的推荐出装中（`item_withered_spring` 为 0），换 ID 后其此前的历史数据会与新 ID 断开，此取舍已确认接受。
