### PR TITLE
Fix butterfly and multicast casting hidden swap sub-abilities

### DIFF
--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -100,6 +100,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
 
     ["elder_titan_ancestral_spirit"] = true,
     ["elder_titan_ancestral_spirit_awaken"] = true, -- 上古巨神 灵体游魂 觉醒
+    ["elder_titan_return_spirit"] = true,           -- 上古巨神 召回游魂
     -- ========================================
     -- 召唤类技能
     -- 原因：召唤单位可能导致单位管理问题和性能下降
@@ -143,6 +144,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["ancient_apparition_ice_blast"] = true,               -- 冰魂 寒冰爆破
     ["phantom_assassin_phantom_strike_datadriven"] = true, -- 幻刺b觉醒
     ["keeper_of_the_light_illuminate"] = true,              -- 光之守卫 冲击波
+    ["keeper_of_the_light_illuminate_end"] = true,          -- 光之守卫 冲击波 释放
     ["special_bonus_unique_keeper_of_the_light_upgrade"] = true, -- 光之守卫 冲击波 觉醒
 
     -- ========================================
@@ -252,6 +254,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["pudge_meat_hook_lua"] = true,
     ["centaur_mount"] = true,
     ["techies_reactive_tazer"] = true,
+    ["techies_reactive_tazer_detonate"] = true, -- 炸弹人 引爆电击
     --幽鬼
     ["spectre_shadow_step"] = true,
     ["spectre_reality"] = true,

--- a/game/scripts/vscripts/abilities/ability_trigger_on_cast.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_cast.lua
@@ -159,6 +159,7 @@ function modifier_trigger_on_cast:TriggerRandomAbility(params)
         local ability = caster:GetAbilityByIndex(i)
         if ability and ability:GetLevel() > 0
             and not ability:IsPassive()
+            and not ability:IsHidden()
             and ability ~= self:GetAbility()
             and not ability:IsItem()
             and not EXCLUDED_ABILITIES_ALLBUTTER[ability:GetAbilityName()] then
@@ -252,6 +253,12 @@ function modifier_trigger_on_cast:TriggerRandomAbility(params)
             return
         end
         if not random_ability or random_ability:IsNull() then
+            self.trigger_depth = self.trigger_depth - 1
+            return
+        end
+        -- 隐藏技能多为槽位互换的子技能，在互换窗口外施放会让引擎再 swap 一次，
+        -- 把可见的主技能永久换到隐藏位。挑选到此处之间状态可能已变，须重新判定
+        if random_ability:IsHidden() then
             self.trigger_depth = self.trigger_depth - 1
             return
         end

