### PR TITLE
Enable bot consumables in item builds

### DIFF
--- a/game/itembuilds/default_abaddon.txt
+++ b/game/itembuilds/default_abaddon.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_abyssal_underlord.txt
+++ b/game/itembuilds/default_abyssal_underlord.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_alchemist.txt
+++ b/game/itembuilds/default_alchemist.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_ancient_apparition.txt
+++ b/game/itembuilds/default_ancient_apparition.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_antimage.txt
+++ b/game/itembuilds/default_antimage.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_arc_warden.txt
+++ b/game/itembuilds/default_arc_warden.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_axe.txt
+++ b/game/itembuilds/default_axe.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_bane.txt
+++ b/game/itembuilds/default_bane.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_batrider.txt
+++ b/game/itembuilds/default_batrider.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_beastmaster.txt
+++ b/game/itembuilds/default_beastmaster.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_bloodseeker.txt
+++ b/game/itembuilds/default_bloodseeker.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_bounty_hunter.txt
+++ b/game/itembuilds/default_bounty_hunter.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_brewmaster.txt
+++ b/game/itembuilds/default_brewmaster.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_bristleback.txt
+++ b/game/itembuilds/default_bristleback.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_broodmother.txt
+++ b/game/itembuilds/default_broodmother.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_centaur.txt
+++ b/game/itembuilds/default_centaur.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_chaos_knight.txt
+++ b/game/itembuilds/default_chaos_knight.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_chen.txt
+++ b/game/itembuilds/default_chen.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_clinkz.txt
+++ b/game/itembuilds/default_clinkz.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_crystal_maiden.txt
+++ b/game/itembuilds/default_crystal_maiden.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_dark_seer.txt
+++ b/game/itembuilds/default_dark_seer.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_dark_willow.txt
+++ b/game/itembuilds/default_dark_willow.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_dawnbreaker.txt
+++ b/game/itembuilds/default_dawnbreaker.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_dazzle.txt
+++ b/game/itembuilds/default_dazzle.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_death_prophet.txt
+++ b/game/itembuilds/default_death_prophet.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_disruptor.txt
+++ b/game/itembuilds/default_disruptor.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_doom_bringer.txt
+++ b/game/itembuilds/default_doom_bringer.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_dragon_knight.txt
+++ b/game/itembuilds/default_dragon_knight.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_drow_ranger.txt
+++ b/game/itembuilds/default_drow_ranger.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_earth_spirit.txt
+++ b/game/itembuilds/default_earth_spirit.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_earthshaker.txt
+++ b/game/itembuilds/default_earthshaker.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_elder_titan.txt
+++ b/game/itembuilds/default_elder_titan.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_ember_spirit.txt
+++ b/game/itembuilds/default_ember_spirit.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_enchantress.txt
+++ b/game/itembuilds/default_enchantress.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_enigma.txt
+++ b/game/itembuilds/default_enigma.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_faceless_void.txt
+++ b/game/itembuilds/default_faceless_void.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_furion.txt
+++ b/game/itembuilds/default_furion.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_grimstroke.txt
+++ b/game/itembuilds/default_grimstroke.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_gyrocopter.txt
+++ b/game/itembuilds/default_gyrocopter.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_hoodwink.txt
+++ b/game/itembuilds/default_hoodwink.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_huskar.txt
+++ b/game/itembuilds/default_huskar.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_invoker.txt
+++ b/game/itembuilds/default_invoker.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_jakiro.txt
+++ b/game/itembuilds/default_jakiro.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_juggernaut.txt
+++ b/game/itembuilds/default_juggernaut.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_keeper_of_the_light.txt
+++ b/game/itembuilds/default_keeper_of_the_light.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_kez.txt
+++ b/game/itembuilds/default_kez.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_kunkka.txt
+++ b/game/itembuilds/default_kunkka.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_largo.txt
+++ b/game/itembuilds/default_largo.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_legion_commander.txt
+++ b/game/itembuilds/default_legion_commander.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_leshrac.txt
+++ b/game/itembuilds/default_leshrac.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_lich.txt
+++ b/game/itembuilds/default_lich.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_life_stealer.txt
+++ b/game/itembuilds/default_life_stealer.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_lina.txt
+++ b/game/itembuilds/default_lina.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_lion.txt
+++ b/game/itembuilds/default_lion.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_lone_druid.txt
+++ b/game/itembuilds/default_lone_druid.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_luna.txt
+++ b/game/itembuilds/default_luna.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_lycan.txt
+++ b/game/itembuilds/default_lycan.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_magnataur.txt
+++ b/game/itembuilds/default_magnataur.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_marci.txt
+++ b/game/itembuilds/default_marci.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_mars.txt
+++ b/game/itembuilds/default_mars.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_medusa.txt
+++ b/game/itembuilds/default_medusa.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_meepo.txt
+++ b/game/itembuilds/default_meepo.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_mirana.txt
+++ b/game/itembuilds/default_mirana.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_monkey_king.txt
+++ b/game/itembuilds/default_monkey_king.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_morphling.txt
+++ b/game/itembuilds/default_morphling.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_muerta.txt
+++ b/game/itembuilds/default_muerta.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_naga_siren.txt
+++ b/game/itembuilds/default_naga_siren.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_necrolyte.txt
+++ b/game/itembuilds/default_necrolyte.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_nevermore.txt
+++ b/game/itembuilds/default_nevermore.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_night_stalker.txt
+++ b/game/itembuilds/default_night_stalker.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_nyx_assassin.txt
+++ b/game/itembuilds/default_nyx_assassin.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_obsidian_destroyer.txt
+++ b/game/itembuilds/default_obsidian_destroyer.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_ogre_magi.txt
+++ b/game/itembuilds/default_ogre_magi.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_omniknight.txt
+++ b/game/itembuilds/default_omniknight.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_oracle.txt
+++ b/game/itembuilds/default_oracle.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_pangolier.txt
+++ b/game/itembuilds/default_pangolier.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_phantom_assassin.txt
+++ b/game/itembuilds/default_phantom_assassin.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_phantom_lancer.txt
+++ b/game/itembuilds/default_phantom_lancer.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_phoenix.txt
+++ b/game/itembuilds/default_phoenix.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_primal_beast.txt
+++ b/game/itembuilds/default_primal_beast.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_puck.txt
+++ b/game/itembuilds/default_puck.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_pudge.txt
+++ b/game/itembuilds/default_pudge.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_pugna.txt
+++ b/game/itembuilds/default_pugna.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_queenofpain.txt
+++ b/game/itembuilds/default_queenofpain.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_rattletrap.txt
+++ b/game/itembuilds/default_rattletrap.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_razor.txt
+++ b/game/itembuilds/default_razor.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_riki.txt
+++ b/game/itembuilds/default_riki.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_ringmaster.txt
+++ b/game/itembuilds/default_ringmaster.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_rubick.txt
+++ b/game/itembuilds/default_rubick.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_sand_king.txt
+++ b/game/itembuilds/default_sand_king.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_shadow_demon.txt
+++ b/game/itembuilds/default_shadow_demon.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_shadow_shaman.txt
+++ b/game/itembuilds/default_shadow_shaman.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_shredder.txt
+++ b/game/itembuilds/default_shredder.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_silencer.txt
+++ b/game/itembuilds/default_silencer.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_skeleton_king.txt
+++ b/game/itembuilds/default_skeleton_king.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_skywrath_mage.txt
+++ b/game/itembuilds/default_skywrath_mage.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_slardar.txt
+++ b/game/itembuilds/default_slardar.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_slark.txt
+++ b/game/itembuilds/default_slark.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_snapfire.txt
+++ b/game/itembuilds/default_snapfire.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_sniper.txt
+++ b/game/itembuilds/default_sniper.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_spectre.txt
+++ b/game/itembuilds/default_spectre.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_spirit_breaker.txt
+++ b/game/itembuilds/default_spirit_breaker.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_storm_spirit.txt
+++ b/game/itembuilds/default_storm_spirit.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_sven.txt
+++ b/game/itembuilds/default_sven.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_techies.txt
+++ b/game/itembuilds/default_techies.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_templar_assassin.txt
+++ b/game/itembuilds/default_templar_assassin.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_terrorblade.txt
+++ b/game/itembuilds/default_terrorblade.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_tidehunter.txt
+++ b/game/itembuilds/default_tidehunter.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_tinker.txt
+++ b/game/itembuilds/default_tinker.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_tiny.txt
+++ b/game/itembuilds/default_tiny.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_treant.txt
+++ b/game/itembuilds/default_treant.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_troll_warlord.txt
+++ b/game/itembuilds/default_troll_warlord.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_tusk.txt
+++ b/game/itembuilds/default_tusk.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_undying.txt
+++ b/game/itembuilds/default_undying.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_ursa.txt
+++ b/game/itembuilds/default_ursa.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_vengefulspirit.txt
+++ b/game/itembuilds/default_vengefulspirit.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_venomancer.txt
+++ b/game/itembuilds/default_venomancer.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_viper.txt
+++ b/game/itembuilds/default_viper.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_visage.txt
+++ b/game/itembuilds/default_visage.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_void_spirit.txt
+++ b/game/itembuilds/default_void_spirit.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_warlock.txt
+++ b/game/itembuilds/default_warlock.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_weaver.txt
+++ b/game/itembuilds/default_weaver.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_windrunner.txt
+++ b/game/itembuilds/default_windrunner.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_winter_wyvern.txt
+++ b/game/itembuilds/default_winter_wyvern.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_wisp.txt
+++ b/game/itembuilds/default_wisp.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_witch_doctor.txt
+++ b/game/itembuilds/default_witch_doctor.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼

--- a/game/itembuilds/default_zuus.txt
+++ b/game/itembuilds/default_zuus.txt
@@ -16,10 +16,10 @@
 
 		"#dota_item_build_windy_consumables_items"
 		{
-			// "item"		"item_ward_observer"  //侦查守卫
-			// "item"		"item_ward_sentry"  //岗哨守卫
-			// "item"		"item_smoke_of_deceit"  //诡计之雾
-			// "item"		"item_dust"  //显影之尘
+			"item"		"item_ward_observer"  //侦查守卫
+			"item"		"item_ward_sentry"  //岗哨守卫
+			"item"		"item_smoke_of_deceit"  //诡计之雾
+			"item"		"item_dust"  //显影之尘
 			"item"		"item_tome_of_knowledge" //知识之书
 			"item"		"item_aghanims_shard" //阿哈利姆魔晶
 			"item"		"item_wings_of_haste" //急速之翼


### PR DESCRIPTION
## Checklist

- [x] Verified all 128 item build configs include active consumable entries.
- [ ] Verify in Dota Tools that bots purchase consumables.