### PR TITLE
Restructure item/ability skills around vanilla modifier reuse

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -357,7 +357,7 @@ png 必须**同时**放两处，并在统一 xml 中登记，三步缺一不可�
 | 原版物品参考 | `docs/reference/<version>/items.txt` |
 | 克隆升级物品 KV | `game/scripts/npc/npc_items_clone.txt` |
 | 自制物品 KV | `game/scripts/npc/npc_items_custom.txt` |
-| 物品共享 DataDriven hub（`item_apply_modifiers`） | `game/scripts/npc/npc_items_modifier.txt` |
+| 物品共享 DataDriven modifier（`item_apply_modifiers`） | `game/scripts/npc/npc_items_modifier.txt` |
 | 觉醒技能 KV | `game/scripts/npc/npc_abilities_custom_awaken.txt` |
 | 通用战斗公式（伤害/护甲等，手写纯 Lua，被遗留纯 Lua 物品脚本引用） | `game/scripts/vscripts/util.lua`（TS 侧同步入口 `src/vscripts/utils/damage-calculation.ts`） |
 | addon 英文本地化 | `game/resource/addon_english.txt` |

--- a/.claude/skills/awaken-ability/SKILL.md
+++ b/.claude/skills/awaken-ability/SKILL.md
@@ -67,7 +67,7 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
   }
   ```
 
-- **`ScriptFile` 实现选型** → 与 `custom-ability` skill 同一优先级：① 含被动属性加成（攻速/护甲/移速/属性…）走 **DataDriven**（KV `Modifiers`→`Properties`，引擎原生求值最省，允许其中 `RunScript` 调少量 Lua 补动态值）→ ② 逻辑技能走 **TS（TSTL）**，源码放 `src/vscripts/abilities/`，KV `ScriptFile` 指向编译产物 `abilities/ts_abilities/<name>`（`@registerAbility`/`@registerModifier`，参考斧王 `axe_auto_culling_blade`、宙斯 `special_bonus_unique_zuus_upgrade`）→ ③ **纯 Lua 仅用于维护已有技能，不从零新写**。被动觉醒标准写法：`GetIntrinsicModifierName()` 返回一个隐藏内置 modifier，无需学习即生效，所有可调值从 KV `AbilityValues` 读取。
+- **`ScriptFile` 实现选型** → 见 `custom-ability` skill，觉醒不另立规则。被动觉醒标准写法：`GetIntrinsicModifierName()` 返回一个隐藏内置 modifier，无需学习即生效，所有可调值从 KV `AbilityValues` 读取。源码放 `src/vscripts/abilities/`，KV `ScriptFile` 指向编译产物 `abilities/ts_abilities/<name>`（参考斧王 `axe_auto_culling_blade`、宙斯 `special_bonus_unique_zuus_upgrade`）。
 
 - **图标** → 引用 Dota2 原版技能名则不放 png；自定义图标才复制同名 png 到 `game/resource/flash3/images/spellicons/<name>.png`。`AbilityTextureName` 也可直接填**至宝/变体 texture 路径**（如 `necrolyte/apostle_of_decay_icons/necrolyte_heartstopper_aura`、`drow_ranger/immortal/drow_ranger_wave_of_silence`、`zuus_static_field_alt1`），引擎直接引用，同样无需放 png。
 
@@ -107,164 +107,23 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
 
 ---
 
-## 进阶方案
+## 进阶技法
 
-按需选用。每项都有对应的真实落地参考（斧王、卓尔、PA、影魔）。
+11 条技法集中在 `references/advanced-techniques.md`，主流程不需要读。**命中下面任一条才去读对应项**：
 
-### 进阶 1：等级与原技能关联（插入/新增也继承等级）
-
-替换分支天然继承原技能等级，但**插入/新增**分支默认用 `newLevel`，初始等级不跟随关联技能。需要全程等级关联（如觉醒技能与某个大招同步升级）时，两步配套：
-
-1. **KV 双向 `LinkedAbility`**（升级时等级同步）——在 `npc_abilities_override.txt` 的关联技能、和 `npc_abilities_custom_awaken.txt` 的觉醒技能，两边各加一行指向对方：
-   ```
-   "LinkedAbility"   "对方技能名"   // 双向联动同步升级
-   ```
-   两个技能的 `MaxLevel` 须一致。
-
-2. **配置 `inheritLevelFrom`**（添加时继承初始等级）——`awaken-config.ts` 该条加：
-   ```ts
-   inheritLevelFrom: '关联技能名',
-   ```
-   `resolveNewLevel` 会在加新技能时取该关联技能当前等级作初始等级（在移除任何技能前求值，故 `inheritLevelFrom` 可以正是被插入槽位的技能）。
-
-> 参考：斧王 `axe_auto_culling_blade` ↔ `axe_culling_blade`。
-
-> **不要用 `Innate "1"` + `DependentOnAbility` 替代 `LinkedAbility`**：官方有「新技能比关联技能多一档等级」的场景用这个组合（古辰山 Absolute Zero 先天、玛尔斯 Sidekick），但那些都是英雄出生自带的先天技能槛位。本项目觉醒技能是运行时用觉醒石 `AddAbility()` 动态加上去的，不是原生先天槛位——给它加 `Innate "1"` 实测会导致技能/buff 图标不显示（卓尔游侠裂影箭觉醒踩过，已放弃改回固定等级）。等级关联场景老老实实用上面的 `LinkedAbility` + `inheritLevelFrom`（要求两边 `MaxLevel` 一致）；如果新技能就是想比关联技能多一档，优先考虑改成固定值/不分级，而不是引入 `DependentOnAbility`。
-
-### 进阶 2：autocast 自动触发（自动施放）
-
-「开 autocast 后自动检测施放」类觉醒，**已有共享基类 `AutoCastAbility`（`src/vscripts/abilities/ts_abilities/shared/auto-cast-ability.ts`），直接继承，不要重复造轮子**：
-
-- KV：`BaseClass ability_lua`、`AbilityBehavior` = `NO_TARGET | IMMEDIATE | AUTOCAST`、`ScriptFile` 指向 `abilities/ts_abilities/...` 编译产物，**不写 `Modifiers`**（intrinsic modifier 由基类提供）。
-- 继承 `AutoCastAbility`，只实现 `OnAutoCastThink(caster)`；需要时覆写 `getThinkInterval()`（默认 0.3）。共享 `modifier_autocast_think` 负责 `IsServer / IsAlive / GetAutoCastState` 守卫后回调。
-- 基类 helper：`getFullCastRange`（含施法距离增强）、`findEnemiesInRange(caster, range, targetType, allowMagicImmune?)`（始终排除迷雾/隐身，可选命中魔免）、`castImmediatelyOnTarget`。
-- 施放用 **`CastAbilityImmediately`**：玩家英雄的背景自动施放**不能**用 order 式（`CastAbilityOnTarget` 等会打断玩家移动/攻击）。新基类/helper 统一放 `ts_abilities/shared/`。
-
-> 参考：斧王 `ts_abilities/axe_auto_culling_blade.ts`（斩杀线阈值 + 可打魔免）、宙斯 `ts_abilities/special_bonus_unique_zuus_upgrade.ts`（英雄优先、雷击仅英雄、不打魔免）。
-
-### 进阶 3：监听某技能施法后触发效果
-
-要在「英雄施放某个特定技能后」附带效果。下面两种实现**不是对等选项**，按步骤 2 的选型优先级选（① 被动属性加成尤其可能卡顿的 → DataDriven ② 逻辑技能 → TS ③ 纯 Lua 只维护已有不从零写；详见 `custom-ability` skill）：监听 + 造成伤害是**逻辑**，**从零新增一律走 TS**；DataDriven 一节仅作为「维护已有 datadriven 技能」的范例，不要据此从零新写。
-
-- **TS intrinsic modifier（从零新增首选）**：`@registerModifier` 的 modifier 在 `DeclareFunctions` 声明事件，回调里判 `event.unit == parent` 且 `event.ability.GetAbilityName() == "目标技能名"`。不依赖技能 behavior，最通用。**先想清触发时机选对事件**：
-  - `MODIFIER_EVENT_ON_ABILITY_START` → `OnAbilityStart`：**前摇开始**就触发（玩家可在前摇结束前取消施法）。只适合需要前摇期就生效的效果（如前摇加魔免防打断，见影魔现有觉醒）。**不要**用它结算附加伤害——玩家取消施法即可反复白嫖。
-  - `MODIFIER_EVENT_ON_ABILITY_FULLY_CAST` → `OnAbilityFullyCast`：**前摇走完、真正 OnSpellStart** 才触发，等价「释放完成」。附加伤害/附加效果一律用这个。目标技能是单体指向时，伤害数值可直接 `event.ability.GetSpecialValueFor("xxx")` 读触发技能当前等级的值，天然随其等级/神杖/天赋分级，无需自带 KV 数值。
-  - `MODIFIER_EVENT_ON_ABILITY_END_CHANNEL` → `OnAbilityEndChannel`：**引导结束**触发，读条走完和被打断/主动取消都会推。引导期间才生效的觉醒（如引导期魔免）用 `FULLY_CAST` 开、`END_CHANNEL` 收，**不要写轮询**——`CDOTA_BaseNPC` 上没有 `IsChannelling`（只有 `CDOTABaseAbility.IsChanneling()`），照着轮询思路写会编译不过。时长用 `event.ability.GetChannelTime()` 申请，实际回收交给 `END_CHANNEL`。参考：冰女 `special_bonus_unique_crystal_maiden_upgrade`。
-- **DataDriven modifier（仅维护已有）**：KV `Modifiers` 加 `"Passive" "1"` 常驻 modifier（配 `"RemoveOnDeath" "0"` + `"Attributes" "MODIFIER_ATTRIBUTE_PERMANENT"`），用 **`OnAbilityExecuted`** 块 `RunScript`。被施放的技能是 **`keys.event_ability`**（不是 `keys.ability`），施法者 `keys.caster`。主动技（如 `UNIT_TARGET`）上也会常驻触发。
-
-> **关键坑**：不要为了让 listener 常驻而给主动技 `AbilityBehavior` 叠加 `DOTA_ABILITY_BEHAVIOR_PASSIVE`——实测会使该主动技**无法施放**。DataDriven 的 `Passive` modifier 不依赖技能 behavior 即可常驻，保持原主动 behavior 即可。
-
-> **关键坑**：`OnAbilityExecuted` 的 `RunScript` 里若要再给自己加一个**同一技能 KV `Modifiers` 里定义的** DataDriven modifier（如限时减伤 buff），必须用 `ability:ApplyDataDrivenModifier(caster, target, "modifier_name", {})`，**不能**用通用的 `unit:AddNewModifier(...)`——用 `AddNewModifier` 加载 DataDriven 定义的 modifier 时，**modifier 本身不会被加载**（不是 KV 占位符解析失败，是整个 modifier 都没生效），buff 图标不会出现在状态栏。`AddNewModifier` 只适用于借用别的技能/原生 hardcoded modifier（见进阶 7），不适用于自己 KV 里定义的 DataDriven modifier。
-
-> 参考：影魔 `ability_lua` + `GetIntrinsicModifierName` 监听 `nevermore_requiem`；PA `ability_datadriven`（`UNIT_TARGET`，未加 PASSIVE）的 `modifier_pa_awaken_dagger_listener` 用 `OnAbilityExecuted`；宙斯 `special_bonus_unique_zuus_upgrade` 是 PASSIVE datadriven 监听范例。
-
-### 进阶 4：数值仅觉醒后生效（special_bonus 关联）
-
-想让原技能某个 KV 数值「仅在该英雄拥有觉醒技能时改变」（运行时无法干净改的固定值，如投射物速度），用**觉醒技能名**作 `special_bonus` key 写进原技能 override KV：
-
-```
-"dagger_speed"
-{
-    "value"                                         "1200"
-    "special_bonus_unique_phantom_assassin_upgrade" "=2100"   // 觉醒后覆盖
-}
-```
-
-`=值` 覆盖、`+值` 增加，此外还支持 `+N%` 按百分比增加（如 `+100%` 表示翻倍，项目里已有大量原版天赋先例，如 `special_bonus_unique_dragon_knight_9 "+120%"`）——多档位字段要整体等比缩放时用这个，不需要手算每档绝对值再写数组。引擎检测英雄拥有该 key 同名技能时自动应用。
-
-> **关键坑：key 必须是 `special_bonus_` 前缀的技能名**。引擎靠前缀识别哪些子 key 是「bonus 覆盖」，非此前缀的子 key 被当无关元数据**静默忽略**（数值不变，无报错）。觉醒技能即使是普通可学习主动技（如 PA `special_bonus_unique_phantom_assassin_upgrade` 是 `UNIT_TARGET` 主动），只要名字带前缀就能当 key；反之，不带前缀的觉醒技能名（如曾用的 `sniper_assassinate_upgrade`）写进去不生效，须把觉醒技能**重命名**为 `special_bonus_unique_*`（连带改抽奖池引用、Lua 类名、本地化 key；ScriptFile 路径/Lua 文件名可不动，仅同步文件内 ability 类名）。该 key 技能还须被英雄拥有且等级 ≥ 1 才应用。
-
-> **同一 value 块可以挂多个 `special_bonus_` key，但引擎只应用块内第一个命中的**，所以觉醒键须排在 `value` 之后、其它键之前。动手前先按 `update-abilities-override` skill 的方法读该技能整段（override 差分 + `docs/reference/<version>/heroes/` 原版全集，**原版键会被合并进来，只看 override 会漏**），确认块内已有哪些 `special_bonus_*`（常见来源：原版天赋、魔晶、神杖、其它觉醒）。排首位意味着觉醒后该字段上的其它 bonus 全部失效，若不可接受则换一个干净字段，或改用其它实现方式（DataDriven Modifiers / TS）。
-
-> **块内原有的原版键必须在 override 里逐条显式重写，并排在觉醒键之后**。只把觉醒键写进 override 是不够的——override 未显式声明的原版键在合并时会排到觉醒键**前面**，觉醒同样静默失效。这些重写行的唯一作用是固定键序，须加注释说明，避免被后续「删同值差分」当冗余清理掉（写与原版不同的值可再加一层保险）。
-
-> 实测：`tiny_tree_grab` 的 `attack_count` 原本挂着原版天赋 `special_bonus_unique_tiny_6` 与魔晶键，觉醒键排第三时**静默失效**（无报错、数值不变）；把觉醒键提到 `value` 之后、并将原版天赋键显式重写在其后，才生效。
-
-> 参考：PA 觉醒后潜匿之刺 `dagger_speed` 1200→2100；狙击手 `special_bonus_unique_sniper_assassinate_upgrade` 觉醒后爆头 `proc_chance` `=100`。
-
-### 进阶 5：加魔免但不顶替真 BKB
-
-给英雄加魔免时，直接 `AddNewModifier("modifier_black_king_bar_immune")` 会缩短/顶掉玩家自己的 BKB。一律走全局工具函数（`game/scripts/vscripts/util.lua`）：
-
-```lua
-ApplyAwakenMagicImmunity(unit, ability, duration)
-```
-
-已有相等或更长的 BKB 时跳过，否则加魔免 + 播音效，**返回是否实际施加**。
-
-**TS 代码优先用已有的 TS 封装**：`src/vscripts/abilities/ts_abilities/shared/awaken-magic-immunity.ts` 导出的 `applyAwakenMagicImmunity(unit, ability, duration)` 是同一逻辑的原生 TS 实现（同样借用 `modifier_black_king_bar_immune` 且不顶替真 BKB），直接 `import` 复用即可，不要再 `declare function` 绑定 Lua 全局。它与 Lua 版的差异是返回值：施加成功返回该 modifier 的句柄（`CDOTA_Buff`），跳过时返回 `undefined`（Lua 版返回布尔值）。
-
-**前摇加魔免要防取消刷新**：魔免绑在 `ON_ABILITY_START`（前摇开始）触发时，玩家可在前摇结束前取消再施法反复刷新（取消不进 CD、不耗蓝）。防法：仅当 `ApplyAwakenMagicImmunity` 返回 true 才启动取消检测；`StartIntervalThink` 轮询 `IsInAbilityPhase()`，前摇结束后若 `GetCooldownTimeRemaining() <= 0`（被取消）则移除；**移除前判据**——仅当 `modifier_black_king_bar_immune` 剩余 ≤ 本次魔免时长才 `Destroy()`，**绝不无条件 `RemoveModifierByName`**（同名 modifier 区分不了来源，会误删真 BKB）。
-
-> 参考：影魔 `special_bonus_unique_nevermore_upgrade.lua` 的 `OnIntervalThink` 取消检测；PA 闪烁/匕首魔免。
-
-### 进阶 6：纯被动标记技能改用 Modifier 展示（省技能栏空间）
-
-纯被动且描述简单的觉醒技能（典型如进阶 4 的「数值仅觉醒后生效」纯 KV 标记技能），不必占技能栏（castbar）一个槛位，可改用常驻 buff 图标展示：
-
-- KV：`AbilityBehavior` 加 `DOTA_ABILITY_BEHAVIOR_HIDDEN`（不进技能栏），同时加一个 `Modifiers` 子块，子 modifier 设 `"Passive" "1"` + `"IsHidden" "0"`（非隐藏，展示为常驻 buff 图标，自动复用 `AbilityTextureName` 做图标）。
-- 本地化：ability 自身的 `DOTA_Tooltip_ability_<name>` / `_Description` **保留不删**——觉醒预览页 `AwakenTab.tsx` 用 `DOTAAbilityImage` 读取的是 ability 的 tooltip，不是 modifier 的。额外补一组 `DOTA_Tooltip_modifier_<modifier_name>` / `_Description`，内容与 ability 标题/描述完全一致，确保游玩时看到的 buff tooltip 与觉醒页说明一致。
-- modifier 描述里若有写死的字面 `%` 号，**同样要转义成 `%%`**（不要因为是 modifier 就漏掉，规则与正文一致，见 CLAUDE.md 本地化文案规约）。
-- **modifier tooltip 不支持直接 `%key%` 读取 ability 的 `AbilityValues`**（会显示空白或吞掉百分号）；ability 自身的描述不受影响，仍可正常用 `%key%`。modifier 这边按实现方式分三种处理：
-  - **DataDriven 且数值挂在内置 `MODIFIER_PROPERTY_*`**（如 `MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE`、`MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT` 等标准属性，`Properties` 块里已声明）：**可以**直接动态取值，本地化写 `%dMODIFIER_PROPERTY_<属性名>%%%` 即可，引擎自动读取该 modifier 当前的属性值，**不需要**任何 RunScript/OnTooltip 代码，也**不需要**手动包白色粗体（项目里已有先例：`monkey_king_defy`、`insight_armor_aura`）。
-  - **DataDriven 且数值不对应任何内置 Property**（纯标记技能、无脚本）：没有代码可补，描述里**写死成具体数字**。
-  - **TS/Lua 脚本类 modifier**（`ability_lua` + `GetIntrinsicModifierName`，如进阶 3 的监听型觉醒）：数值若会变化（随等级、天赋等），**不要写死**——用 `MODIFIER_PROPERTY_TOOLTIP` 动态取值：`DeclareFunctions` 加 `ModifierFunction.TOOLTIP`，实现 `OnTooltip(): number` 返回目标值（如 `this.GetAbility()?.GetSpecialValueFor('xxx') ?? 0`），本地化里用 `%dMODIFIER_PROPERTY_TOOLTIP%%%` 占位（同一 modifier 最多两个动态值，第二个用 `MODIFIER_PROPERTY_TOOLTIP2`/`OnTooltip2`/`%dMODIFIER_PROPERTY_TOOLTIP2%`）。只有真正固定不变的数值才写死。**`%dMODIFIER_PROPERTY_TOOLTIP%` 不会像 ability 的 `%key%` 一样自动套白色粗体**（实测），需要手动包 `<font color='#FFFFFF'><b>...</b></font>`，和写死数值的处理方式一样（这条仅限自定义 `TOOLTIP`/`TOOLTIP2`，内置 Property 不受影响）。
-
-> 参考：寒冬飞龙觉醒 `special_bonus_unique_winter_wyvern_upgrade`（DataDriven 写死数值）；卓尔游侠裂影箭觉醒 `special_bonus_unique_drow_ranger_upgrade`（TS modifier，分裂概率会被天赋提升，用 `OnTooltip` 动态显示而非写死）；发条技师觉醒 `special_bonus_unique_rattletrap_upgrade_shield`（DataDriven 内置 Property 动态取值，`%dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%`）。
-
-### 进阶 7：借用原生 hardcoded modifier（如隐身）实现效果
-
-某些效果（如隐身）引擎有原生硬编码 modifier 支撑，但目标 KV 里查不到 `Modifiers` 块（完全编译进引擎，无法照抄），仍可在 TS 里直接 `AddNewModifier` 按名字借用：
-
-```ts
-const invis = parent.AddNewModifier(parent, this.GetAbility(), 'modifier_riki_backstab', {
-  duration,
-  fade_delay: fadeDelay,
-});
-```
-
-`duration` 参数通常能让原生 modifier 自动到期（如 `modifier_black_king_bar_immune`）。**若实机验证发现某个借用的原生 modifier 不吃 `duration` 自动移除**，改用 `Timers.CreateTimer(duration, callback)` 手动 `Destroy()`，`callback` 内先 `IsNull()` 判空再 `Destroy()`（防止已被其它途径提前移除时重复调用报错）：
-
-```ts
-if (!invis) return;
-Timers.CreateTimer(duration, () => {
-  if (invis.IsNull()) return;
-  invis.Destroy();
-});
-```
-
-原生 modifier 内部可能还支持其它同名参数覆写（如本例 `fade_delay`），具体哪些参数生效、哪些字段该从自身觉醒技能 KV 读取（而非硬编码），**没有文档，只能靠实机反复验证**，不要凭一次测试结果下结论。
-
-> 参考：风行者觉醒 `windrunner_whirlwind_custom`（`GetIntrinsicModifierName` 挂的被动 modifier）借用隐刺 `modifier_riki_backstab`；该被动与技能自身的主动 `OnSpellStart` 共存，二者互不影响——`GetIntrinsicModifierName` 不依赖 `AbilityBehavior`，主动大招可以正常保留 `IMMEDIATE | NO_TARGET` 之类行为。
-
-### 进阶 8：需要读取「施法者当前 AoE/属性加成」等动态值时，优先在自身 KV 声明同名字段
-
-想让觉醒技能的某个数值自动叠加施法者当前的 AoE 加成（或其他类似的引擎内置加成机制）时，**不要**用「哑值探测」手法（如声明一个 `value: "1"` 的占位数值加 `affected_by_aoe_increase: "1"`，再用 `GetSpecialValueFor() - 1` 反推出加成百分比、手动相加到别的数值上）。正确做法是直接在自身 KV 里声明目标字段本身（字段名与原版一致，如 `scepter_aura_radius`），带上同样的 `affected_by_aoe_increase: "1"`，让 `GetSpecialValueFor('scepter_aura_radius')` 直接返回已经计入加成的最终值。这样既不需要跨技能读取原版 KV，也不需要额外的相加逻辑，且能直接用 `%scepter_aura_radius%` 占位符内联进本地化正文（与原版写法一致）。
-
-### 进阶 9：运行时替换类技能的 `HasScepterUpgrade` + `scepter_description` 不会正常显示
-
-觉醒技能若是**运行时替换**（通过 `awaken-config.ts` 的 `targetAbility` 把原版技能整体换成新的 `ability_lua`），即使 KV 里带 `HasScepterUpgrade: "1"` 并写了 `_scepter_description`，引擎也不会渲染这个神杖对比预览面板——因为该面板依赖的是"英雄默认自带、原生学习"的技能实例，替换类技能走的是完全不同的运行时挂载路径。神杖相关的效果说明应直接写进主 `_Description` 正文（可加 `<font color='#92acf5'>阿哈利姆神杖</font>` 提示），不要指望 `_scepter_description` 单独显示。（注：常驻挂在英雄默认技能槽的觉醒技能，如 `imba_chaos_knight_phantasm`，`scepter_description` 可以正常显示，问题只出在替换类。）
-
-### 进阶 10：觉醒专属参数不要塞进原版技能的 override KV
-
-觉醒技能若需要「跟随某个原版技能的等级/天赋联动」某个数值（如领域半径随原版技能天赋扩大），**不要**为了图省事把这个觉醒专属的自定义字段直接写进 `npc_abilities_override.txt` 里原版技能自己的 `AbilityValues`——即使代码要通过 `FindAbilityByName(原版技能).GetSpecialValueFor('自定义字段')` 去读、需要蹭同一份天赋绑定，也不能把字段存放在原版技能身上。这样会让原版技能的差分文件里混入一个只有觉醒机制认识的字段，看 override 文件的人无法理解这个字段为什么存在，后续调整原版技能数值平衡时也容易误改或误删。
-
-正确做法：字段直接定义在觉醒技能自己的 KV 里；需要联动原版技能当前等级/天赋时，在代码里读取原版技能实例的等级/已生效数值，用公式在觉醒技能侧算出最终值，而不是让原版技能替觉醒机制保管参数。
-
-### 进阶 11：目标是「简化原版操作」时，优先包一层自动化外壳，不要重新实现原版机制
-
-有些觉醒诉求本质是「原版技能手动操作太繁琐，希望自动帮玩家完成」（如某个需要手动施放+手动收尾两步操作的技能，想在自动施法开启后全自动化）。这类需求容易被过度设计成一套全新机制（如引入持续 buff/领域/独立数值体系去模拟"自动化后应有的效果"），实际上完全不需要——原版技能自身的施法逻辑、命中判定、加成效果都不用动，觉醒技能只需要做**一层控制外壳**。
-
-这个方案还额外解决了英雄技能槽位已满、无法新增独立技能的问题：把原版技能隐藏（`SetHidden(true)`）挂在英雄身上而不是移除，觉醒技能占用同一个槽位对外显示，自身 KV 完整还原原版数值供玩家查看，内部通过代为调用原版技能的 `OnSpellStart()` 复用其全部效果——玩家看到的是"同一个技能位置多了自动施法能力"，而不是"技能被替换成了别的东西"。这是利用引擎已有机制实现最小改动的方式，槽位紧张、又只想加自动化能力时优先考虑这个思路。
-
-- 关闭自动施法：技能栏显示原版技能本体，玩家手动操作，行为与不觉醒时完全一致
-- 打开自动施法：觉醒技能的 intrinsic modifier 用 `OnIntervalThink` 周期检测触发条件（如冷却是否转好、范围内是否有合适目标），满足条件时**代替玩家调用原版技能自身的 `OnSpellStart()`**（而不是重新实现一遍技能效果），原版技能命中判定、加成、伤害全部原样生效；需要玩家原本手动点第二步操作（如某个收尾/确认技能）时，同样在检测循环里判断该技能是否可施放，可施放就代为调用
-
-判断「简化操作」类需求是否走偏了的信号：如果实现过程中出现了原版技能本身没有的新数值字段（半径、持续时间、加成档位）、新的 buff/debuff modifier、或者需要"叠加/覆盖原版效果"的逻辑，那大概率是把"自动化操作"和"改变技能效果"这两件事混在一起了——先回头确认需求到底是哪一种，多数"简化操作"类诉求只需要前者。代码代为触发 `OnSpellStart()` 时须补 `UseResources`，见 CLAUDE.md「常见陷阱」。
-
-**替换类觉醒仍需完整还原原版技能的 KV 数值和本地化文案**：这层"自动化外壳"不改变原版效果，因此觉醒技能自己的 KV（`AbilityValues`、`AbilityCooldown`、`AbilityManaCost`、`HasScepterUpgrade` 等）和本地化描述都应该与原版技能 + `npc_abilities_override.txt` 差分之后的最终值保持完全一致（玩家在未开自动施法时，看到的技能面板本质就是原版技能本身）。新增的自动施法说明追加在原版描述之后，不要替换掉原版的效果描述。
-
-> 参考：上古巨神觉醒 `elder_titan_ancestral_spirit_awaken`——自动施法开启后，冷却转好且附近有敌方英雄时自动朝最远的英雄施放先祖之魂（直接调用原版 `elder_titan_ancestral_spirit` 的 `OnSpellStart`），游魂可召回时自动调用原版 `elder_titan_return_spirit`，不新增任何数值/效果，原版命中加成、护甲魔抗削弱、KV 数值、本地化描述全部原样保留。
+| 需求 | 进阶 |
+| ---- | ---- |
+| 觉醒技能要与某个原技能**同步升级** | 1 |
+| 要**自动施放**（开 autocast 后自动检测触发） | 2 |
+| 要在**施放某个技能之后**附带效果 | 3 |
+| 某个原技能数值**仅觉醒后改变** | 4 |
+| 要**加魔免**（不能顶替玩家真 BKB） | 5 |
+| 纯被动标记技能想**省掉技能栏槽位** | 6 |
+| 要借用引擎**原生 hardcoded modifier**（隐身等） | 7，另见 `../shared-references/vanilla-modifiers.md` |
+| 要读取施法者**当前 AoE / 属性加成** | 8 |
+| 替换类技能的**神杖描述**不显示 | 9 |
+| 觉醒专属参数该**放哪个 KV** | 10 |
+| 需求本质是**简化原版操作**而非改效果 | 11 |
 
 ---
 

--- a/.claude/skills/awaken-ability/references/advanced-techniques.md
+++ b/.claude/skills/awaken-ability/references/advanced-techniques.md
@@ -1,0 +1,158 @@
+# 觉醒进阶技法
+
+供 `awaken-ability` 按需查阅，主流程不需要读完。每项都有真实落地参考（斧王、卓尔、PA、影魔、上古巨神等）。
+
+### 进阶 1：等级与原技能关联（插入/新增也继承等级）
+
+替换分支天然继承原技能等级，但**插入/新增**分支默认用 `newLevel`，初始等级不跟随关联技能。需要全程等级关联（如觉醒技能与某个大招同步升级）时，两步配套：
+
+1. **KV 双向 `LinkedAbility`**（升级时等级同步）——在 `npc_abilities_override.txt` 的关联技能、和 `npc_abilities_custom_awaken.txt` 的觉醒技能，两边各加一行指向对方：
+   ```
+   "LinkedAbility"   "对方技能名"   // 双向联动同步升级
+   ```
+   两个技能的 `MaxLevel` 须一致。
+
+2. **配置 `inheritLevelFrom`**（添加时继承初始等级）——`awaken-config.ts` 该条加：
+   ```ts
+   inheritLevelFrom: '关联技能名',
+   ```
+   `resolveNewLevel` 会在加新技能时取该关联技能当前等级作初始等级（在移除任何技能前求值，故 `inheritLevelFrom` 可以正是被插入槽位的技能）。
+
+> 参考：斧王 `axe_auto_culling_blade` ↔ `axe_culling_blade`。
+
+> **不要用 `Innate "1"` + `DependentOnAbility` 替代 `LinkedAbility`**：官方有「新技能比关联技能多一档等级」的场景用这个组合（古辰山 Absolute Zero 先天、玛尔斯 Sidekick），但那些都是英雄出生自带的先天技能槛位。本项目觉醒技能是运行时用觉醒石 `AddAbility()` 动态加上去的，不是原生先天槛位——给它加 `Innate "1"` 实测会导致技能/buff 图标不显示（卓尔游侠裂影箭觉醒踩过，已放弃改回固定等级）。等级关联场景老老实实用上面的 `LinkedAbility` + `inheritLevelFrom`（要求两边 `MaxLevel` 一致）；如果新技能就是想比关联技能多一档，优先考虑改成固定值/不分级，而不是引入 `DependentOnAbility`。
+
+### 进阶 2：autocast 自动触发（自动施放）
+
+「开 autocast 后自动检测施放」类觉醒，**已有共享基类 `AutoCastAbility`（`src/vscripts/abilities/ts_abilities/shared/auto-cast-ability.ts`），直接继承，不要重复造轮子**：
+
+- KV：`BaseClass ability_lua`、`AbilityBehavior` = `NO_TARGET | IMMEDIATE | AUTOCAST`、`ScriptFile` 指向 `abilities/ts_abilities/...` 编译产物，**不写 `Modifiers`**（intrinsic modifier 由基类提供）。
+- 继承 `AutoCastAbility`，只实现 `OnAutoCastThink(caster)`；需要时覆写 `getThinkInterval()`（默认 0.3）。共享 `modifier_autocast_think` 负责 `IsServer / IsAlive / GetAutoCastState` 守卫后回调。
+- 基类 helper：`getFullCastRange`（含施法距离增强）、`findEnemiesInRange(caster, range, targetType, allowMagicImmune?)`（始终排除迷雾/隐身，可选命中魔免）、`castImmediatelyOnTarget`。
+- 施放用 **`CastAbilityImmediately`**：玩家英雄的背景自动施放**不能**用 order 式（`CastAbilityOnTarget` 等会打断玩家移动/攻击）。新基类/helper 统一放 `ts_abilities/shared/`。
+
+> 参考：斧王 `ts_abilities/axe_auto_culling_blade.ts`（斩杀线阈值 + 可打魔免）、宙斯 `ts_abilities/special_bonus_unique_zuus_upgrade.ts`（英雄优先、雷击仅英雄、不打魔免）。
+
+### 进阶 3：监听某技能施法后触发效果
+
+要在「英雄施放某个特定技能后」附带效果。下面两种实现**不是对等选项**：监听 + 造成伤害是**逻辑**，**从零新增一律走 TS**；DataDriven 一节仅作为「维护已有 datadriven 技能」的范例，不要据此从零新写。
+
+- **TS intrinsic modifier（从零新增首选）**：`@registerModifier` 的 modifier 在 `DeclareFunctions` 声明事件，回调里判 `event.unit == parent` 且 `event.ability.GetAbilityName() == "目标技能名"`。不依赖技能 behavior，最通用。**先想清触发时机选对事件**：
+  - `MODIFIER_EVENT_ON_ABILITY_START` → `OnAbilityStart`：**前摇开始**就触发（玩家可在前摇结束前取消施法）。只适合需要前摇期就生效的效果（如前摇加魔免防打断，见影魔现有觉醒）。**不要**用它结算附加伤害——玩家取消施法即可反复白嫖。
+  - `MODIFIER_EVENT_ON_ABILITY_FULLY_CAST` → `OnAbilityFullyCast`：**前摇走完、真正 OnSpellStart** 才触发，等价「释放完成」。附加伤害/附加效果一律用这个。目标技能是单体指向时，伤害数值可直接 `event.ability.GetSpecialValueFor("xxx")` 读触发技能当前等级的值，天然随其等级/神杖/天赋分级，无需自带 KV 数值。
+  - `MODIFIER_EVENT_ON_ABILITY_END_CHANNEL` → `OnAbilityEndChannel`：**引导结束**触发，读条走完和被打断/主动取消都会推。引导期间才生效的觉醒（如引导期魔免）用 `FULLY_CAST` 开、`END_CHANNEL` 收，**不要写轮询**——`CDOTA_BaseNPC` 上没有 `IsChannelling`（只有 `CDOTABaseAbility.IsChanneling()`），照着轮询思路写会编译不过。时长用 `event.ability.GetChannelTime()` 申请，实际回收交给 `END_CHANNEL`。参考：冰女 `special_bonus_unique_crystal_maiden_upgrade`。
+- **DataDriven modifier（仅维护已有）**：KV `Modifiers` 加 `"Passive" "1"` 常驻 modifier（配 `"RemoveOnDeath" "0"` + `"Attributes" "MODIFIER_ATTRIBUTE_PERMANENT"`），用 **`OnAbilityExecuted`** 块 `RunScript`。被施放的技能是 **`keys.event_ability`**（不是 `keys.ability`），施法者 `keys.caster`。主动技（如 `UNIT_TARGET`）上也会常驻触发。
+
+> **关键坑**：不要为了让 listener 常驻而给主动技 `AbilityBehavior` 叠加 `DOTA_ABILITY_BEHAVIOR_PASSIVE`——实测会使该主动技**无法施放**。DataDriven 的 `Passive` modifier 不依赖技能 behavior 即可常驻，保持原主动 behavior 即可。
+
+> **关键坑**：`OnAbilityExecuted` 的 `RunScript` 里若要再给自己加一个**同一技能 KV `Modifiers` 里定义的** DataDriven modifier（如限时减伤 buff），必须用 `ability:ApplyDataDrivenModifier(caster, target, "modifier_name", {})`，**不能**用通用的 `unit:AddNewModifier(...)`——用 `AddNewModifier` 加载 DataDriven 定义的 modifier 时，**modifier 本身不会被加载**（不是 KV 占位符解析失败，是整个 modifier 都没生效），buff 图标不会出现在状态栏。`AddNewModifier` 只适用于借用别的技能/原生 hardcoded modifier（见进阶 7），不适用于自己 KV 里定义的 DataDriven modifier。
+
+> 参考：影魔 `ability_lua` + `GetIntrinsicModifierName` 监听 `nevermore_requiem`；PA `ability_datadriven`（`UNIT_TARGET`，未加 PASSIVE）的 `modifier_pa_awaken_dagger_listener` 用 `OnAbilityExecuted`；宙斯 `special_bonus_unique_zuus_upgrade` 是 PASSIVE datadriven 监听范例。
+
+### 进阶 4：数值仅觉醒后生效（special_bonus 关联）
+
+想让原技能某个 KV 数值「仅在该英雄拥有觉醒技能时改变」（运行时无法干净改的固定值，如投射物速度），用**觉醒技能名**作 `special_bonus` key 写进原技能 override KV：
+
+```
+"dagger_speed"
+{
+    "value"                                         "1200"
+    "special_bonus_unique_phantom_assassin_upgrade" "=2100"   // 觉醒后覆盖
+}
+```
+
+`=值` 覆盖、`+值` 增加，此外还支持 `+N%` 按百分比增加（如 `+100%` 表示翻倍，项目里已有大量原版天赋先例，如 `special_bonus_unique_dragon_knight_9 "+120%"`）——多档位字段要整体等比缩放时用这个，不需要手算每档绝对值再写数组。引擎检测英雄拥有该 key 同名技能时自动应用。
+
+> **关键坑：key 必须是 `special_bonus_` 前缀的技能名**。引擎靠前缀识别哪些子 key 是「bonus 覆盖」，非此前缀的子 key 被当无关元数据**静默忽略**（数值不变，无报错）。觉醒技能即使是普通可学习主动技（如 PA `special_bonus_unique_phantom_assassin_upgrade` 是 `UNIT_TARGET` 主动），只要名字带前缀就能当 key；反之，不带前缀的觉醒技能名（如曾用的 `sniper_assassinate_upgrade`）写进去不生效，须把觉醒技能**重命名**为 `special_bonus_unique_*`（连带改抽奖池引用、Lua 类名、本地化 key；ScriptFile 路径/Lua 文件名可不动，仅同步文件内 ability 类名）。该 key 技能还须被英雄拥有且等级 ≥ 1 才应用。
+
+> **同一 value 块可以挂多个 `special_bonus_` key，但引擎只应用块内第一个命中的**，所以觉醒键须排在 `value` 之后、其它键之前。动手前先按 `update-abilities-override` skill 的方法读该技能整段（override 差分 + `docs/reference/<version>/heroes/` 原版全集，**原版键会被合并进来，只看 override 会漏**），确认块内已有哪些 `special_bonus_*`（常见来源：原版天赋、魔晶、神杖、其它觉醒）。排首位意味着觉醒后该字段上的其它 bonus 全部失效，若不可接受则换一个干净字段，或改用其它实现方式（DataDriven Modifiers / TS）。
+
+> **块内原有的原版键必须在 override 里逐条显式重写，并排在觉醒键之后**。只把觉醒键写进 override 是不够的——override 未显式声明的原版键在合并时会排到觉醒键**前面**，觉醒同样静默失效。这些重写行的唯一作用是固定键序，须加注释说明，避免被后续「删同值差分」当冗余清理掉（写与原版不同的值可再加一层保险）。
+
+> 实测：`tiny_tree_grab` 的 `attack_count` 原本挂着原版天赋 `special_bonus_unique_tiny_6` 与魔晶键，觉醒键排第三时**静默失效**（无报错、数值不变）；把觉醒键提到 `value` 之后、并将原版天赋键显式重写在其后，才生效。
+
+> 参考：PA 觉醒后潜匿之刺 `dagger_speed` 1200→2100；狙击手 `special_bonus_unique_sniper_assassinate_upgrade` 觉醒后爆头 `proc_chance` `=100`。
+
+### 进阶 5：加魔免但不顶替真 BKB
+
+给英雄加魔免时，直接 `AddNewModifier("modifier_black_king_bar_immune")` 会缩短/顶掉玩家自己的 BKB。一律走全局工具函数（`game/scripts/vscripts/util.lua`）：
+
+```lua
+ApplyAwakenMagicImmunity(unit, ability, duration)
+```
+
+已有相等或更长的 BKB 时跳过，否则加魔免 + 播音效，**返回是否实际施加**。
+
+**TS 代码优先用已有的 TS 封装**：`src/vscripts/abilities/ts_abilities/shared/awaken-magic-immunity.ts` 导出的 `applyAwakenMagicImmunity(unit, ability, duration)` 是同一逻辑的原生 TS 实现（同样借用 `modifier_black_king_bar_immune` 且不顶替真 BKB），直接 `import` 复用即可，不要再 `declare function` 绑定 Lua 全局。它与 Lua 版的差异是返回值：施加成功返回该 modifier 的句柄（`CDOTA_Buff`），跳过时返回 `undefined`（Lua 版返回布尔值）。
+
+**前摇加魔免要防取消刷新**：魔免绑在 `ON_ABILITY_START`（前摇开始）触发时，玩家可在前摇结束前取消再施法反复刷新（取消不进 CD、不耗蓝）。防法：仅当 `ApplyAwakenMagicImmunity` 返回 true 才启动取消检测；`StartIntervalThink` 轮询 `IsInAbilityPhase()`，前摇结束后若 `GetCooldownTimeRemaining() <= 0`（被取消）则移除；**移除前判据**——仅当 `modifier_black_king_bar_immune` 剩余 ≤ 本次魔免时长才 `Destroy()`，**绝不无条件 `RemoveModifierByName`**（同名 modifier 区分不了来源，会误删真 BKB）。
+
+> 参考：影魔 `special_bonus_unique_nevermore_upgrade.lua` 的 `OnIntervalThink` 取消检测；PA 闪烁/匕首魔免。
+
+### 进阶 6：纯被动标记技能改用 Modifier 展示（省技能栏空间）
+
+纯被动且描述简单的觉醒技能（典型如进阶 4 的「数值仅觉醒后生效」纯 KV 标记技能），不必占技能栏（castbar）一个槛位，可改用常驻 buff 图标展示：
+
+- KV：`AbilityBehavior` 加 `DOTA_ABILITY_BEHAVIOR_HIDDEN`（不进技能栏），同时加一个 `Modifiers` 子块，子 modifier 设 `"Passive" "1"` + `"IsHidden" "0"`（非隐藏，展示为常驻 buff 图标，自动复用 `AbilityTextureName` 做图标）。
+- 本地化：ability 自身的 `DOTA_Tooltip_ability_<name>` / `_Description` **保留不删**——觉醒预览页 `AwakenTab.tsx` 用 `DOTAAbilityImage` 读取的是 ability 的 tooltip，不是 modifier 的。额外补一组 `DOTA_Tooltip_modifier_<modifier_name>` / `_Description`，内容与 ability 标题/描述完全一致，确保游玩时看到的 buff tooltip 与觉醒页说明一致。
+- modifier 描述里若有写死的字面 `%` 号，**同样要转义成 `%%`**（不要因为是 modifier 就漏掉，规则与正文一致，见 CLAUDE.md 本地化文案规约）。
+- **modifier tooltip 不支持直接 `%key%` 读取 ability 的 `AbilityValues`**（会显示空白或吞掉百分号）；ability 自身的描述不受影响，仍可正常用 `%key%`。modifier 这边按实现方式分三种处理：
+  - **DataDriven 且数值挂在内置 `MODIFIER_PROPERTY_*`**（如 `MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE`、`MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT` 等标准属性，`Properties` 块里已声明）：**可以**直接动态取值，本地化写 `%dMODIFIER_PROPERTY_<属性名>%%%` 即可，引擎自动读取该 modifier 当前的属性值，**不需要**任何 RunScript/OnTooltip 代码，也**不需要**手动包白色粗体（项目里已有先例：`monkey_king_defy`、`insight_armor_aura`）。
+  - **DataDriven 且数值不对应任何内置 Property**（纯标记技能、无脚本）：没有代码可补，描述里**写死成具体数字**。
+  - **TS/Lua 脚本类 modifier**（`ability_lua` + `GetIntrinsicModifierName`，如进阶 3 的监听型觉醒）：数值若会变化（随等级、天赋等），**不要写死**——用 `MODIFIER_PROPERTY_TOOLTIP` 动态取值：`DeclareFunctions` 加 `ModifierFunction.TOOLTIP`，实现 `OnTooltip(): number` 返回目标值（如 `this.GetAbility()?.GetSpecialValueFor('xxx') ?? 0`），本地化里用 `%dMODIFIER_PROPERTY_TOOLTIP%%%` 占位（同一 modifier 最多两个动态值，第二个用 `MODIFIER_PROPERTY_TOOLTIP2`/`OnTooltip2`/`%dMODIFIER_PROPERTY_TOOLTIP2%`）。只有真正固定不变的数值才写死。**`%dMODIFIER_PROPERTY_TOOLTIP%` 不会像 ability 的 `%key%` 一样自动套白色粗体**（实测），需要手动包 `<font color='#FFFFFF'><b>...</b></font>`，和写死数值的处理方式一样（这条仅限自定义 `TOOLTIP`/`TOOLTIP2`，内置 Property 不受影响）。
+
+> 参考：寒冬飞龙觉醒 `special_bonus_unique_winter_wyvern_upgrade`（DataDriven 写死数值）；卓尔游侠裂影箭觉醒 `special_bonus_unique_drow_ranger_upgrade`（TS modifier，分裂概率会被天赋提升，用 `OnTooltip` 动态显示而非写死）；发条技师觉醒 `special_bonus_unique_rattletrap_upgrade_shield`（DataDriven 内置 Property 动态取值，`%dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%`）。
+
+### 进阶 7：借用原生 hardcoded modifier（如隐身）实现效果
+
+某些效果（如隐身）引擎有原生硬编码 modifier 支撑，但目标 KV 里查不到 `Modifiers` 块（完全编译进引擎，无法照抄），仍可在 TS 里直接 `AddNewModifier` 按名字借用：
+
+```ts
+const invis = parent.AddNewModifier(parent, this.GetAbility(), 'modifier_riki_backstab', {
+  duration,
+  fade_delay: fadeDelay,
+});
+```
+
+`duration` 参数通常能让原生 modifier 自动到期（如 `modifier_black_king_bar_immune`）。**若实机验证发现某个借用的原生 modifier 不吃 `duration` 自动移除**，改用 `Timers.CreateTimer(duration, callback)` 手动 `Destroy()`，`callback` 内先 `IsNull()` 判空再 `Destroy()`（防止已被其它途径提前移除时重复调用报错）：
+
+```ts
+if (!invis) return;
+Timers.CreateTimer(duration, () => {
+  if (invis.IsNull()) return;
+  invis.Destroy();
+});
+```
+
+原生 modifier 内部可能还支持其它同名参数覆写（如本例 `fade_delay`），具体哪些参数生效、哪些字段该从自身觉醒技能 KV 读取（而非硬编码），**没有文档，只能靠实机反复验证**，不要凭一次测试结果下结论。
+
+> 参考：风行者觉醒 `windrunner_whirlwind_custom`（`GetIntrinsicModifierName` 挂的被动 modifier）借用隐刺 `modifier_riki_backstab`；该被动与技能自身的主动 `OnSpellStart` 共存，二者互不影响——`GetIntrinsicModifierName` 不依赖 `AbilityBehavior`，主动大招可以正常保留 `IMMEDIATE | NO_TARGET` 之类行为。
+
+### 进阶 8：需要读取「施法者当前 AoE/属性加成」等动态值时，优先在自身 KV 声明同名字段
+
+想让觉醒技能的某个数值自动叠加施法者当前的 AoE 加成（或其他类似的引擎内置加成机制）时，**不要**用「哑值探测」手法（如声明一个 `value: "1"` 的占位数值加 `affected_by_aoe_increase: "1"`，再用 `GetSpecialValueFor() - 1` 反推出加成百分比、手动相加到别的数值上）。正确做法是直接在自身 KV 里声明目标字段本身（字段名与原版一致，如 `scepter_aura_radius`），带上同样的 `affected_by_aoe_increase: "1"`，让 `GetSpecialValueFor('scepter_aura_radius')` 直接返回已经计入加成的最终值。这样既不需要跨技能读取原版 KV，也不需要额外的相加逻辑，且能直接用 `%scepter_aura_radius%` 占位符内联进本地化正文（与原版写法一致）。
+
+### 进阶 9：运行时替换类技能的 `HasScepterUpgrade` + `scepter_description` 不会正常显示
+
+觉醒技能若是**运行时替换**（通过 `awaken-config.ts` 的 `targetAbility` 把原版技能整体换成新的 `ability_lua`），即使 KV 里带 `HasScepterUpgrade: "1"` 并写了 `_scepter_description`，引擎也不会渲染这个神杖对比预览面板——因为该面板依赖的是"英雄默认自带、原生学习"的技能实例，替换类技能走的是完全不同的运行时挂载路径。神杖相关的效果说明应直接写进主 `_Description` 正文（可加 `<font color='#92acf5'>阿哈利姆神杖</font>` 提示），不要指望 `_scepter_description` 单独显示。（注：常驻挂在英雄默认技能槽的觉醒技能，如 `imba_chaos_knight_phantasm`，`scepter_description` 可以正常显示，问题只出在替换类。）
+
+### 进阶 10：觉醒专属参数不要塞进原版技能的 override KV
+
+觉醒技能若需要「跟随某个原版技能的等级/天赋联动」某个数值（如领域半径随原版技能天赋扩大），**不要**为了图省事把这个觉醒专属的自定义字段直接写进 `npc_abilities_override.txt` 里原版技能自己的 `AbilityValues`——即使代码要通过 `FindAbilityByName(原版技能).GetSpecialValueFor('自定义字段')` 去读、需要蹭同一份天赋绑定，也不能把字段存放在原版技能身上。这样会让原版技能的差分文件里混入一个只有觉醒机制认识的字段，看 override 文件的人无法理解这个字段为什么存在，后续调整原版技能数值平衡时也容易误改或误删。
+
+正确做法：字段直接定义在觉醒技能自己的 KV 里；需要联动原版技能当前等级/天赋时，在代码里读取原版技能实例的等级/已生效数值，用公式在觉醒技能侧算出最终值，而不是让原版技能替觉醒机制保管参数。
+
+### 进阶 11：目标是「简化原版操作」时，优先包一层自动化外壳，不要重新实现原版机制
+
+有些觉醒诉求本质是「原版技能手动操作太繁琐，希望自动帮玩家完成」（如某个需要手动施放+手动收尾两步操作的技能，想在自动施法开启后全自动化）。这类需求容易被过度设计成一套全新机制（如引入持续 buff/领域/独立数值体系去模拟"自动化后应有的效果"），实际上完全不需要——原版技能自身的施法逻辑、命中判定、加成效果都不用动，觉醒技能只需要做**一层控制外壳**。
+
+这个方案还额外解决了英雄技能槽位已满、无法新增独立技能的问题：把原版技能隐藏（`SetHidden(true)`）挂在英雄身上而不是移除，觉醒技能占用同一个槽位对外显示，自身 KV 完整还原原版数值供玩家查看，内部通过代为调用原版技能的 `OnSpellStart()` 复用其全部效果——玩家看到的是"同一个技能位置多了自动施法能力"，而不是"技能被替换成了别的东西"。这是利用引擎已有机制实现最小改动的方式，槽位紧张、又只想加自动化能力时优先考虑这个思路。
+
+- 关闭自动施法：技能栏显示原版技能本体，玩家手动操作，行为与不觉醒时完全一致
+- 打开自动施法：觉醒技能的 intrinsic modifier 用 `OnIntervalThink` 周期检测触发条件（如冷却是否转好、范围内是否有合适目标），满足条件时**代替玩家调用原版技能自身的 `OnSpellStart()`**（而不是重新实现一遍技能效果），原版技能命中判定、加成、伤害全部原样生效；需要玩家原本手动点第二步操作（如某个收尾/确认技能）时，同样在检测循环里判断该技能是否可施放，可施放就代为调用
+
+判断「简化操作」类需求是否走偏了的信号：如果实现过程中出现了原版技能本身没有的新数值字段（半径、持续时间、加成档位）、新的 buff/debuff modifier、或者需要"叠加/覆盖原版效果"的逻辑，那大概率是把"自动化操作"和"改变技能效果"这两件事混在一起了——先回头确认需求到底是哪一种，多数"简化操作"类诉求只需要前者。代码代为触发 `OnSpellStart()` 时须补 `UseResources`，见 CLAUDE.md「常见陷阱」。
+
+**替换类觉醒仍需完整还原原版技能的 KV 数值和本地化文案**：这层"自动化外壳"不改变原版效果，因此觉醒技能自己的 KV（`AbilityValues`、`AbilityCooldown`、`AbilityManaCost`、`HasScepterUpgrade` 等）和本地化描述都应该与原版技能 + `npc_abilities_override.txt` 差分之后的最终值保持完全一致（玩家在未开自动施法时，看到的技能面板本质就是原版技能本身）。新增的自动施法说明追加在原版描述之后，不要替换掉原版的效果描述。
+
+> 参考：上古巨神觉醒 `elder_titan_ancestral_spirit_awaken`——自动施法开启后，冷却转好且附近有敌方英雄时自动朝最远的英雄施放先祖之魂（直接调用原版 `elder_titan_ancestral_spirit` 的 `OnSpellStart`），游魂可召回时自动调用原版 `elder_titan_return_spirit`，不新增任何数值/效果，原版命中加成、护甲魔抗削弱、KV 数值、本地化描述全部原样保留。

--- a/.claude/skills/custom-ability/SKILL.md
+++ b/.claude/skills/custom-ability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: custom-ability
-description: 从零自制一个全新自定义技能时使用——BaseClass 为 ability_datadriven / ability_lua / TS @registerAbility 的非继承技能。核心是「DataDriven vs Lua vs TS」实现选型（含性能取舍）与通用技法库（被动 intrinsic modifier、autocast 自动触发、施法监听、special_bonus 关联、加魔免）。区别于 clone-ability（继承原版差分克隆）与 awaken-ability（觉醒石替换槽位）。当用户说「写一个新技能」「自制技能」「这个技能用 datadriven/lua/ts 怎么写」「纯属性加成技能」「自动触发/施法监听技法」等时触发。
+description: 从零自制一个全新自定义技能时使用——非继承原版、非觉醒替换的技能，从零新增一律走 TS。先查可复用的原版 modifier，再写实现骨架（被动 intrinsic modifier、弹道命中判定）。区别于 clone-ability（继承原版差分克隆）与 awaken-ability（觉醒石替换槽位）。当用户说「写一个新技能」「自制技能」「这个技能怎么实现」等时触发。
 ---
 
 # 自定义技能（从零自制）
@@ -11,56 +11,61 @@ description: 从零自制一个全新自定义技能时使用——BaseClass 为
 | ---- | ---- |
 | 继承原版技能差分改数值/行为（`BaseClass` = 原版名） | `clone-ability` |
 | 觉醒石替换/插入英雄技能槽 | `awaken-ability` |
-| **从零自制**（`BaseClass` = `ability_datadriven` / `ability_lua` / TS `@registerAbility`） | **本 skill** |
+| **从零自制**（TS `@registerAbility`，KV `BaseClass` = `ability_lua`） | **本 skill** |
 
 > 图标、本地化、KV tab 缩进、`#base` 引入、技能系统名查找、参考文件路径 —— 全部见 CLAUDE.md「图片资源管理」「Dota 2 参考文件速查」与 `localization-format-guide`，本文不重复。
 
 ---
 