--- a/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
+++ b/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
@@ -91,6 +91,7 @@ no_support_abilitys = {
 	ancient_apparition_ice_blast_release = 1,       -- 冰晶爆轰
 	elder_titan_ancestral_spirit = 1,               -- 灵体游魂
 	elder_titan_ancestral_spirit_awaken = 1,        -- 上古巨神 灵体游魂 觉醒
+	elder_titan_return_spirit = 1,                  -- 上古巨神 召回游魂
 	primal_beast_onslaught = 1,                     -- 獸 突
 	hoodwink_sharpshooter = 1,                      -- 一箭穿心
 	hoodwink_sharpshooter_release = 1,              -- 一箭穿心
@@ -107,7 +108,9 @@ no_support_abilitys = {
 	enchantress_enchant = 1,                        -- 魅惑魔女 魅惑
 	undying_tombstone = 1,                          -- 不朽尸王 墓碑
 	keeper_of_the_light_illuminate = 1,             -- 光之守卫 冲击波
+	keeper_of_the_light_illuminate_end = 1,         -- 光之守卫 冲击波 释放
 	special_bonus_unique_keeper_of_the_light_upgrade = 1, -- 光之守卫 冲击波 觉醒
+	techies_reactive_tazer_detonate = 1,            -- 炸弹人 引爆电击
 }
 no_support_items = {
 	-- 消耗品
@@ -243,6 +246,13 @@ function modifier_ogre_magi_multicast_lua:OnAbilityExecuted(keys)
 
 		-- 英雄持续施法时 不触发多重
 		if keys.unit:IsChanneling() then
+			ability.multicast = nil
+			return nil
+		end
+
+		-- 隐藏技能多为槽位互换的子技能，在互换窗口外施放会让引擎再 swap 一次，
+		-- 把可见的主技能永久换到隐藏位。施法瞬间它仍可见，只能延迟到重放前才判定
+		if ability:IsHidden() then
 			ability.multicast = nil
 			return nil
 		end


### PR DESCRIPTION
## Issue

- [ ] 玩家反馈：上古巨神 2 技能、光之守卫 1 技能、炸弹人 2 技能偶尔从技能栏永久消失

## Checklist

- [ ] I have tested the changes works well.

## 问题分析

三个英雄丢失的槽位都是**引擎槽位互换（swap）技能对**：主技能施放后子技能顶进槽位，子技能用掉或时限到后再换回。

| 英雄 | 丢失槽位 | 对应隐藏子技能 |
|---|---|---|
| 上古巨神 | `elder_titan_ancestral_spirit` | `elder_titan_return_spirit` |
| 光之守卫 | `keeper_of_the_light_illuminate` | `keeper_of_the_light_illuminate_end` |
| 炸弹人 | `techies_reactive_tazer` | `techies_reactive_tazer_detonate` |

在互换窗口之外再施放一次子技能，引擎会再 swap 一次，把可见的主技能换到隐藏位且不再换回，槽位永久空白。两条触发路径：

1. `ability_trigger_on_cast.lua`（蝴蝶效应·红魔）挑选随机技能时缺少 `IsHidden()` 过滤，可以直接抽中隐藏子技能。其余五个蝴蝶（`ability_trigger_learned_skills` / `on_attacked` / `on_move` / `on_spell_reflect` / `on_active`）都有这层过滤，红魔是唯一遗漏的。
2. `ogre_magi_multicast_lua.lua`（多重施法）全程没有 `IsHidden()` 判断。施法瞬间子技能仍可见，判断必须推迟到延迟重放前才有意义。

按名字维护黑名单不足以覆盖：`techies_reactive_tazer_detonate` 是 Dota 2 7.41 新增的子技能，黑名单无从预知。改为通用判据后，现存与将来新增的互换子技能一并覆盖。

## 改动

- `ability_trigger_on_cast.lua`：挑选循环补 `not ability:IsHidden()`；延迟施法前重新判定一次（挑选到施放间隔 0.5 秒，状态可能已变）。
- `ogre_magi_multicast_lua.lua`：`SetContextThink` 重放回调中、`CastAbilityImmediately` 之前补 `IsHidden()` 判定。
- 两份黑名单补入 `elder_titan_return_spirit`、`keeper_of_the_light_illuminate_end`、`techies_reactive_tazer_detonate` 作为双保险。

## 验证

纯 Lua 改动，不涉及 TSTL 编译与 jest 覆盖范围。需在 Dota tools 实机确认：抽到红魔蝴蝶 / 多重施法后，反复施放上述三个技能，技能栏不再出现空槽。

## Release Note

```
[b]游戏性更新 v5.48a[/b]

- 修正蝴蝶效应·红魔与多重施法会让上古巨神灵体游魂，光之守卫冲击波，炸弹人活性电击等技能永久从技能栏消失的问题。
```

```
[b]Gameplay update v5.48a[/b]

- Fixed Butterfly Effect: Red and Multicast permanently removing abilities from the ability bar, including Elder Titan's Astral Spirit, Keeper of the Light's Illuminate and Techies' Reactive Tazer.
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01UdTuQhXMUWUCExnETzaAs5)_