### PR TITLE
Fix custom shop items not displaying after 7.41e

### DIFF
--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -3,6 +3,7 @@
 		<include src="file://{resources}/scripts/custom_game/main.js" />
 		<include src="file://{resources}/scripts/custom_game/replaceHeroImage.js"/>
 		<include src="file://{resources}/scripts/custom_game/replaceGold.js"/>
+		<include src="file://{resources}/scripts/custom_game/shop_fix.js"/>
 	</scripts>
 	<styles>
 		<include src="s2r://panorama/styles/dotastyles.vcss_c" />

--- a/content/panorama/scripts/custom_game/shop_fix.js
+++ b/content/panorama/scripts/custom_game/shop_fix.js
@@ -1,0 +1,20 @@
+function FindDotaHudElement(id) {
+  return GetDotaHud().FindChildTraverse(id);
+}
+
+function GetDotaHud() {
+  var panel = $.GetContextPanel();
+  while (panel && panel.id !== 'Hud') {
+    panel = panel.GetParent();
+  }
+  return panel;
+}
+
+// 7.41e 引擎 bug：商店会多渲染一层默认物品格子，覆盖显示为原版物品/贴图缺失
+(function () {
+  const pShop = FindDotaHudElement('GridBasicItems');
+  if (pShop) pShop.RemoveAndDeleteChildren();
+
+  const pShop2 = FindDotaHudElement('GridUpgradeItems');
+  if (pShop2) pShop2.RemoveAndDeleteChildren();
+})();

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -443,7 +443,7 @@
 		"DOTA_Tooltip_modifier_tower_power_Description"		"This structure's attack damage and max health is increased by %dMODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE%%%.<br>This structure also has %dMODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT% extra health regeneration."
 
 		"DOTA_Tooltip_modifier_global_melee_resistance"					"Melee Hero Bonus"
-		"DOTA_Tooltip_modifier_global_melee_resistance_Description"		"Melee heroes have <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%</b></font> extra magic resistance and <font color='#FFFFFF'><b>20%%</b></font> status resistance."
+		"DOTA_Tooltip_modifier_global_melee_resistance_Description"		"Melee heroes have <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%</b></font> extra magic resistance and <font color='#FFFFFF'><b>15%%</b></font> status resistance."
 
 		"DOTA_Tooltip_ability_creep_buff"								"Creep Buff"
 		"DOTA_Tooltip_ability_creep_buff_Description"					"Level up based on how many towers are destroyed."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -323,7 +323,7 @@
 		"DOTA_Tooltip_modifier_tower_power_Description"		"Урон атаки и максимальное здоровье этого строения увеличены на %dMODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE%%%.<br>Эта постройка также имеет дополнительные %dMODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT% восстановления здоровья"
 
 		"DOTA_Tooltip_modifier_global_melee_resistance"					"Melee Hero Bonus"
-		"DOTA_Tooltip_modifier_global_melee_resistance_Description"		"Герои ближнего боя получают <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%</b></font> дополнительного сопротивления магии и <font color='#FFFFFF'><b>20%%</b></font> сопротивления эффектам."
+		"DOTA_Tooltip_modifier_global_melee_resistance_Description"		"Герои ближнего боя получают <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%</b></font> дополнительного сопротивления магии и <font color='#FFFFFF'><b>15%%</b></font> сопротивления эффектам."
 
 		"DOTA_Tooltip_ability_creep_buff"								"Creep Buff"
 		"DOTA_Tooltip_ability_creep_buff_bonus_damage"					"Бонус к урону"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -443,7 +443,7 @@
 		"DOTA_Tooltip_modifier_tower_power_Description"		"建筑物的攻击和最大生命值增加 %dMODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE%%%。<br>获得额外 %dMODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT%点/秒生命恢复。"
 
 		"DOTA_Tooltip_modifier_global_melee_resistance"					"威压"