-## 第一步：实现方式选型（先定这个）
+## 第一步：先查复用
 
-| 技能内容 | 推荐实现 | 原因 |
-| ---- | ---- | ---- |
-| **含被动属性加成**（攻击/护甲/属性/移速/抗性…） | **DataDriven**（KV `Modifiers`→`Properties`） | 引擎原生求值，**无 per-frame Lua 回调**，性能最好 |
-| 无属性、逻辑简单 | **Lua 或 TS** | 看与周边一致 / 个人偏好 |
-| **逻辑复杂**（状态机、多文件依赖、要 jest、要复用 `src/` 类型） | **TS（TSTL）** | 类型安全；ts 编译不是负担（开发环境自动编译） |
-| 既有属性又有逻辑 | 属性走 DataDriven/KV，逻辑部分 Lua/TS | 各取所长 |
-| 已有 Lua 实现 | **保持 Lua** | 不强制迁移，无收益 |
+写之前**自己**先对着 `../shared-references/vanilla-modifiers.md` 过一遍——原版 modifier 是引擎原生 C++，能挑到就不用自己实现，**不用为此询问用户**。技能常用的是清单「通用状态」一节：眩晕、禁锢、沉默、无敌、击退、定时死亡、魔免，以及「原版技能 modifier」一节里的现成效果（背刺、霜箭减速、锚击瞬击标记）。
 
