### PR TITLE
Fix item lottery purchaser stacking and blacklist Elder Titan awaken

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -2032,6 +2032,7 @@
 		"DOTA_Tooltip_ability_yukari_tentacles" "Tentacle Portal"
 		"DOTA_Tooltip_ability_yukari_tentacles_Description" "Opens a portal filled with dire tentacles in the target area, dealing damage over time, slowing movement speed, and reducing vision to a consistent 600. Bonus damage is added based on Yukari's Intelligence."
 		"DOTA_Tooltip_ability_yukari_tentacles_damage_per_second" "DAMAGE PER SECOND:"
+		"DOTA_Tooltip_ability_yukari_tentacles_radius" "RADIUS:"
 		"DOTA_Tooltip_ability_yukari_tentacles_intelligence_per_second"	"BONUS DAMAGE PER INT:"
 		"DOTA_Tooltip_ability_yukari_tentacles_duration" "DURATION:"
 		"DOTA_Tooltip_ability_yukari_tentacles_root"	"%MOVEMENT SPEED SLOW:"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1859,6 +1859,7 @@
 		"DOTA_Tooltip_ability_yukari_tentacles"	"静观其变之眼"
 		"DOTA_Tooltip_ability_yukari_tentacles_Description"	"在目标区域打开一个充满可怕触手的间隙，持续造成伤害，减慢敌人的移动速度，并将视野范围限制为600."
 		"DOTA_Tooltip_ability_yukari_tentacles_damage_per_second"	"每秒伤害:"
+		"DOTA_Tooltip_ability_yukari_tentacles_radius"	"作用范围："
 		"DOTA_Tooltip_ability_yukari_tentacles_intelligence_per_second"	"智力伤害系数:"
 		"DOTA_Tooltip_ability_yukari_tentacles_duration"	"间隙持续时间:"
 		"DOTA_Tooltip_ability_yukari_tentacles_root"	"%移动速度降低:"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -1021,8 +1021,16 @@
 		// Ability Values		//------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"start_radius"			"300"
-			"end_radius"			"300"
+			"start_radius"
+			{
+				"value"						"300"
+				"affected_by_aoe_increase"	"1"
+			}
+			"end_radius"
+			{
+				"value"						"300"
+				"affected_by_aoe_increase"	"1"
+			}
 			"speed"					"1500.0"
 			"cast_range"			"650"
 			"stun_duration"			"1 1.1 1.2 1.3 1.4"
@@ -1126,7 +1134,11 @@
 		"AbilityValues"
 		{
 			"amp_pct"					"8 10 12 14 16"
-			"radius"					"450"
+			"radius"
+			{
+				"value"						"450"
+				"affected_by_aoe_increase"	"1"
+			}
 			"slow_amount"				"-30 -35 -40 -45 -50"
 			"duration"					"3"
 			"damage"
@@ -1193,7 +1205,11 @@
 			"cast_delay"			"1.0"
 			"duration"				"2.0"
 			"range"					"2000"
-			"width"					"350"
+			"width"
+			{
+				"value"						"350"
+				"affected_by_aoe_increase"	"1"
+			}
 			"speed"					"2000.0"
 			"interval"				"0.2"
 			"AbilityCooldown"
@@ -1260,7 +1276,11 @@
 			"cast_delay"			"1.0"
 			"duration"				"2.5"
 			"range"					"4000"
-			"width"					"400"
+			"width"
+			{
+				"value"						"400"
+				"affected_by_aoe_increase"	"1"
+			}
 			"speed"					"4000.0"
 			"interval"				"0.2"
 			"AbilityCooldown"
@@ -1645,7 +1665,11 @@
 			"bonus_attackspeed"				"30 45 60 75 90"
 			"super_saiyan_tick"				"0.2"
 			"super_saiyan_range"			"900"
-			"super_saiyan_radius"			"400"
+			"super_saiyan_radius"
+			{
+				"value"						"400"
+				"affected_by_aoe_increase"	"1"
+			}
 			"super_saiyan_cooldown"			"14"
 		}
 
@@ -1763,7 +1787,11 @@
 			"channel"					"2"
 			"visionRange_max"			"2500"
 			"damage_max"				"1500"
-			"radius_max"				"400"
+			"radius_max"
+			{
+				"value"						"400"
+				"affected_by_aoe_increase"	"1"
+			}
 			"speed"						"2500"
 		}
 