-		"DOTA_Tooltip_modifier_global_melee_resistance_Description"		"近战英雄额外获得 <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%</b></font> 魔法抗性和 <font color='#FFFFFF'><b>20%%</b></font> 状态抗性。"
+		"DOTA_Tooltip_modifier_global_melee_resistance_Description"		"近战英雄额外获得 <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%%</b></font> 魔法抗性和 <font color='#FFFFFF'><b>15%%</b></font> 状态抗性。"
 
 		"DOTA_Tooltip_ability_creep_buff"								"小兵Buff"
 		"DOTA_Tooltip_ability_creep_buff_Description"					"根据摧毁防御塔的数量升级。"

--- a/game/scripts/npc/npc_items_override.txt
+++ b/game/scripts/npc/npc_items_override.txt
@@ -9,7 +9,7 @@
 	"item_recipe_travel_boots_2"	"REMOVE"
 	"item_travel_boots_2"			"REMOVE"
 	"item_recipe_moon_shard"		"REMOVE"
-	// "item_moon_shard"				"REMOVE"
+	"item_moon_shard"				"REMOVE"
 	"item_helm_of_the_dominator"	"REMOVE" // 支配头盔
 	"item_helm_of_the_overlord"		"REMOVE" // 统御头盔
 

--- a/game/scripts/shops.txt
+++ b/game/scripts/shops.txt
@@ -3,7 +3,8 @@
 	// 消耗品
 	"consumables"
 	{
-		"item"		"item_tpscroll"				// 回城卷轴
+		// "item"		"item_tpscroll"				// 回城卷轴
+		"item"		"item_travel_boots"			// 飞鞋 远行鞋
 		"item"		"item_clarity"				// 净化药水
 		"item"		"item_faerie_fire"			// 仙灵之火
 		"item"		"item_smoke_of_deceit"		// 诡计之雾
@@ -168,8 +169,7 @@
 		"item"		"item_hand_of_group"		// 团队之手
 		"item"		"item_roshans_banner"		// 肉山的战旗
 		"item"		"item_wings_of_haste"		// 急速之翼
-		"item"		"item_moon_shard"			// 银月之晶
-		// "item"		"item_moon_shard_datadriven"
+		"item"		"item_moon_shard_datadriven" // 真 银月之晶
 		"item"		"item_consumable_gem"		// 幻影宝石
 		"item"		"item_tome_of_ability_reset"	// 技能重选书
 	}
@@ -293,8 +293,8 @@
 	"artifacts"
 	{
 		"item"		"item_echo_sabre_2"			// 音速战刃
-		"item"		"item_yasha"
-		"item"		"item_kaya"
+		"item"		"item_harpoon"				// 鱼叉
+		"item"		"item_specialists_array"	// 行家阵列
 		"item"		"item_hydras_breath_2"		// 神器怪蛇之息
 
 		"item"		"item_devastator_2"			// 神圣斧
@@ -302,25 +302,23 @@
 		"item"		"item_blue_fantasy"			// 苍蓝幻想
  		"item"		"item_skadi_2"				// 斯嘉蒂之眼
 
- 		"item"		"item_kaya_and_sange_1"		// 散慧对剑
- 		"item"		"item_sange_and_yasha_1"	// 散夜对剑
- 		"item"		"item_yasha_and_kaya_1"		// 夜慧对剑
-		"item"		"item_specialists_array"	// 行家阵列
-
-		// "item"		"item_harpoon"				// 鱼叉
-		"item"		"item_tome_of_strength"
-		"item"		"item_tome_of_agility"
-		"item"		"item_tome_of_intelligence"
-		"item"		"item_tome_of_luoshu"		// 洛书
-
 		"item"		"item_overwhelming_blink_2"
 		"item"		"item_swift_blink_2"
 		"item"		"item_arcane_blink"
 		"item"		"item_jump_jump_jump"
 
-		"item"		"item_magic_crit_blade"		// 魔龙狂舞 FIXME 暂时移动
-		// "item"      "item_shadow_judgment"      // 暗影裁决
+ 		"item"		"item_kaya_and_sange_1"		// 散慧对剑
+ 		"item"		"item_sange_and_yasha_1"	// 散夜对剑
+ 		"item"		"item_yasha_and_kaya_1"		// 夜慧对剑
 		"item"		"item_sacred_six_vein"		// 六脉神剑
+
+		"item"		"item_tome_of_strength"
+		"item"		"item_tome_of_agility"
+		"item"		"item_tome_of_intelligence"
+		"item"		"item_tome_of_luoshu"		// 洛书
+
+		"item"		"item_magic_crit_blade"		// 魔龙狂舞 FIXME 暂时移动
+		"item"      "item_shadow_judgment"      // 暗影裁决
 		"item"      "item_hawkeye_fighter"      // 鹰眼战机
 		"item"      "item_swift_glove"      // 无限手套
 	}