-**默认优先级**（同等可行时）：① DataDriven + 少量 Lua → ② TS → ③ 纯 Lua。
+清单只收录本仓已在用的，不是全集。里面没有但原版确实有对应技能时，按该文件「表外的怎么找」查出 modifier 名再试。
 
-- ①② 之间按**复杂度**选，不是「先试 ① 再升级」：简单/声明式走 ①，复杂/有状态（状态机、要 jest、复用 `src/` 类型）直接 ②。
-- ① 里的「少量 Lua」是补 DataDriven 的**动态值短板**（读运行时 spell amp / 智力等 KV 静态值表达不了的量），不写主体逻辑；那段 Lua 一旦不再「少量」、开始承载状态逻辑，就是切 ② 的信号。
-- ③ 仅指**维护已有纯 Lua**，不从零新写纯 Lua（既无类型又无声明式便利，是最差组合）。
+## 第二步：实现方式选型
 
-### 性能：高频查询的属性一律走 DataDriven
+**从零新增一律走 TS（TSTL）**——类型安全，能 jest，能复用 `src/` 的 helper 与类型；ts 编译不是负担（开发环境自动编译）。
 
-Lua modifier 的每个 `GetModifier*` 属性都是「引擎每次查询 → 回调一次 Lua」。单位越多、查询越频繁越卡。**以下属性用 Lua 实现会明显卡顿，纯数值加成时必须用 DataDriven `Properties`**：
+| 情况 | 怎么做 |
+| ---- | ---- |
+| **从零新增**（绝大多数） | **TS** |
+| 已有纯 Lua 实现 | **保持 Lua**，不强制迁移，无收益 |
+| 已有 DataDriven 实现 | **保持 DataDriven**，仅维护 |
 