@@ -1852,7 +1880,11 @@
 				"special_bonus_unique_yukari_01_stun" "+0.6"
 			}
 			"speed"			"1200"
-			"radius"		"150"
+			"radius"
+			{
+				"value"						"150"
+				"affected_by_aoe_increase"	"1"
+			}
 			"range"			"1200"
 			"num"			"6"
 			"cast_range"	"1200"
@@ -2034,15 +2066,31 @@
 		}
 		"AbilityValues"
 		{
-			"min_radius"	"750"
-			"max_radius"	"750"
+			"min_radius"
+			{
+				"value"						"750"
+				"affected_by_aoe_increase"	"1"
+			}
+			"max_radius"
+			{
+				"value"						"750"
+				"affected_by_aoe_increase"	"1"
+			}
 			"target_range"	"0"
 			"barrage_spawn_point"	"16"
 			"barrage_fire_interval"	"0.1"
 			"barrage_damage"	"200"
-			"barrage_radius"	"750"
+			"barrage_radius"
+			{
+				"value"						"750"
+				"affected_by_aoe_increase"	"1"
+			}
 			"ex_damage"			"50"
-			"wanbaochui_radius"	"750"
+			"wanbaochui_radius"
+			{
+				"value"						"750"
+				"affected_by_aoe_increase"	"1"
+			}
 			"int_bonus"			"4"
 			"stun_duration"
 			{
@@ -2310,7 +2358,11 @@
 			"AbilityCooldown"		"90"
 			"AbilityManaCost"		"160"
 			// "radius_normal"			"200"
-			"radius_active"			"400"
+			"radius_active"
+			{
+				"value"						"400"
+				"affected_by_aoe_increase"	"1"
+			}
 			"duration"				"30"
 		}
 	}
@@ -2418,7 +2470,11 @@
 				"value"									"150"
 				"special_bonus_unique_sword_master_2"	"+80"
 			}
-			"radius"						"350"
+			"radius"
+			{
+				"value"						"350"
+				"affected_by_aoe_increase"	"1"
+			}
 			"damage_bonus"					"100 160 220 280 340"
 		}
 	}
@@ -2565,7 +2621,11 @@
 				"CalculateSpellDamageTooltip"	"1"
 			}
 			"damage_crit"				"180 260 340"