--- a/src/vscripts/ai/team/bot-team.ts
+++ b/src/vscripts/ai/team/bot-team.ts
@@ -16,7 +16,7 @@ export class BotTeam {
   private pushStarted: boolean = false; // 是否已进入推进阶段
   private addAmount: number = 0; // Bot发钱的基础金额
 
-  private readonly addAmountBase: number = 1.5; // Bot发钱的基础金额
+  private readonly addAmountBase: number = 2; // Bot发钱的基础金额
   private readonly addAmountPlayerNumberBonus: number = 0.15; // 每个玩家增加的金额
   private readonly addAmountNeedLevel: number = 0.02; // 每玩家等级增加的金额
   private readonly refreshInterval: number = 1; // 刷新策略间隔

--- a/src/vscripts/modifiers/global/melee_status_resistance.ts
+++ b/src/vscripts/modifiers/global/melee_status_resistance.ts
@@ -3,7 +3,7 @@ import { BaseModifier, registerModifier } from '../../utils/dota_ts_adapter';
 /** 近战英雄状态抗性加成，与 KV 的 modifier_global_melee_resistance（魔抗）并列挂载，自身保持隐藏不重复显示图标 */
 @registerModifier('modifiers/global/melee_status_resistance')
 export class modifier_global_melee_status_resistance extends BaseModifier {
-  private static readonly STATUS_RESISTANCE_BONUS = 20;
+  private static readonly STATUS_RESISTANCE_BONUS = 15;
 
   IsHidden(): boolean {
     return true;

--- a/src/vscripts/modules/event/event-npc-spawned.ts
+++ b/src/vscripts/modules/event/event-npc-spawned.ts
@@ -182,10 +182,11 @@ export class EventNpcSpawned {
   // 英雄出生
   private OnRealHeroSpawned(hero: CDOTA_BaseNPC_Hero): void {
     this.SetHeroSpawnPoint(hero);
-    // 近战buff
+    // 近战buff，仅对玩家生效
     if (
-      hero.GetAttackCapability() === UnitAttackCapability.MELEE_ATTACK ||
-      hero.GetName() === 'npc_dota_hero_troll_warlord'
+      PlayerHelper.IsHumanPlayer(hero) &&
+      (hero.GetAttackCapability() === UnitAttackCapability.MELEE_ATTACK ||
+        hero.GetName() === 'npc_dota_hero_troll_warlord')
     ) {
       ModifierHelper.applyGlobalModifier(hero, 'modifier_global_melee_resistance');
       hero.AddNewModifier(hero, undefined, modifier_global_melee_status_resistance.name, {});


### PR DESCRIPTION
## Checklist

- [x] 在 Dota Tools 中验证商店自定义物品图标恢复正常显示
- [ ] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.49b[/b]

- 修正 Dota 2 7.41e 更新后，商店中自定义物品不正常显示问题。
- 电脑近战英雄不再获得威压buff。
```

```
[b]Gameplay update v5.49b[/b]

- Fixed custom shop items not displaying correctly after the Dota 2 7.41e update.
- Bot melee heroes no longer gain the Melee Hero Bonus buff.
```