-- 移速：`MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT` / `_PERCENTAGE`
-- 攻速 / 攻击伤害：`MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT`、`MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE`
-- 护甲 / 魔抗 / 状态抵抗：`MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS`、`MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS`、`MODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING`
-- 伤害增减：`MODIFIER_PROPERTY_DAMAGEOUTGOING_PERCENTAGE`、`MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE`、`MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE`
-- 属性：`MODIFIER_PROPERTY_STATS_STRENGTH_BONUS` / `_AGILITY_BONUS` / `_INTELLECT_BONUS`
+`ability_datadriven` **不用于从零新写**：技能通常没有常驻属性加成，DataDriven 的声明式优势用不上，反而丢掉类型检查。纯 Lua 同理，既无类型又无声明式便利，是最差组合。
 
-> 实测范例：`game/scripts/npc/npc_items_modifier.txt` —— 项目里这些属性加成**全部**因为卡顿迁成了 DataDriven `Modifiers`/`Properties`，不再用 Lua。新写纯属性技能照此办。
-
-> **例外（按规模豁免）**：上面「必须 DataDriven」针对的是**单位多 / 查询频繁**的规模。当 (1) 数值是**动态的**、DataDriven 静态 `%value` 表达不了（如召唤物要按召唤瞬间施法者的 spell amp / 智力放大），且 (2) 作用单位很少（几个召唤物），可用 Lua modifier：`OnCreated` 缓存一次值、`GetModifier*` 返回缓存，单查询开销可忽略。参考巫医觉醒 `special_bonus_unique_witch_doctor_upgrade`（死亡守卫按 spell amp 放大攻击）。
+> **例外：技能确实要挂常驻数值属性时**，Lua/TS modifier 的每个 `GetModifier*` 都是「引擎每查一次 → 回一次 Lua」，单位多时会卡。作用单位少（几个召唤物）可以照写，`OnCreated` 缓存一次值、`GetModifier*` 返回缓存即可（参考巫医觉醒 `special_bonus_unique_witch_doctor_upgrade`，死亡守卫按 spell amp 放大攻击）。作用面大且是纯静态常量时才值得改走 KV `Modifiers`→`Properties`；物品侧的完整取舍见 `custom-item` skill 的「回调税」一节。
 
 ---
 
-## 第二步：三种 BaseClass 的落点与骨架
+## 第三步：骨架
 
-### A. DataDriven（`ability_datadriven`）— 属性 / 声明式触发首选
+实现放 `src/vscripts/abilities/`（范例 `src/vscripts/abilities/ts_abilities/ward_slot/`），用装饰器自动注册，从 `utils/dota_ts_adapter` 扩展 `BaseAbility` / `BaseModifier`：
 