-			"radius"					"350"
+			"radius"
+			{
+				"value"						"350"
+				"affected_by_aoe_increase"	"1"
+			}
 			"AbilityCooldown"
 			{
 				"value"									"25"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -2046,7 +2046,11 @@
 		}
 		"AbilityValues"
 		{
-			"min_radius"	"750"
+			"min_radius"
+			{
+				"value"						"750"
+				"affected_by_aoe_increase"	"1"
+			}
 			"max_radius"
 			{
 				"value"						"750"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -1021,16 +1021,8 @@
 		// Ability Values		//------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"start_radius"
-			{
-				"value"						"300"
-				"affected_by_aoe_increase"	"1"
-			}
-			"end_radius"
-			{
-				"value"						"300"
-				"affected_by_aoe_increase"	"1"
-			}
+			"start_radius"			"300"
+			"end_radius"			"300"
 			"speed"					"1500.0"
 			"cast_range"			"650"
 			"stun_duration"			"1 1.1 1.2 1.3 1.4"
@@ -1205,11 +1197,7 @@
 			"cast_delay"			"1.0"
 			"duration"				"2.0"
 			"range"					"2000"
-			"width"
-			{
-				"value"						"350"
-				"affected_by_aoe_increase"	"1"
-			}
+			"width"					"350"
 			"speed"					"2000.0"
 			"interval"				"0.2"
 			"AbilityCooldown"
@@ -1276,11 +1264,7 @@
 			"cast_delay"			"1.0"
 			"duration"				"2.5"
 			"range"					"4000"
-			"width"
-			{
-				"value"						"400"
-				"affected_by_aoe_increase"	"1"
-			}
+			"width"					"400"
 			"speed"					"4000.0"
 			"interval"				"0.2"
 			"AbilityCooldown"
@@ -1880,11 +1864,7 @@
 				"special_bonus_unique_yukari_01_stun" "+0.6"
 			}
 			"speed"			"1200"
-			"radius"
-			{
-				"value"						"150"
-				"affected_by_aoe_increase"	"1"
-			}
+			"radius"		"150"
 			"range"			"1200"
 			"num"			"6"
 			"cast_range"	"1200"
@@ -2066,11 +2046,7 @@
 		}
 		"AbilityValues"
 		{
-			"min_radius"
-			{
-				"value"						"750"
-				"affected_by_aoe_increase"	"1"
-			}
+			"min_radius"	"750"
 			"max_radius"
 			{
 				"value"						"750"
@@ -2080,17 +2056,9 @@
 			"barrage_spawn_point"	"16"
 			"barrage_fire_interval"	"0.1"
 			"barrage_damage"	"200"
-			"barrage_radius"
-			{
-				"value"						"750"
-				"affected_by_aoe_increase"	"1"
-			}
+			"barrage_radius"	"750"
 			"ex_damage"			"50"
-			"wanbaochui_radius"
-			{
-				"value"						"750"
-				"affected_by_aoe_increase"	"1"
-			}
+			"wanbaochui_radius"	"750"
 			"int_bonus"			"4"
 			"stun_duration"
 			{

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -1197,7 +1197,11 @@
 			"cast_delay"			"1.0"
 			"duration"				"2.0"
 			"range"					"2000"
-			"width"					"350"
+			"width"
+			{
+				"value"						"350"
+				"affected_by_aoe_increase"	"1"
+			}
 			"speed"					"2000.0"
 			"interval"				"0.2"
 			"AbilityCooldown"
@@ -1264,7 +1268,11 @@
 			"cast_delay"			"1.0"
 			"duration"				"2.5"
 			"range"					"4000"
-			"width"					"400"
+			"width"
+			{
+				"value"						"400"
+				"affected_by_aoe_increase"	"1"
+			}
 			"speed"					"4000.0"
 			"interval"				"0.2"
 			"AbilityCooldown"

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -99,6 +99,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
 
 
     ["elder_titan_ancestral_spirit"] = true,
+    ["elder_titan_ancestral_spirit_awaken"] = true, -- 上古巨神 灵体游魂 觉醒
     -- ========================================
     -- 召唤类技能
     -- 原因：召唤单位可能导致单位管理问题和性能下降

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -109,6 +109,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["furion_force_of_nature"] = true,    -- 先知 自然之力
     ["zuus_cloud"] = true,                -- 宙斯 雷云
     ["venomancer_plague_ward"] = true,    -- 剧毒术士 瘟疫守卫
+    ["undying_tombstone"] = true,         -- 不朽尸王 墓碑
 
     -- ========================================
     -- 持续施法/引导类技能

--- a/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
+++ b/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
@@ -89,6 +89,7 @@ no_support_abilitys = {
 	ancient_apparition_ice_blast = 1,               -- 冰晶爆轰
 	ancient_apparition_ice_blast_release = 1,       -- 冰晶爆轰
 	elder_titan_ancestral_spirit = 1,               -- 灵体游魂
+	elder_titan_ancestral_spirit_awaken = 1,        -- 上古巨神 灵体游魂 觉醒
 	primal_beast_onslaught = 1,                     -- 獸 突
 	hoodwink_sharpshooter = 1,                      -- 一箭穿心
 	hoodwink_sharpshooter_release = 1,              -- 一箭穿心

--- a/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
+++ b/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
@@ -104,6 +104,7 @@ no_support_abilitys = {
 	ability_fate_roulette = 1,                     -- 命运轮盘（重复施放只会刷新自身状态）
 	venomancer_plague_ward = 1,                     -- 剧毒术士 瘟疫守卫
 	enchantress_enchant = 1,                        -- 魅惑魔女 魅惑
+	undying_tombstone = 1,                          -- 不朽尸王 墓碑
 }
 no_support_items = {
 	-- 消耗品

--- a/src/vscripts/modules/lottery/item/item-lottery-helper.ts
+++ b/src/vscripts/modules/lottery/item/item-lottery-helper.ts
@@ -5,8 +5,8 @@ import { itemTiers } from './lottery-items';
 export enum ItemLotteryPool {
   INITIAL = 'initial', // 开局点位：屏蔽 T7~T4，避开引擎全价卖出窗口
   DEFAULT = 'default', // 普通藏宝箱
-  PREMIUM = 'premium', // 后期 / 肉山 / 会员：高 tier 加权
-  ULTRA = 'ultra', // 大后期：保底 T3，高 tier 明显加权
+  PREMIUM = 'premium', // 后期：高 tier 加权
+  ULTRA = 'ultra', // 大后期 / 肉山：保底 T3，高 tier 明显加权
 }
 
 const POOL_RATES: Record<ItemLotteryPool, number[]> = {

--- a/src/vscripts/modules/lottery/item/item-lottery.test.ts
+++ b/src/vscripts/modules/lottery/item/item-lottery.test.ts
@@ -38,7 +38,7 @@ global.PlayerResource = {
 };
 
 // CreateItem 全局函数 mock：返回一个带 name 字段的伪 item 用于断言
-global.CreateItem = jest.fn((name: string) => ({ name }));
+global.CreateItem = jest.fn((name: string) => ({ name, SetPurchaser: jest.fn() }));
 
 jest.mock('../../helper/player-helper', () => ({
   PlayerHelper: {
@@ -149,7 +149,7 @@ describe('ItemLottery', () => {
         } as any,
       );
       expect(global.CreateItem).toHaveBeenCalledWith(target.name, undefined, undefined);
-      expect(mockHero.AddItem).toHaveBeenCalledWith({ name: target.name });
+      expect(mockHero.AddItem).toHaveBeenCalledWith(expect.objectContaining({ name: target.name }));
       // 选完后写空 candidates 清行
       expect(netTable['lottery_item']['3'].candidates).toEqual([]);
       expect(netTable['lottery_item']['3'].isRefreshed).toBe(false);

--- a/src/vscripts/modules/lottery/item/item-lottery.ts
+++ b/src/vscripts/modules/lottery/item/item-lottery.ts
@@ -1,8 +1,8 @@
 import { LotteryDto } from '../../../../common/dto/lottery';
-import { ApiClient } from '../../../api/api-client';
 import { GA4PickItemTracker } from '../../../api/analytics/ga4/ga4-pick-item-tracker';
-import { PlayerMemberPointApi } from '../../../api/player-member-point';
+import { ApiClient } from '../../../api/api-client';
 import { MemberLevel, Player } from '../../../api/player';
+import { PlayerMemberPointApi } from '../../../api/player-member-point';
 import { reloadable } from '../../../utils/tstl-utils';
 import { PlayerHelper } from '../../helper/player-helper';
 import { ItemLotteryHelper, ItemLotteryPool } from './item-lottery-helper';
@@ -68,8 +68,7 @@ export class ItemLottery {
       return;
     }
 
-    // 用 CreateItem 提前指定 purchaser=undefined 再加进 inventory，
-    // 让引擎从一开始就不把它当作"刚购买的"——既能立即使用，又按半价出售。
+    // CreateItem 时 purchaser 传 undefined 避免引擎按"刚购买"处理（能立即使用、半价出售）
     const item = CreateItem(matched.name, undefined, undefined);
     if (item !== undefined) {
       hero.AddItem(item);
@@ -86,6 +85,12 @@ export class ItemLottery {
     });
 
     GA4PickItemTracker.SendPick(playerId, matched.name, matched.level);
+
+    // 英雄有同名可叠加物品，添加后item会消失，必须判定非 undefined 才能 SetPurchaser
+    if (item !== undefined) {
+      // 防止属性书等物品无法合成
+      item.SetPurchaser(hero);
+    }
   }
 
   refreshItem(playerId: PlayerID): void {


### PR DESCRIPTION
## Issue

- [ ] fix #1618

## Checklist

- [ ] 在 Dota Tools 中验证抽奖获得力量之书/敏捷之书/智力之书能正常合成洛书
- [ ] 在 Dota Tools 中验证上古巨神觉醒技能灵体游魂被多重施法触发时不再导致技能消失
- [ ] 在 Dota Tools 中验证「作用范围」属性能正常加成 saber/孙悟空/杰克/八云紫/执剑泰斗的技能范围
- [ ] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.48a[/b]

- 修正抽奖获得属性书无法合成洛书的问题，修正上古巨神觉醒被多重施法触发导致技能消失等若干BUG
- 修正部分自定义英雄技能范围不受「作用范围」属性加成的问题
```

```
[b]Gameplay update v5.48a[/b]

- Fixed lottery tomes failing to combine into Tome of Luoshu, fixed Elder Titan's Awakened Ancestral Spirit disappearing when triggered by Multicast .etc
- Fixed some custom heroes' spell radius not scaling with the "AOE Bonus" property
```
