### PR TITLE
Apply basic dispel to enemies on Doom Awakened cast

### DIFF
--- a/src/vscripts/abilities/ts_abilities/doom_bringer_doom_awakened.ts
+++ b/src/vscripts/abilities/ts_abilities/doom_bringer_doom_awakened.ts
@@ -31,6 +31,10 @@ function getEnemyDoomDuration(target: CDOTA_BaseNPC, duration: number): number {
   return Math.max(0, duration * (1 - target.GetStatusResistance()));
 }
 
+function applyBasicDispel(target: CDOTA_BaseNPC): void {
+  target.Purge(true, false, false, false, false);
+}
+
 function hasLearnedTalent(caster: CDOTA_BaseNPC | undefined, talentName: string): boolean {
   if (!caster || caster.IsNull()) return false;
   const talent = caster.FindAbilityByName(talentName);
@@ -133,6 +137,7 @@ export class DoomBringerDoomAwakened extends BaseAbility {
       : getEnemyDoomDuration(target, baseDuration);
 
     if (!targetIsFriendly) {
+      applyBasicDispel(target);
       applyOrRefreshDoom(caster, this, target, effectDuration);
     }
 


### PR DESCRIPTION
## Issue

- 无关联 issue

技能说明（中/英/俄）都写明末日觉醒会对敌人驱散、驱散类型为弱驱散，但 `doom_bringer_doom_awakened` 在 Lua 侧自行施加末日 modifier，没有走引擎的驱散流程，实际施放时不会清除目标身上的正面 buff。

本次在 `OnSpellStart` 的敌方分支里补上弱驱散 `Purge(true, false, false, false, false)`，与 `item_blue_fantasy.lua` 等既有写法一致。友方目标（A 杖）不驱散，A 杖光环范围内的敌人也不驱散，只有直接指向敌人的那次施放会驱散。文案已与实现一致，无需改动本地化。

## Checklist

- [ ] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.48b[/b]

- 修正末日使者觉醒技能对敌人施放时没有驱散正面buff的问题。
```

```
[b]Gameplay update v5.48b[/b]

- Fixed Doom Awakened not dispelling buffs from the enemy target on cast.
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01KkjWVRX2gFm554c6W5Pbf3)_