-KV 直接写 `Modifiers`，数值用 `%key` 引 `AbilityValues`（范式见 `npc_items_modifier.txt`）：
+```ts
+import { BaseAbility, registerAbility } from '../../utils/dota_ts_adapter';
+
+@registerAbility('my_ability')
+export class MyAbility extends BaseAbility {
+  OnSpellStart(): void { /* ... */ }
+}
+```
+
+KV `BaseClass` 写 `ability_lua`、`ScriptFile` 指向 TSTL 编译产物路径 `abilities/ts_abilities/<name>`。引擎枚举成员用 normalized 名（`UnitFilterResult.FAIL_CUSTOM`，见 CLAUDE.md）。
+
+被动技能标准写法：`GetIntrinsicModifierName()` 返回一个隐藏内置 modifier，无需学习即生效，可调值全从 KV `AbilityValues` 读。
+
+<details>
+<summary>维护已有 DataDriven / 纯 Lua 技能时的骨架（不用于从零新写）</summary>
+
+DataDriven：KV 直接写 `Modifiers`，数值用 `%key` 引 `AbilityValues`；含逻辑时用 `OnAbilityExecuted` / `OnIntervalThink` 等事件块 `RunScript` 调一段 Lua。
 
 ```
 "my_ability"
 {
     "BaseClass"             "ability_datadriven"
     "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_PASSIVE"
-    "AbilityTextureName"    "some_icon"
     "AbilityValues" { "bonus_armor" "10" }
     "Modifiers"
     {
@@ -75,43 +80,15 @@ KV 直接写 `Modifiers`，数值用 `%key` 引 `AbilityValues`（范式见 `npc
 }
 ```
 
-含逻辑时用 `OnAbilityExecuted` / `OnIntervalThink` 等事件块 `RunScript` 调一段 Lua（见技法库「施法监听」）。
+纯 Lua：实现放 `game/scripts/vscripts/abilities/<name>.lua`，`class({})` + `LinkLuaModifier`，**不经 TSTL**，改完 `script_reload` 热重载。KV `BaseClass` = `ability_lua`、`ScriptFile` = `abilities/<name>`。
 
-### B. 纯 Lua（`ability_lua`）
-
-实现放 `game/scripts/vscripts/abilities/<name>.lua`，`class({})` + `LinkLuaModifier`，**不经 TSTL**，改完 `script_reload` 热重载。被动技能标准写法：`GetIntrinsicModifierName()` 返回一个隐藏内置 modifier，无需学习即生效，可调值全从 KV `AbilityValues` 读。
-
-```lua
-my_ability = class({})
-function my_ability:GetIntrinsicModifierName() return "modifier_my_ability" end
-
-LinkLuaModifier("modifier_my_ability", "abilities/my_ability", LUA_MODIFIER_MOTION_NONE)
-modifier_my_ability = class({})
-function modifier_my_ability:IsHidden() return true end
-```
-
-KV `BaseClass` = `ability_lua`，`ScriptFile` = `abilities/<name>`。
-
-### C. TS（TSTL）— 逻辑复杂 / 要复用 src 类型
-
-实现放 `src/vscripts/abilities/`（范例 `src/vscripts/abilities/ts_abilities/ward_slot/`），用装饰器自动注册，从 `utils/dota_ts_adapter` 扩展 `BaseAbility` / `BaseModifier`：
-
-```ts
-import { BaseAbility, registerAbility } from '../../utils/dota_ts_adapter';
-
-@registerAbility('my_ability')
-export class MyAbility extends BaseAbility {
-  OnSpellStart(): void { /* ... */ }
-}
-```
-
-KV `BaseClass` 同样写 `ability_lua`、`ScriptFile` 指向 TSTL 编译产物路径。引擎枚举成员用 normalized 名（`UnitFilterResult.FAIL_CUSTOM`，见 CLAUDE.md）。
+</details>
 
 ---
 
 ## 进阶技法
 
-觉醒及「自动施放」类技法——autocast 自动触发（含共享基类 `AutoCastAbility`）、监听某技能施法、加魔免不顶 BKB、`special_bonus` 仅特定技能时生效——目前都只由觉醒技能使用，集中在 **`awaken-ability`** 的「进阶」章节，需要时去那里查。
+autocast 自动触发（共享基类 `AutoCastAbility`）、监听某技能施法、加魔免不顶 BKB、`special_bonus` 仅特定技能时生效、借用原生 hardcoded modifier —— 这些目前都只由觉醒技能使用，集中在 `../awaken-ability/references/advanced-techniques.md`，需要时按标题去查。
 
 ### 弹道命中判定：用原生 `OnProjectileHit`
 
@@ -124,12 +101,11 @@ KV `BaseClass` 同样写 `ability_lua`、`ScriptFile` 指向 TSTL 编译产物�
 - **图标 / 本地化 / `#base` 引入新 KV 文件** → 见 CLAUDE.md 与 `localization-format-guide`。
 - **进抽奖池** → 在 `src/vscripts/modules/lottery/lottery-abilities.ts`（及 `lottery-abilities-bot.ts`）加技能名。
 - **bot 会用** → 见 `bot-ability-usage`。
-- **验证** → 纯 Lua `script_reload` 实跑；TS 仅在收尾跑一次 `npm run build:vscripts` 看是否报错，不读编译产物；运行时行为靠 jest（自己的分支逻辑）+ Dota tools 实跑。
+- **验证** → 收尾跑一次 `npm run build:vscripts` 看是否报错，不读编译产物；运行时行为靠 jest（自己的分支逻辑）+ Dota tools 实跑。维护已有纯 Lua 时 `script_reload` 实跑。
 
 ## 不明确时询问
 
 用 `AskUserQuestion` 菜单确认，不要自行假设：
-- 实现方式（datadriven / lua / ts）当语义不明时
 - 技能是被动属性、主动逻辑还是混合
 - 主动技是否做成 autocast 自动触发
 - 数值是「全局对该英雄生效」还是「仅拥有某技能时生效」

--- a/.claude/skills/custom-item/SKILL.md
+++ b/.claude/skills/custom-item/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: custom-item
-description: 从零自制一个全新自定义物品时使用——BaseClass 为 item_datadriven 或 item_lua 的非克隆物品（含多材料合成神器）。核心是「item_datadriven 整体 KV 化 vs item_lua + item_apply_modifiers 共享 hub」选型，以及合成配方/ID 分配惯例。区别于 clone-item（继承原版数值倍率克隆）。当用户说「做一个新物品」「合成神器」「这个物品属性会不会卡顿」「item_lua 还是 item_datadriven」等时触发。
+description: 从零自制全新自定义物品（BaseClass = item_datadriven / item_lua，含多材料合成神器）。复用原版 modifier、两模式选型「DataDriven 主体」与「TS 主体」、回调税与镜像值取舍、合成配方与 ID 分配。区别于 clone-item（原版倍率克隆）。当用户说「做一个新物品」「合成神器」「物品属性会不会卡顿」「item_lua 还是 item_datadriven」时触发。
 ---
 
 # 自定义物品（从零自制）
-
-做一个**全新**物品（不是把某个原版物品数值翻倍）。先用下表确认这是不是该用的 skill：
 
 | 场景 | skill |
 | ---- | ---- |
@@ -16,24 +14,136 @@ description: 从零自制一个全新自定义物品时使用——BaseClass 为
 
 ---
 
-## 第一步：整体实现方式选型（先定这个，不是逐条属性决定）
+## 第一步：先查复用
 
-```dot
-digraph item_baseclass {
-    "物品有 DataDriven 表达不了的逻辑？\n（动态计算/百分比层数/ABSORB_SPELL/\nPROCATTACK_FEEDBACK/条件判断型属性/复杂状态机）" [shape=diamond];
-    "BaseClass = item_datadriven\n属性写自己 KV 的 Modifiers→Properties\n主动技能用 OnSpellStart 的 DataDriven Actions" [shape=box];
-    "BaseClass = item_lua（本体推荐 TS）\n纯数值属性挪进 item_apply_modifiers 共享 hub\nLua/TS modifier 只手写表外逻辑" [shape=box];
+判模式之前**自己**先对着 `../shared-references/vanilla-modifiers.md` 过一遍，命中就直接复用，整条选型链都不用走，**不用为此询问用户**：
 
-    "物品有 DataDriven 表达不了的逻辑？\n（动态计算/百分比层数/ABSORB_SPELL/\nPROCATTACK_FEEDBACK/条件判断型属性/复杂状态机）" -> "BaseClass = item_datadriven\n属性写自己 KV 的 Modifiers→Properties\n主动技能用 OnSpellStart 的 DataDriven Actions" [label="没有"];
-    "物品有 DataDriven 表达不了的逻辑？\n（动态计算/百分比层数/ABSORB_SPELL/\nPROCATTACK_FEEDBACK/条件判断型属性/复杂状态机）" -> "BaseClass = item_lua（本体推荐 TS）\n纯数值属性挪进 item_apply_modifiers 共享 hub\nLua/TS modifier 只手写表外逻辑" [label="有"];
-}
+- 需求里出现「继承 / 参照 / 基于某个原版装备」→ 直接套那件装备的 modifier，字段名照抄它的 `AbilityValues`
+- 效果是通用状态（魔免、眩晕、禁锢、沉默、无敌、击退、定时死亡）→ 清单「通用状态」一节直接有
+- 效果与某个原版物品或英雄技能的现成行为一致（溅射、减甲、反伤、缴械、位移、真视）→ 查清单对应行
+
+清单只收录了本仓已在用的，**不是全集**。清单里没有但原版确实有对应物品/技能时，按该文件「表外的怎么找」查出 modifier 名再试，别直接转为自己实现。反过来也不要硬凑：语义不符的原版 modifier 会连带它自己的其它行为和属性一起生效，比自己写更难排查。
+
+在自己 KV 里按**原版字段名**写值，`AddNewModifier` 时把自己的 ability 传进去，原版 modifier 就按这些值工作——它是引擎原生 C++，不交回调税，而且**连属性一起复用**。
+
+`item_magic_crit_blade` 自己的 `Modifiers` 块里**一条 `Properties` 都没有**，智力 200 / 攻速 80 / 护甲 14 全部由 `modifier_item_devastator` 提供：
+
+| 字段 | 原版 `item_devastator` | `item_magic_crit_blade` |
+| --- | --- | --- |
+| `bonus_intellect` | 40 | 200 |
+| `bonus_attack_speed` | 40 | 80 |
+| `int_damage_multiplier` | 0.75 | 1.25 |
+| `active_mres_reduction` | 20 | 40 |
+
+因此这条路径同时避开两个模式的主要代价：
+
+| | 复用原版 modifier | 模式 1 自己写 `Properties` | 模式 2 下沉 `item_apply_modifiers` |
+| --- | --- | --- | --- |
+| 属性声明 | **不用写** | 要写 `Properties` | 要写 `_stats` |
+| 数值真相源 | **物品自己 KV，一处** | 一处 | 两处（+镜像值） |
+| tooltip | **直接 `%字段名`** | 直接引 | 要写 `_tooltip` 镜像 |
+| 逻辑代码量 | **0** | Actions | TS |
+
+仓库里 7 个物品这么做：`item_beast_armor`（刃甲）、`item_beast_shield`（永世法衣）、`item_hawkeye_turret`（黯灭）、`item_magic_crit_blade`（圣斧）、`item_magic_sword`（狂战斧 + 黯灭）、`item_forbidden_staff`（缚灵索）、`item_shadow_impact`（绝刃）。
+
+### 三条机制规则
+
+字段名从 `docs/reference/<version>/items.txt` 抄，**逐条核对**，这三条踩中都不会报错，只会数值悄悄不对：
+
+1. **按需取用**——只写你要的字段。不写的字段对应效果就不生效，不必完整复制原版 `AbilityValues`。不想要某个子效果时，删掉 key 或填 `0` 都可以（`item_magic_sword` 把 `bonus_damage_per_kill` 等显式写 `0`，表达"知道有这个效果，主动关了"）。
+2. **写了就一定被套用**——自己的 `Properties` **不要**再声明同名属性，否则原版 modifier 加一次、自己的 `Properties` 再加一次，**数值双倍**。
+3. **多个原版共有字段会各读一次**——复用两个以上原版 modifier 时，先查它们 `AbilityValues` 的交集。落在交集里的字段会被每个 modifier 各加一次。
+
+### 字段冲突了怎么办
+
+**默认让原版提供**（保持原版字段名，自己不写 `Properties`）——行数最少，字段名自解释。`item_beast_armor` 的 `bonus_armor` 60 就是这么交给刃甲的。
+
+命中下面任一条才**改名规避**（换个原版读不到的字段名，自己 `Properties` 提供）：
+
+- 多个原版共有同名字段，必须拆开 —— `item_magic_sword` 复用狂战斧 + 黯灭，两者都有 `bonus_damage`，于是 KV 里不写这个字段，改用 `bonus_damage_passive` 由自己提供，两个原版都读不到
+- 原版该字段值为 `0` 或明显是遗留字段 —— 随时可能在版本同步中被删掉，属性会静默消失
+- 该数值属于本物品自己的一组属性，不想被原版行为左右 —— 如 `item_beast_armor` 的 `bonus_intellect_passive` 与 `bonus_strength` / `bonus_agility` 同属"全属性"三件套
+
+改名会连带影响本地化：stat tooltip 的 key 是 `DOTA_Tooltip_ability_<物品名>_<字段名>`，字段改名后这一行也要改。
+
+排查已有物品是否踩中规则 2、3 的方法 → `references/datadriven-scope.md`。
+
+---
+
+## 第二步：选模式
+
+复用消化不掉的部分，**只有两个模式**。
+
+| | 模式 1「**DataDriven 主体**」 | 模式 2「**TS 主体**」 |
+| ---- | ---- | ---- |
+| `BaseClass` | `item_datadriven` | `item_lua` |
+| 属性住在 | 物品自己 KV 的 `Modifiers` → `Properties` | `item_apply_modifiers` 的 `_stats` |
+| 逻辑住在 | KV 的 Actions 块；不够时 `RunScript` 调原生 Lua **全局函数** | `src/vscripts/items/ts_items/<name>.ts` |
+| 数值真相源 | **一处** | 两处（真值 + 镜像值） |
+| modifier 清空 | **引擎自动** | 三处生命周期手动对齐 |
+| 类型检查 / jest | 无 | **有** |
+| 仓库存量 | 18 纯 KV + 20 带 RunScript | 7 |
+
+**唯一弃用的写法**：`item_lua` + 手写 `class({})` 原生 Lua（35 个存量）—— 既无类型又无声明式便利。存量不迁移，改动存量物品时按原写法继续，不顺手重构。
+
+### 分界：表外的是「动作」还是「modifier」
+
+先查 `references/datadriven-scope.md` 判断哪些部分 DataDriven 表达不了（查表，不要凭记忆）。表外的部分再看它是什么形态：
+
+- 表外的是一段**动作**——造伤害、生成单位、挂个原版 modifier、发金币、整理场上物品 → **模式 1**，`RunScript` 写成 Lua 全局函数
+- 表外的是一个**常驻 modifier**——`ABSORB_SPELL`、`PROCATTACK_FEEDBACK`、带记账的 `OnAttackLanded`、内置冷却、跨实例状态同步 → **模式 2**
+
+**可检查的越界信号**：模式 1 的 Lua 文件里一旦出现 `LinkLuaModifier` + `class({})`，就已经掉进弃用写法了，该走模式 2。仓库 13 个样本无一例外——10 个纯全局函数的（11~179 行）都健康，3 个长出 `class({})` 的（`item_beast_armor` 195 行 / `item_hawkeye_turret` 256 行 / `item_magic_crit_blade` 193 行）正是当初该写成 TS 的。注意这三个越界的原因是**那个手写 modifier**，不是它们复用原版 —— 复用部分本身是干净的。
+
+**行数不是判据**，`item_collector` 179 行全是全局函数，仍然是干净的模式 1。
+
+### 回调税
+
+Lua/TS modifier 的每个 `GetModifier*` 都是「引擎每查一次 → 回一次 Lua」。单位越多、查询越频繁越卡，这就是**回调税**。DataDriven `Properties` 由引擎原生求值，不交税。
+
+所以**永久数值常量属性一律不写在 TS 里**：模式 1 写自己 KV，模式 2 下沉 `item_apply_modifiers`。项目里这些属性早已全量迁走（`npc_items_modifier.txt` 27 个 `_stats` 块），新物品照此办。
+
+`item_lua` 的 KV **不支持**自己的 `Modifiers` 块（全仓 0 例），这正是 `item_apply_modifiers` 存在的原因，不是风格选择。
+
+### 镜像值：模式 2 的代价
+
+`item_apply_modifiers` 是一件谁也不持有的全局单例假物品，`_stats` 的 `%value` 只能引它自己的 `AbilityValues`（键须加 `<物品名>_` 前缀）。物品 tooltip 引不到那里，同一个数字因此要写两处：
+
+```kv
+// npc_items_modifier.txt → item_apply_modifiers 的 AbilityValues：真值
+"item_saint_orb_bonus_all_stats"    "30"
+
+// npc_items_custom.txt → item_saint_orb 自己的 AbilityValues：镜像值，只为 tooltip 显示
+"bonus_all_stats_tooltip"           "30"
 ```
 
-决策只看「这个物品整体要不要 Lua」，不要纠结「这一条属性放哪」——属性层面的取舍只在「物品已经因为别的原因留着 Lua」的前提下才有意义。
+改数值必须手动同步两处，没有任何机制会报错。模式 1 没有这个问题——数值只有一处，tooltip 直接引同一个键。
 
-**完整可迁移属性列表 / 必须 Lua 列表 / hub 用法（A 永久绑定物品 / B 永久不绑定 / C 临时 buff）** → 见 `references/datadriven-scope.md`，查表使用，不要凭记忆判断属性是否可 DataDriven。
+---
 
-### A. 纯 `item_datadriven`（无 Lua intrinsic modifier）
+## 第三步：modifier 的挂载与清空
+
+**清空责任跟着挂法走**，挂法选错就要自己补记账。
+
+| 挂法 | 谁负责清空 | 用在 |
+| ---- | ---- | ---- |
+| 物品自己 KV 的 `Modifiers` | **引擎**，随物品得失自动挂摘 | 模式 1 |
+| KV `ApplyModifier` 挂原版 modifier + `Duration` | **引擎**，时限到期 | 模式 1 主动技能 |
+| 脚本 `AddNewModifier` 挂**带 duration** 的 modifier | **引擎**，时限到期 | 两个模式 |
+| 脚本 `AddNewModifier` 挂**永久**原版 modifier | **自己**，`ability.added_modifiers` 数组 + `OnDestroy` 遍历 `Destroy()` | 两个模式 |
+| `item_apply_modifiers` 的 `_stats` | **`RefreshItemDataDrivenModifier`**，`OnCreated`/`OnRefresh`/`OnDestroy` 三处都要调 | **只有模式 2** |
+
+**`item_apply_modifiers` 只属于模式 2**：27 个 `_stats` 对应的物品 100% 是 `item_lua`，没有一个 `item_datadriven`。模式 1 有自己的 `Modifiers` 块，不需要也不应该碰它。
+
+模式 1 挂**永久**型原版 modifier 时，把 DataDriven modifier 自身的 `OnCreated` / `OnDestroy` 事件块当钩子用（范例 `item_beast_armor`）——这两个回调由引擎随物品得失触发，比自己判断时机可靠。多个原版 modifier 的批量记账写法 → `references/datadriven-scope.md`。
+
+---
+
+## 第四步：模式骨架
+
+### 模式 1「DataDriven 主体」
+
+数值与触发在同一个 KV 块内。范例 `item_wasp_despotic`（零脚本：`Random` / `ApplyModifier` / `RemoveModifier` / `FireSound` 串出概率暴击 + 主动增益）：
 
 ```kv
 "item_my_new_item"
@@ -47,7 +157,7 @@ digraph item_baseclass {
         "modifier_item_my_new_item"
         {
             "Passive"        "1"
-            "IsHidden"        "1"
+            "IsHidden"       "1"
             "Attributes"     "MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_MULTIPLE | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
             "Properties" { "MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor" }
         }
@@ -55,11 +165,22 @@ digraph item_baseclass {
 }
 ```
 
-主动技能优先用 `OnSpellStart` 的 DataDriven Actions（`FireSound`、`ApplyModifier`、`Damage` 等，完整列表见 [Valve Wiki Actions](https://developer.valvesoftware.com/wiki/Dota_2_Workshop_Tools/Scripting/Abilities_Data_Driven#Actions)）。仅当 Actions 也表达不了时，才用 `RunScript` 调一段**原生 Lua** 函数（`ScriptFile` 指向 `game/scripts/vscripts/items/<name>.lua`，引擎机制决定不经 TSTL，不是选择）。范例：`item_beast_armor`、`item_hawkeye_turret`。
+Actions 完整清单见 [Valve Wiki](https://developer.valvesoftware.com/wiki/Dota_2_Workshop_Tools/Scripting/Abilities_Data_Driven#Actions)。KV 里也可以直接 `ApplyModifier` 一个原版 modifier（范例 `item_beast_shield` 的 `modifier_black_king_bar_immune`），不必先在自己的 `Modifiers` 块里声明。
 
-### B. `item_lua`（本体推荐 TS）
+**Actions 表达不了时接 RunScript**，Lua 放 `game/scripts/vscripts/items/<name>.lua`，只写全局函数：
 
-实现放 `src/vscripts/items/ts_items/`，物品本体继承 `BaseItem`、intrinsic modifier 继承 `BaseItemModifier`（`src/vscripts/items/ts_items/base_item_modifier.ts`），范例见 `item_saint_orb.ts`：
+```kv
+"OnSpellStart"
+{
+    "RunScript" { "ScriptFile" "items/item_my_new_item"  "Function" "MyNewItemOnSpell" }
+}
+```
+
+`RunScript` 的 `ScriptFile` 必须是原生 Lua——TSTL 产物是模块包装，函数不在文件全局作用域，仓库无先例。要写 TS 就走模式 2，不要试图让 RunScript 指向编译产物。
+
+### 模式 2「TS 主体」
+
+KV `BaseClass` = `item_lua`，`ScriptFile` 指向 `items/ts_items/<name>`；实现放 `src/vscripts/items/ts_items/`，物品本体继承 `BaseItem`、intrinsic modifier 继承 `BaseItemModifier`。范例 `item_saint_orb.ts`、`item_six_paths_reincarnation_gun.ts`：
 
 ```ts
 import { BaseItem, registerAbility, registerModifier } from '../../utils/dota_ts_adapter';
@@ -74,28 +195,23 @@ export class ItemMyNewItem extends BaseItem {
 
 @registerModifier('items/ts_items/item_my_new_item', 'modifier_item_my_new_item_passive')
 export class ModifierItemMyNewItemPassive extends BaseItemModifier {
-  override statsModifierName = 'modifier_item_my_new_item_stats'; // 留空字符串 '' 表示不用 hub
-  // 仅手写 references/datadriven-scope.md 列表之外的逻辑
+  override statsModifierName = 'modifier_item_my_new_item_stats'; // 无永久属性时填 ''
+  // 只手写 references/datadriven-scope.md 表外的逻辑
 }
 ```
 
-KV `BaseClass` = `item_lua`，`ScriptFile` 指向 TSTL 编译产物路径。已有 51 个物品是历史遗留的**原生 Lua**（`game/scripts/vscripts/items/*.lua`，手写 `class({})` + `LinkLuaModifier`），不强制迁移，但新建一律走 TS。原生 Lua 写法仍可参考 `item_swift_glove.lua` 理解 hub 调用时机（`OnCreated` 必须先调 `OnRefresh`，`OnRefresh`/`OnDestroy` 都调 `RefreshItemDataDrivenModifier`）。
+`BaseItemModifier` 已实现三个生命周期的 `_stats` 同步（按背包里该物品实例数对齐层数）。**override 这三个回调时必须调 `super.XXX()`**，否则属性静默失效。
 
-**标准流程**：物品新增的 modifier 若是可见 buff/debuff（`IsHidden()` 为 `false`，比如主动技能生成的增益/减益），都应显式加一个 `GetTexture()` 覆盖，返回该物品的系统注册名：
+物品若压根没有永久属性（消耗品 / 工具类，7 个 TS 物品有 4 个如此），`statsModifierName` 填 `''`，完全不碰 `item_apply_modifiers`。
 
-```ts
-GetTexture(): string {
-  return 'item_my_new_item'; // 带 item_ 前缀，即该物品的注册名
-}
-```
+**两个易踩的坑**：
 
-`GetTexture()` 返回的是**物品/技能的系统注册名**（带 `item_`/`ability_` 前缀），引擎据此找到该物品 KV 的 `AbilityTextureName` 再定位 `spellicons/`/`items/` 下的实际 png，**不是**贴图文件名本身。
-
-手写 TS modifier 时容易踩的坑：`StartIntervalThink(interval)` 的**第一次** `OnIntervalThink` 会立即触发，不是等一个 interval 后才触发。若逻辑是"每隔 N 秒造成一次伤害/效果"，需要用一个标记跳过首次回调，否则创建瞬间就会多结算一次。
+- 物品新增的**可见** buff/debuff（`IsHidden()` 为 `false`）都要显式覆盖 `GetTexture()`，返回该物品的**系统注册名**（带 `item_` 前缀）。引擎据此找到物品 KV 的 `AbilityTextureName` 再定位实际 png，**不是**贴图文件名本身。
+- `StartIntervalThink(interval)` 的**第一次** `OnIntervalThink` 立即触发，不是等一个 interval。「每隔 N 秒结算一次」的逻辑需要用标记跳过首次回调，否则创建瞬间就多结算一次。
 
 ---
 
-## 第二步：合成配方（Recipe）
+## 第五步：合成配方与 ID
 
 ```kv
 "item_recipe_my_new_item"
@@ -114,47 +230,51 @@ GetTexture(): string {
 }
 ```
 
-- 每个 `"0N"` 是一个**槽位**（AND 关系，全部槽位都要满足才能合成），槽位内用 `;` 分隔的是**该槽位的可选项**（OR 关系）。OR 列表里若混有 `item_fusion_agile` 这类无属性的纯令牌材料，习惯把它排在该槽位**最后一个**（参考 `item_recipe_ten_thousand_swords` 的写法），真正有数值的材料排在前面。
-- **多路径合成**（同一神器允许从不同顺序的中间合成品拼出来，如 `item_recipe_sacred_trident` 用 4 个槽位覆盖 3 种两两合成顺序）属于高级用法，仅在用户明确要求"任意顺序都能合成"时才用，默认给单一路径即可。
-- `ItemCost`（图纸费）/ 物品本体 `ItemCost`（合成后总价）：没有强制公式，按"材料总价 + 图纸费 = 物品总价"反推,具体数值找用户确认或参考同类神器定价。
-
-### 配方材料变更时的属性取舍
-
-多路径融合神器（`"01"` 槽位用 `;` 列出可选材料）的成品属性通常是**固定值**，与具体走哪条路径无关（先例：`item_fusion_agile` 是无属性的纯令牌材料，仅作为合成条件）。当配方新增/替换某个可选材料时，不要默认「维持固定属性不变」或「把新材料的全部数值/机制直接合并进成品」，而是按材料的投入成本分情况，用 `AskUserQuestion` 给出 2~3 档选项让用户取舍：
-
-- 廉价/限购令牌材料（如 `item_fusion_agile`）：不贡献属性，维持现状即可
-- 高价值神器材料（数千至数万金）：其独有数值（伤害/护甲/生命回复等）完全丢弃会显得浪费投入，可考虑追加一两条简单数值；但触发型机制（换血、连锁效果、主动单体增益等）通常不直接带入，否则成品会堆叠过多技能机制
-- 每档明确标注舍弃了哪些机制，不要自行拍板
-
-若某个可选材料的主动技能要求**继承**到成品上（而不是被丢弃），需要三处同步，缺一不可：
-1. KV：成品的 `AbilityBehavior` 改为目标型行为，补齐 `AbilityUnitTarget*`、`AbilityCastRange` 等字段，以及该主动原有的充能/共享冷却机制
-2. Lua/TS：把源材料的 `OnSpellStart` 逻辑搬到成品的实现里（充能消耗判定也要改成检查成品自己的物品名）
-3. bot 会用：除 `bot-ability-usage` 的 AbilitySpec 注册外，检查 `ai/item/use-item.ts` 等按物品名硬编码调用的文件——这类文件不会因为复用了同一段技能逻辑就自动识别新物品，必须显式加一行调用，否则 bot 永远不会对新物品施放这个主动技能
+- 每个 `"0N"` 是一个**槽位**（槽位之间 AND，全部满足才能合成），槽位内用 `;` 分隔的是**该槽位可选项**（OR）。OR 列表里若混有 `item_fusion_agile` 这类无属性纯令牌材料，习惯排在该槽位**最后**（参考 `item_recipe_ten_thousand_swords`），有数值的材料排前面。
+- **多路径合成**（同一神器允许不同顺序的中间品拼出，如 `item_recipe_sacred_trident` 用 4 个槽位覆盖 3 种顺序）仅在用户明确要求"任意顺序都能合成"时才用，默认单一路径。
+- `ItemCost`：按「材料总价 + 图纸费 = 物品总价」反推，具体数值找用户确认或参考同类神器定价。
 
 ### ID 分配
 
-自制物品（非克隆）需要显式 `"ID"` 字段。取 `game/scripts/npc/npc_items_custom.txt` 中所有 `"ID"` 字段的当前最大值 + 1：
+自制物品（非克隆）需要显式 `"ID"`。取 **`game/scripts/npc/npc_items*.txt` 全部文件**中 `"ID"` 的最大值 + 1 —— 各文件 ID 段互相交错（custom 3021 起、artifact 9623 起，同一段内混排），只扫一个文件会撞号。
 
 ```
 Grep pattern: "ID"
-files: game/scripts/npc/npc_items_custom.txt
+files: game/scripts/npc/npc_items_*.txt
 ```
 
 ID 一旦写入不要再改（项目内已有惯例注释："Do not change this once established"）。
 
+### 配方材料变更时的属性取舍
+
+多路径融合神器的成品属性通常是**固定值**，与走哪条路径无关（先例：`item_fusion_agile` 是无属性纯令牌，仅作合成条件）。当配方新增/替换某个可选材料时，不要默认「维持固定属性不变」或「把新材料全部数值直接合并进成品」，按材料投入成本用 `AskUserQuestion` 给 2~3 档让用户取舍：
+
+- 廉价/限购令牌材料：不贡献属性，维持现状
+- 高价值神器材料（数千至数万金）：其独有数值（伤害/护甲/生命回复等）完全丢弃显得浪费投入，可考虑追加一两条简单数值；但触发型机制（换血、连锁效果、主动单体增益等）通常不带入，否则成品堆叠过多机制
+- 每档明确标注舍弃了哪些机制，不要自行拍板
+
+若某个可选材料的**主动技能**要求继承到成品（而非丢弃），三处同步缺一不可：
+
+1. KV：成品 `AbilityBehavior` 改为目标型，补齐 `AbilityUnitTarget*` / `AbilityCastRange`，以及该主动原有的充能 / 共享冷却机制
+2. 脚本：把源材料的 `OnSpellStart` 逻辑搬到成品实现里（充能消耗判定也要改成检查成品自己的物品名）
+3. bot 会用：除 `bot-item-usage` 的 ItemSpec 登记外，检查按物品名硬编码调用的文件——复用同一段技能逻辑**不会**让 bot 自动识别新物品，必须显式加一行
+
 ---
 
-## 第三步：收尾
+## 第六步：收尾
 
-- **图标 / 本地化 / `#base` 引入新 KV 文件** → 见 CLAUDE.md 与 `localization-format-guide`（物品同时有主动+被动时，两段 `<h1>` 之间用 `\n` 分隔，不要用 `<br><br>`，见该 skill 换行符规则一节）。
-- **物品 KV 路径** → `game/scripts/npc/npc_items_custom.txt`（自制物品本体）；`game/scripts/npc/npc_items_modifier.txt`（`item_apply_modifiers` 共享 hub，仅放 `_stats`/独立永久 BUFF/临时 buff 的 DataDriven modifier，不放物品本体）。
-- **bot 会用** → 参考 `bot-ability-usage` 的施法规则写法（物品同理登记到对应 AI 配置）。
-- **验证** → 原生 Lua `script_reload` 实跑；TS 仅在收尾跑一次 `npm run build:vscripts` 看是否报错，不读编译产物；运行时行为靠 jest（自己的分支逻辑）+ Dota tools 实跑。
+- **图标 / 本地化 / `#base` 引入新 KV 文件** → CLAUDE.md 与 `localization-format-guide`（物品同时有主动 + 被动时，两段 `<h1>` 之间用 `\n` 分隔，不要用 `<br><br>`）
+- **KV 落点** → 普通自制物品 `npc_items_custom.txt`；龙珠/祝福等神器系列 `npc_items_artifact.txt`；`item_apply_modifiers` 的 `_stats` 与独立 DataDriven modifier `npc_items_modifier.txt`（**不放**物品本体）
+- **bot 会买 / 会用** → `bot-item-build`（购买决策）、`bot-item-usage`（战斗使用）
+- **验证** → 改 KV 后重启 Dota Tools（`script_reload` 不重读 KV）；模式 1 的 Lua 改完 `script_reload` 即可；模式 2 收尾跑一次 `npm run build:vscripts` 只看报错，不读编译产物，运行时行为靠 jest（自己的分支逻辑）+ Dota Tools 实跑
+- **复用过原版 modifier 的物品**，实机确认属性数值与 KV 一致（双倍是静默的，tooltip 显示的是 KV 值，不是实际生效值）
 
 ## 不明确时询问
 
 用 `AskUserQuestion` 菜单确认，不要自行假设：
-- 整体实现方式（`item_datadriven` 全 KV / `item_lua`+TS）当物品同时含属性和逻辑、语义不明时
-- 某条属性是否「表外」必须留 Lua，存在歧义时（先查 `references/datadriven-scope.md`，仍不确定才问）
+
+- 模式选型：表外部分是「动作」还是「常驻 modifier」语义不明时
+- 字段冲突用「让原版提供」还是「改名规避」，判据不唯一时
+- 某条属性是否表外（先查 `references/datadriven-scope.md`，仍不确定才问）
 - 合成材料、配方费用、物品总价
 - 是否需要多路径合成

--- a/.claude/skills/custom-item/references/datadriven-scope.md
+++ b/.claude/skills/custom-item/references/datadriven-scope.md
@@ -1,34 +1,46 @@
-# DataDriven 可表达范围与 Lua 落点参考
+# DataDriven 可表达范围与 `item_apply_modifiers` 用法
 
-供 `custom-item` 第一步「整体实现方式选型」与第二步「属性拆分」查表使用。
+供 `custom-item` 第二步「选模式」查表使用。官方文档：https://developer.valvesoftware.com/wiki/Dota_2_Workshop_Tools/Scripting/Abilities_Data_Driven
 
-官方文档：https://developer.valvesoftware.com/wiki/Dota_2_Workshop_Tools/Scripting/Abilities_Data_Driven
+## 可写进 `Properties` 的属性
 
-## 可迁移到 DataDriven `Properties` 的属性
-
-只有以下属性可以直接写 KV `Properties`（无论物品本身是 `item_datadriven` 自带 `Modifiers`，还是 `item_lua` 挪进 `item_apply_modifiers` 的 `_stats` 子 modifier）：
+下列属性可直接写 KV `Properties`（模式 1 写物品自己的 `Modifiers`，模式 2 写 `item_apply_modifiers` 的 `_stats`）。**均为本仓已在用的**，出现次数取自 `npc_items_custom.txt` / `npc_items_artifact.txt` / `npc_items_modifier.txt`：
 
 **基础属性**
+
 - `MODIFIER_PROPERTY_STATS_STRENGTH_BONUS` / `_AGILITY_BONUS` / `_INTELLECT_BONUS`
 
 **攻击相关**
+
 - `MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE`、`MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT`
 - `MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE`、`MODIFIER_PROPERTY_ATTACK_RANGE_BONUS`
+- `MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE`（暴击倍率；触发概率用 `Random` 事件块，见下）
 
 **防御相关**
-- `MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS`、`MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS`、`MODIFIER_PROPERTY_EVASION_CONSTANT`
+
+- `MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS`、`MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS`
+- `MODIFIER_PROPERTY_EVASION_CONSTANT`、`MODIFIER_PROPERTY_MISS_PERCENTAGE`
+- `MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE`
 
 **移动相关**
-- `MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT` / `_PERCENTAGE` / `_UNIQUE`、`MODIFIER_PROPERTY_MOVESPEED_ABSOLUTE`、`MODIFIER_PROPERTY_TURN_RATE_PERCENTAGE`
 
-**生命/魔法相关**
+- `MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT` / `_PERCENTAGE` / `_UNIQUE`、`MODIFIER_PROPERTY_MOVESPEED_ABSOLUTE`
+- `MODIFIER_PROPERTY_TURN_RATE_PERCENTAGE`
+
+**生命 / 魔法 / 视野**
+
 - `MODIFIER_PROPERTY_HEALTH_BONUS`、`MODIFIER_PROPERTY_MANA_BONUS`
 - `MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT`、`MODIFIER_PROPERTY_MANA_REGEN_CONSTANT`
+- `MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE`
+- `MODIFIER_PROPERTY_BONUS_DAY_VISION`、`MODIFIER_PROPERTY_BONUS_NIGHT_VISION`
 
 **法术相关**
-- `MODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE`
 
-## 可用 `States` 块表达的状态
+- `MODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE`、`MODIFIER_PROPERTY_COOLDOWN_PERCENTAGE`
+
+表里没有的属性名不代表一定不行（DataDriven 支持面比这更宽），但**没有本仓先例**，先在 Dota Tools 验证再铺开。
+
+## 可写进 `States` 的状态
 
 ```kv
 "States"
@@ -38,16 +50,48 @@
 }
 ```
 
-常用：`MODIFIER_STATE_ROOTED`（禁锢）、`DISARMED`（缴械）、`SILENCED`（沉默）、`MUTED`（锁闭）、`STUNNED`、`HEXED`、`INVISIBLE`、`INVULNERABLE`、`MAGIC_IMMUNE`、`FLYING`、`NO_HEALTH_BAR`、`NO_UNIT_COLLISION`、`ATTACK_IMMUNE`、`UNSELECTABLE`、`CANNOT_MISS`、`BLIND`。值：`MODIFIER_STATE_VALUE_ENABLED` / `_DISABLED`。
+常用：`ROOTED`（禁锢）、`DISARMED`（缴械）、`SILENCED`、`MUTED`、`STUNNED`、`HEXED`、`INVISIBLE`、`INVULNERABLE`、`MAGIC_IMMUNE`、`FLYING`、`FORCED_FLYING_VISION`、`NO_HEALTH_BAR`、`NO_UNIT_COLLISION`、`ATTACK_IMMUNE`、`UNSELECTABLE`、`CANNOT_MISS`、`BLIND`。值：`MODIFIER_STATE_VALUE_ENABLED` / `_DISABLED`。
 
-## 必须留在 Lua 的属性/逻辑
+## 声明式触发（不写脚本也能做的逻辑）
 
-- `MODIFIER_PROPERTY_ABSORB_SPELL`（法术格挡，如莲花球）
+`Modifiers` 内的事件块（`OnAttackStart` / `OnAttackLanded` / `OnSpellStart` / `OnIntervalThink` …）配合 Actions 可以表达一整条概率触发链，无需任何脚本。范例 `item_wasp_despotic`：`OnAttackStart` 里 `RemoveModifier` 清上次结果 → `Random` 掷 `%crit_chance` → `OnSuccess` `ApplyModifier` 挂暴击 modifier → 命中后 `OnAttackLanded` 再 `RemoveModifier` 清掉。
+
+判断「这条逻辑能不能纯 KV」时，先看它是不是能拆成「掷骰 → 挂/摘 modifier → 播音效/特效 → 造成伤害」这几步的组合。
+
+## 必须留在脚本侧的部分
+
+表外的部分按形态决定去哪个模式：
+
+**「动作」型 → 模式 1 的 `RunScript` 全局函数**
+
+- 一次性结算：造伤害、生成单位、发金币经验、播特效音效、整理场上实体
+- 挂/摘一个原版 modifier（挂点用 DataDriven modifier 自身的 `OnCreated` / `OnDestroy` 事件块）
+- 逐帧/定时的单步动作（`ThinkInterval` + `OnIntervalThink` 里 `RunScript` 结算一次伤害）
+
+**「常驻 modifier」型 → 模式 2 的 TS**
+
+- `MODIFIER_PROPERTY_ABSORB_SPELL`（法术格挡，如清莲宝珠）
 - `MODIFIER_PROPERTY_PROCATTACK_FEEDBACK`（攻击触发反馈）
-- 需要动态计算的值（按生命百分比/层数/条件判断，DataDriven 静态 `%value` 表达不了）
-- 光环中带逐帧判断逻辑、`OnTakeDamage` 等需要复杂分支的事件回调
+- 需要**动态计算**的值（按生命百分比 / 层数 / 目标护甲 / 条件判断，静态 `%value` 表达不了）
+- 带记账的事件回调：内置冷却计时、attack record 跟踪、`OnTakeDamage` 复杂分支
+- 需要跨物品实例同步的状态（多件充能对齐等）
 
-## 复用 Dota 原生 modifier（无需任何虚拟物品）
+判据不是代码长度，是**要不要写一个 modifier 类**。模式 1 的 Lua 里一旦出现 `LinkLuaModifier` + `class({})`，就说明选错了模式。
+
+## 复用原版 modifier：字段冲突排查
+
+选型规则与三条机制规则见 SKILL.md 第一步，这里是查证手段。
+
+**排查一个物品有没有踩中「同名字段双倍」**，两步对照：
+
+1. 从 `docs/reference/<version>/items.txt` 取被复用原版物品的 `AbilityValues` 字段名（键在 4 层 tab 缩进下，按 3 层匹配会漏）
+2. 取本物品 `Modifiers` → `Properties` 里 `%xxx` 引用的字段名
+
+两者交集非空 = 该属性被原版 modifier 加一次、自己的 `Properties` 再加一次。复用两个以上原版时，还要取那几个原版彼此的字段交集，落在里面的字段会被各读一次。
+
+已核对的先例：`item_beast_shield` / `item_hawkeye_turret` / `item_magic_crit_blade` / `item_forbidden_staff` / `item_shadow_impact` 交集为空；`item_magic_sword` 用 `bonus_damage_passive` 规避了狂战斧与黯灭共有的 `bonus_damage`；`item_beast_armor` 曾在 `bonus_damage` / `bonus_intellect` 上双倍，已改名修正。
+
+**永久型原版 modifier 的挂/摘**：
 
 ```lua
 -- OnCreated
@@ -56,9 +100,9 @@ caster:AddNewModifier(caster, ability, "modifier_item_eternal_shroud", {})
 caster:RemoveModifierByName("modifier_item_eternal_shroud")
 ```
 
-原生 modifier 自动从传入的 `ability` 读取它需要的 `AbilityValues` 字段（按原版字段名补全即可），不要在自己 KV 的 `Modifiers` 块里重复定义这个原生 modifier。
+不要在自己 KV 的 `Modifiers` 块里重复定义这个原版 modifier。
 
-**需要同时合并多个原生 modifier 时**，`RemoveModifierByName` 得逐个手写调用名字，不够通用；改用 `ability` 上挂一个数组记录所有合并进来的 modifier 句柄，`OnDestroy` 时统一遍历 `Destroy()`：
+**同时合并多个原版 modifier 时**，`RemoveModifierByName` 得逐个手写名字，不够通用；改用 `ability` 上挂一个数组记录句柄，`OnDestroy` 统一遍历 `Destroy()`：
 
 ```lua
 -- OnCreated
@@ -77,27 +121,31 @@ end
 ability.added_modifiers = nil
 ```
 
-范例：`item_magic_crit_blade.lua`（合并 `modifier_item_devastator`）。
+范例：`item_magic_crit_blade.lua`（合并 `modifier_item_devastator`）、`item_beast_armor.lua`（合并 `modifier_item_blade_mail`）。
 
-## `item_apply_modifiers` 共享 hub 的三类场景
+## `item_apply_modifiers` 的三类场景
 
-`game/scripts/npc/npc_items_modifier.txt` 里的 `item_apply_modifiers`（`BaseClass item_datadriven`）是一个全局共享物品，专门用来存放各个 `item_lua` 物品「纯数值常量加成」部分的 DataDriven 定义，避免每个物品都要写一遍 Lua `GetModifier*`。
+`game/scripts/npc/npc_items_modifier.txt` 里的 `item_apply_modifiers`（`BaseClass item_datadriven`）是全局单例物品，存放 `item_lua` 物品「纯数值常量加成」部分的 DataDriven 定义 —— 因为 `item_lua` 的 KV 不支持自己的 `Modifiers` 块。
+
+**只服务模式 2**：27 个 `_stats` 对应的物品 100% 是 `item_lua`。模式 1 的属性写在物品自己的 `Modifiers` 块里，不碰这里。
 
 ### A. 永久物品基础属性（绑定物品实例，最常见）
 
-- 命名约定：`modifier_item_<name>_stats`，写进 `item_apply_modifiers` 的 `Modifiers` 块
-- Lua/TS 物品的 intrinsic modifier 在 `OnCreated`（必须先调 `OnRefresh`）/`OnRefresh`/`OnDestroy` 里调用：
+- 命名 `modifier_item_<name>_stats`，写进 `item_apply_modifiers` 的 `Modifiers` 块
+- 数值真值写进 `item_apply_modifiers` 自己的 `AbilityValues`，键须加 `<物品名>_` 前缀（如 `item_saint_orb_bonus_all_stats`），`Properties` 用 `%<前缀键>` 引用；物品自己的 `AbilityValues` 再补一条 `xxx_tooltip` **镜像值**供 tooltip 显示
+- TS：继承 `src/vscripts/items/ts_items/base_item_modifier.ts` 的 `BaseItemModifier`，只声明 `statsModifierName`，三个生命周期回调已实现
+- 存量原生 Lua：`OnCreated`（必须先调 `OnRefresh`）/ `OnRefresh` / `OnDestroy` 三处都调
   ```lua
   RefreshItemDataDrivenModifier(_, self:GetAbility(), self.stats_modifier_name)
   ```
-  TS 直接继承 `src/vscripts/items/ts_items/base_item_modifier.ts` 的 `BaseItemModifier`，只需声明 `statsModifierName` 字段，三个生命周期回调已实现。
-- 该函数会按持有者背包里这个物品的**实例数**，自动同步 `_stats` modifier 的叠加层数（多件叠加用 `MODIFIER_ATTRIBUTE_MULTIPLE`）。
-- `OnCreated` 里只读取 Lua **真正需要**的值（特殊逻辑用的），仅用于 tooltip 显示的值不要读，也不要在 Lua `DeclareFunctions()`/`GetModifier*()` 里保留已迁移属性的重复实现。
+  首参 `_` 是 TSTL 编译产物的隐式 context 参数，Lua 侧必须占位；TS 侧调用不写这一参
+- 该函数按持有者背包里这个物品的**实例数**自动对齐 `_stats` 的叠加层数（多件叠加需 `MODIFIER_ATTRIBUTE_MULTIPLE`）
+- `OnCreated` 里只读脚本**真正要用**的值；仅供 tooltip 显示的值不要读，也不要在 `DeclareFunctions()` / `GetModifier*()` 里保留已下沉属性的重复实现
 
 ### B. 永久 BUFF（不绑定物品实例，例如消耗品永久赋予）
 
-- 直接在 `npc_items_modifier.txt` 写完整 DataDriven modifier（不需要 `_stats` 后缀，也不需要 Lua modifier 类）
-- 消耗物品的 Lua/TS 里调用：
+- 直接在 `npc_items_modifier.txt` 写完整 DataDriven modifier（不需要 `_stats` 后缀，也不需要脚本侧 modifier 类）
+- 消耗物品的脚本里调用：
   ```lua
   ApplyItemDataDrivenModifier(_, caster, target, "modifier_xxx", {})
   ```
@@ -105,12 +153,14 @@ ability.added_modifiers = nil
 
 ### C. 临时 Buff / Debuff（有持续时间）
 
-- 同样直接写完整 DataDriven modifier（`Properties` 为静态部分；需要逐帧效果时加 `ThinkInterval` + `OnIntervalThink` 的 `RunScript`）
-- 用 `ApplyItemDataDrivenModifier` 附加到目标，并传入 `duration`
+- 同样写完整 DataDriven modifier（`Properties` 放静态部分；需要逐帧效果时加 `ThinkInterval` + `OnIntervalThink` 的 `RunScript`）
+- 用 `ApplyItemDataDrivenModifier` 附加到目标并传入 `duration`
 
 ## 决策口诀
 
-- 整个物品没有「必须 Lua」的逻辑 → `BaseClass = item_datadriven`，属性写自己 KV 的 `Modifiers`，不需要 hub
-- 物品因为别的逻辑必须留 `item_lua`，但部分属性是纯数值常量 → 那部分属性进 `item_apply_modifiers` 的 `_stats`，Lua/TS 里只手写「表外」属性
+- 表外部分是**动作** → 模式 1，`RunScript` 调 Lua 全局函数，属性仍写自己 KV，**不碰 `item_apply_modifiers`**，数值只有一处
+- 表外部分是**常驻 modifier** → 模式 2，纯数值常量属性下沉 `item_apply_modifiers` 的 `_stats`，TS 只手写表外那部分
+- 模式 2 但没有永久属性（消耗品 / 工具类）→ `statsModifierName = ''`，同样不碰 `item_apply_modifiers`
+- 想消掉表外部分 → 先看有没有原版 modifier 能复用，能复用就退回模式 1
 - 不绑定物品实例的永久效果 → `ApplyItemDataDrivenModifier` + 完整 modifier
 - 有持续时间的临时效果 → 完整 DataDriven modifier（+ `RunScript` 处理逐帧逻辑）

--- a/.claude/skills/shared-references/README.md
+++ b/.claude/skills/shared-references/README.md
@@ -1,0 +1,20 @@
+# 跨 skill 共享参考
+
+放两个以上 skill 都要查的参考资料。**本目录没有 `SKILL.md`，不会被当成 skill 加载**，因此不占每轮 context——只在被 skill 用相对路径指到时才读。
+
+| 文件 | 内容 | 被谁引用 |
+| ---- | ---- | ---- |
+| `vanilla-modifiers.md` | 可复用的原版 modifier 清单（通用状态 / 原版物品 / 原版技能三组），含表外查名方法 | `custom-item`、`custom-ability`、`awaken-ability` |
+
+## 什么该放进来
+
+只放**两个以上 skill 都会查**的内容。单个 skill 专用的查表放该 skill 自己的 `references/`。
+
+判据是「不在场会怎样」：
+
+- 不在场就会写出错误代码的硬约束 → `.claude/CLAUDE.md`（每轮必进）
+- 做某类任务时的决策与流程 → 对应 skill 的 `SKILL.md`
+- 只有部分分支才读的查表 → skill 自己的 `references/`
+- 多个 skill 都读的查表 → 本目录
+
+新增文件时在上表登记，并在引用它的每个 skill 里加相对路径指路（`../shared-references/<file>.md`）。

--- a/.claude/skills/shared-references/vanilla-modifiers.md
+++ b/.claude/skills/shared-references/vanilla-modifiers.md
@@ -1,0 +1,106 @@
+# 可复用的原版 modifier 清单
+
+自制物品 / 技能时优先从这里挑，能挑到就不用自己实现——原版 modifier 是引擎原生 C++，不交回调税。
+
+**下表全部是本仓已在用、已验证的，远不是全集**。表里没有不代表做不到——原版有对应物品/技能时，按文末「表外的怎么找」去查名字再试，不要直接放弃转为自己实现。
+
+## 两种挂法
+
+```kv
+// KV（模式 1）：临时效果，引擎按 Duration 自动摘
+"ApplyModifier"
+{
+    "ModifierName"  "modifier_black_king_bar_immune"
+    "Target"        "CASTER"
+    "Duration"      "%active_duration"
+}
+```
+
+```lua
+-- 脚本（两个模式都行）：永久型必须自己在 OnDestroy 摘掉
+caster:AddNewModifier(caster, ability, "modifier_item_devastator", {})
+```
+
+传进去的 `ability` 决定这个 modifier 读谁的 `AbilityValues`——**这就是「连属性一起复用」的来源**，也是同名字段双倍的来源。字段规则见 SKILL.md 第一步。
+
+## 通用状态
+
+不绑定任何物品/技能，任何地方都能直接挂。
+
+| modifier | 效果 | 参数 | 仓库先例 |
+| --- | --- | --- | --- |
+| `modifier_stunned` | 眩晕 | `duration` | 全仓最常复用的一个，19 个文件在用 |
+| `modifier_rooted` | 禁锢 | `duration` | `event-npc-spawned.ts` |
+| `modifier_silence` | 沉默 | `duration` | `Debug.ts` |
+| `modifier_invulnerable` | 无敌 | `duration` | `primal_split.lua` |
+| `modifier_knockback` | 击退位移 | 需传位移参数表（距离/高度/时长） | `item_heavens_halberd_v2.ts`、`liu_kick.lua` |
+| `modifier_kill` | 到期杀死宿主 | `duration` | 给眼位/召唤物设寿命，`ability_ward_observer_slot.ts` |
+| `modifier_black_king_bar_immune` | 魔免（BKB） | `duration` | `item_beast_shield` KV、`awaken-magic-immunity.ts` |
+| `modifier_fountain_glyph` | 防御符文 | `duration` | `event-npc-spawned.ts` |
+
+眩晕别自己写：`modifier_stunned` 已是全仓统一写法，配 `duration` 即可，记得乘 `1 - target:GetStatusResistance()`。
+
+## 原版物品 modifier
+
+复用时在**自己**的 KV 按原版字段名写数值，字段名查 `docs/reference/<version>/items.txt` 对应物品的 `AbilityValues`。
+
+| modifier | 来源物品 | 效果 | 仓库先例 |
+| --- | --- | --- | --- |
+| `modifier_item_blade_mail` | 刃甲 | 被动反伤 + 属性 | `item_beast_armor` |
+| `modifier_item_blade_mail_reflect` | 刃甲 | 主动反伤（带 `duration`） | `item_beast_armor` |
+| `modifier_item_battlefury` | 狂战斧 | 溅射 + 属性 | `item_magic_sword` |
+| `modifier_item_desolator` | 黯灭 | 攻击减甲 + 属性 | `item_hawkeye_turret`、`item_magic_sword` |
+| `modifier_item_devastator` | 圣斧 | 智力转伤害 / 减魔抗 + 属性 | `item_magic_crit_blade` |
+| `modifier_item_eternal_shroud` | 永世法衣 | 法伤转魔法 + 属性 | `item_beast_shield` |
+| `modifier_item_gungir` | 缚灵索 | 攻击触发群体禁锢 + 属性 | `item_forbidden_staff` |
+| `modifier_item_angels_demise` | 绝刃 | 被动本体 | `item_shadow_impact` |
+| `modifier_item_angels_demise_slow` / `_break` | 绝刃 | 减速 / 破坏（带 `duration`） | `item_shadow_impact` |
+| `modifier_item_lotus_orb_active` | 清莲宝珠 | 反弹指向性法术（带 `duration`） | `item_saint_orb.ts`、`item_beast_armor` |
+| `modifier_heavens_halberd_debuff` | 天堂之戟 | 缴械（带 `duration`） | `item_heavens_halberd_v2.ts` |
+| `modifier_item_force_staff_motion` | 原力法杖 | 直线位移（带 `duration`） | `item_force_staff` |
+| `modifier_item_swift_blink_buff` | 迅疾闪光 | 攻速/移速增益 | `item_jump_jump_jump` |
+| `modifier_item_overwhelming_blink_debuff` | 盛势闪光 | 减速（带 `duration`） | `item_jump_jump_jump` |
+| `modifier_item_ultimate_scepter` | 阿哈利姆神杖 | 神杖效果（`duration = -1` 为永久） | `item_ultimate_scepter_2` |
+| `modifier_item_buff_ward` | 侦察守卫 | 眼位存在状态 | `ability_ward_observer_slot.ts` |
+| `modifier_item_ward_true_sight` | 岗哨守卫 | 真视 | `ability_ward_sentry_slot.ts` |
+
+## 原版技能 modifier
+
+借某个英雄技能的现成效果。
+
+| modifier | 来源 | 效果 | 仓库先例 |
+| --- | --- | --- | --- |
+| `modifier_tidehunter_anchor_smash_caster` | 潮汐猎人 锚击 | 包在 `PerformAttack` 外层标记「技能触发的瞬间攻击」，10 个技能统一这么写 | `sword_master_tap.lua`、`artoria_strike_air.lua` |
+| `modifier_riki_backstab` | 力丸 刀光谍影 | 背后攻击加伤 | `windrunner_whirlwind_custom.ts` |
+| `modifier_drow_ranger_frost_arrows_slow` | 卓尔游侠 霜冻之箭 | 攻击减速（带 `duration`） | `special_bonus_unique_drow_ranger_upgrade.ts` |
+| `modifier_brewmaster_belligerent_damage` | 酒仙 元素分离 | 分身增伤 | `primal_split.lua` |
+| `modifier_brewmaster_void_brawler_slow` | 酒仙 元素分离 | 分身减速 | `primal_split.lua` |
+
+`modifier_tidehunter_anchor_smash_caster` 的写法固定为 挂 → `PerformAttack` → 立即摘，照抄先例即可，不要只挂不摘。
+
+## 表外的怎么找
+
+原版 modifier 名是引擎内部名，**KV 文件里没有**（`grep items.txt` 查不到不代表不存在）。按下面顺序找，找到候选就先试：
+
+**1. 原版本地化反查**——覆盖所有**可见** buff/debuff（玩家能看到图标的那些），`abilities_schinese.txt` 里有 2596 个 `DOTA_Tooltip_modifier_*` 键：
+
+```bash
+# 已知是哪件物品/技能：用它的系统名当关键词
+grep -o "DOTA_Tooltip_modifier_.*blade_mail.*" docs/reference/<version>/abilities_schinese.txt
+# 只知道中文效果名：先搜中文定位到键，再取键里的 modifier 名
+grep "缴械" docs/reference/<version>/abilities_schinese.txt
+```
+
+**2. 猜命名惯例**——**隐藏的被动 modifier 没有 tooltip，本地化里查不到**（圣斧、缚灵索、绝刃的被动本体都是这种）。多数是 `modifier_` + 物品系统名，但**有例外，只能当候选**：
+
+| 物品 | modifier | 偏差 |
+| --- | --- | --- |
+| `item_blade_mail` | `modifier_item_blade_mail` | 无，直接拼 |
+| `item_bfury` | `modifier_item_battlefury` | 用的是全名不是系统名缩写 |
+| `item_heavens_halberd` | `modifier_heavens_halberd_debuff` | 没有 `item_` 前缀 |
+
+**3. 查文档**——上面两步都没结果时走 `dota-docs-lookup` skill（ModDota API 索引 / Valve Wiki）。
+
+**4. 实机验证**——名字猜错**不会报错**，只是静默没效果。拿到候选后必须在 Dota Tools 里挂上去确认真的生效，不要凭名字看着像就写进代码。
+
+四步都没找到，才按 SKILL.md 第二步选模式自己实现。

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3410,7 +3410,7 @@
 		"DOTA_Tooltip_ability_item_beast_armor_bonus_health_regen"						"+$hp_regen"
 		"DOTA_Tooltip_ability_item_beast_armor_bonus_mana_regen"						"+$mana_regen"
 		"DOTA_Tooltip_ability_item_beast_armor_bonus_aoe"								"+$aoe_bonus"
-		"DOTA_Tooltip_ability_item_beast_armor_bonus_damage"							"+$damage"
+		"DOTA_Tooltip_ability_item_beast_armor_bonus_damage_passive"					"+$damage"
 		"DOTA_Tooltip_ability_item_beast_armor_evasion"									"%+$evasion"
 
 		"DOTA_Tooltip_modifier_item_beast_armor_debuff"									"Cold Shock"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3422,7 +3422,7 @@
 		"DOTA_Tooltip_ability_item_beast_armor_bonus_health_regen"						"+$hp_regen"
 		"DOTA_Tooltip_ability_item_beast_armor_bonus_mana_regen"						"+$mana_regen"
 		"DOTA_Tooltip_ability_item_beast_armor_bonus_aoe"								"+$aoe_bonus"
-		"DOTA_Tooltip_ability_item_beast_armor_bonus_damage"							"+$damage"
+		"DOTA_Tooltip_ability_item_beast_armor_bonus_damage_passive"					"+$damage"
 		"DOTA_Tooltip_ability_item_beast_armor_evasion"									"%+$evasion"
 
 		"DOTA_Tooltip_modifier_item_beast_armor_debuff"									"极寒冲击"

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -7046,12 +7046,13 @@
 			"blind_pct"						"10"	// 致盲百分比
 
 			// 被动属性
+			// 智力与攻击力的字段名须与刃甲 modifier 错开，同名会被它再读一次导致数值翻倍
 			"bonus_strength"				"30"	// 力量
 			"bonus_agility"					"30"	// 敏捷
-			"bonus_intellect"				"30"	// 智力
+			"bonus_intellect_passive"		"30"	// 智力
 			"bonus_health_regen"			"40"	// 生命回复
 			"bonus_mana_regen"				"25"	// 魔法回复
-			"bonus_damage"					"120"	// 攻击力
+			"bonus_damage_passive"			"120"	// 攻击力
 			"evasion"						"25"	// 闪避
 
 			"bonus_aoe"						"150"	// 作用范围 lua
@@ -7081,10 +7082,10 @@
 				{
 					"MODIFIER_PROPERTY_STATS_STRENGTH_BONUS"	"%bonus_strength"
 					"MODIFIER_PROPERTY_STATS_AGILITY_BONUS"		"%bonus_agility"
-					"MODIFIER_PROPERTY_STATS_INTELLECT_BONUS"	"%bonus_intellect"
+					"MODIFIER_PROPERTY_STATS_INTELLECT_BONUS"	"%bonus_intellect_passive"
 					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT"	"%bonus_health_regen"
 					"MODIFIER_PROPERTY_MANA_REGEN_CONSTANT"		"%bonus_mana_regen"
-					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE"	"%bonus_damage"
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE"	"%bonus_damage_passive"
 					"MODIFIER_PROPERTY_EVASION_CONSTANT"		"%evasion"
 				}
 


### PR DESCRIPTION
## Issue

无对应 issue（skill 文档整理 + 顺带发现的数值 bug）。

## 改动

### 1. 修复兽化甲属性双倍（玩家可见）

`item_beast_armor` 的 `bonus_damage` / `bonus_intellect` 与它复用的原版刃甲 modifier 字段同名，导致刃甲加一次、物品自己的 `Properties` 再加一次，实际生效 +240 攻击力 / +60 智力（应为 +120 / +30）。已由用户实机确认。

按仓库既有先例（`item_magic_sword` 的 `bonus_damage_passive`）改名规避，同步改了两个本地化文件的 stat tooltip key。护甲仍按原样委托给刃甲提供。

### 2. custom-item skill 重写

基于全仓 218 个物品块的实际分布，把混杂的实现写法收敛成两个模式：

- **模式 1 DataDriven 主体**（`item_datadriven`，逻辑不够时 `RunScript` 调原生 Lua 全局函数）
- **模式 2 TS 主体**（`item_lua` + `ts_items/`，纯数值属性下沉 `item_apply_modifiers`）
- 弃用 `item_lua` + 手写 `class({})` 原生 Lua（35 个存量不迁移）

新增可机械检查的分界判据：表外逻辑是「动作」走模式 1，是「常驻 modifier」走模式 2；模式 1 的 Lua 里出现 `LinkLuaModifier` + `class({})` 即为越界信号（13 个样本无一例外）。

补上此前没写的两条代价：**回调税**（Lua `GetModifier*` 每次查询回调）与**镜像值**（hub 数值要在两处手写同步）。

### 3. 新增可复用原版 modifier 清单

`shared-references/vanilla-modifiers.md`，30 个已验证在用的原版 modifier 分三组（通用状态 / 原版物品 / 原版技能），含三条机制规则（按需取用、写了就被套用、多原版共有字段各读一次）和表外查名方法。

放在 `shared-references/`（无 `SKILL.md`，不占每轮 context）供 `custom-item` / `custom-ability` / `awaken-ability` 共用——清单里 8/10 先例本来就来自技能文件。

### 4. 消除 skill 间重复与臃肿

- `awaken-ability`：11 条进阶技法（158 行）下沉 `references/advanced-techniques.md`，主文 278 → 137 行，替换为带命中条件的索引表
- `awaken-ability` 两处复述的实现选型删除，改指 `custom-ability`
- `custom-ability`：按「技能通常没有属性、不考虑 `ability_datadriven`」简化为「从零新增一律走 TS」

## Checklist

- [x] 兽化甲实机确认攻击力 120、智力 30
- [ ] `npc_items_custom.txt` 的重复 ID 10313 / 10314 仍未修复（`item_recipe_withered_spring` vs `item_recipe_shadow_impact`、`item_withered_spring` vs `item_shadow_impact`），之前拆出的任务未落地，需另行处理
- [ ] `modifier_tidehunter_anchor_smash_caster` 在清单里只记了可观察用法（挂 → `PerformAttack` → 立即摘），引擎语义未确认
- [ ] 分支名未带 issue 号（本次无对应 issue）

## Release Note

按要求本次不写更新日志。注意改动 1 是玩家可见的数值修正，发版时可能需要补一条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
