### PR TITLE
Game end add control time

### DIFF
--- a/content/panorama/layout/custom_game/end_screen_2.xml
+++ b/content/panorama/layout/custom_game/end_screen_2.xml
@@ -37,7 +37,7 @@
 					</Panel>
 					<Label class="LegendPanel HeroHealingColumn" text="#dota_page_match_details_legend_hero_healing" onmouseover="UIShowTextTooltipStyled( #dota_page_match_details_legend_hero_healing_tooltip, ShortTextTooltip )" onmouseout="UIHideTextTooltip()" />
 					<Label class="LegendPanel TowerKillsColumn" text="#custom_end_screen_tower_kills" />
-					<Label class="LegendPanel StunsColumn" text="#custom_end_screen_control_time" />
+					<Label class="LegendPanel StunsColumn" text="#custom_end_screen_control_time" onmouseover="UIShowTextTooltipStyled( #custom_end_screen_control_time_tooltip, ShortTextTooltip )" onmouseout="UIHideTextTooltip()" />
 					<Panel class="LegendPanel PtsColumn">
 						<Image class="PtsColumnImg" src="s2r://panorama/images/custom_game/battlepass/pts_earned_png.vtex" onmouseover="UIShowTextTooltipStyled( #data_panel_season_point, ShortTextTooltip )" onmouseout="UIHideTextTooltip()" />
 					</Panel>

--- a/content/panorama/layout/custom_game/end_screen_2.xml
+++ b/content/panorama/layout/custom_game/end_screen_2.xml
@@ -37,6 +37,7 @@
 					</Panel>
 					<Label class="LegendPanel HeroHealingColumn" text="#dota_page_match_details_legend_hero_healing" onmouseover="UIShowTextTooltipStyled( #dota_page_match_details_legend_hero_healing_tooltip, ShortTextTooltip )" onmouseout="UIHideTextTooltip()" />
 					<Label class="LegendPanel TowerKillsColumn" text="#custom_end_screen_tower_kills" />
+					<Label class="LegendPanel StunsColumn" text="#custom_end_screen_control_time" />
 					<Panel class="LegendPanel PtsColumn">
 						<Image class="PtsColumnImg" src="s2r://panorama/images/custom_game/battlepass/pts_earned_png.vtex" onmouseover="UIShowTextTooltipStyled( #data_panel_season_point, ShortTextTooltip )" onmouseout="UIHideTextTooltip()" />
 					</Panel>
@@ -72,6 +73,7 @@
 				<Label class="TotalDamageReceivedColumn" text="{d:damagereceived}" />
 				<Label class="HeroHealingColumn" text="{d:heroHealing}" />
 				<Label class="TowerKillsColumn" text="{d:towerKills}" />
+				<Label class="StunsColumn" text="{d:stuns}" />
 				<Panel id="PointsLabel" class="PtsColumn">
 					<Panel class="PointsInner">
 						<Label id="PointsValue" class="PointsValue" text="" />

--- a/content/panorama/scripts/custom_game/end_screen_2.js
+++ b/content/panorama/scripts/custom_game/end_screen_2.js
@@ -103,6 +103,7 @@ function Snippet_Player(playerId, rootPanel, index) {
   panel.SetDialogVariableInt('damagereceived', playerData?.damagereceived ?? 0);
   panel.SetDialogVariableInt('heroHealing', playerData?.healing ?? 0);
   panel.SetDialogVariableInt('towerKills', playerData?.towerKills ?? 0);
+  panel.SetDialogVariableInt('stuns', Math.round(playerData?.stuns ?? 0));
   const pointModifier = playerData?.pointModifier ?? 0;
   const conductPoint = playerData?.conductPoint ?? 100;
   const points = playerData?.points ?? 0;

--- a/content/panorama/styles/custom_game/end_screen.css
+++ b/content/panorama/styles/custom_game/end_screen.css
@@ -16,7 +16,7 @@
 }
 
 #EndScreenWindow #MatchResultBlock {
-  width: 1800px;
+  width: 1850px;
   background-color: rgba(20, 20, 20, 0.5);
   background-color: gradient(
     linear,
@@ -216,11 +216,11 @@
 }
 
 .HeaderColumn {
-  width: 400px;
+  width: 360px;
 }
 
 .AspectRatio4x3 .HeaderColumn {
-  width: 400px;
+  width: 360px;
 }
 
 .SavesColumn {
@@ -437,7 +437,7 @@
 }
 
 .Team #TeamInfo {
-  width: 1800px;
+  width: 1850px;
   height: 50px;
   padding-top: 1px;
   padding-bottom: 6px;
@@ -556,7 +556,7 @@
 }
 
 .Player {
-  width: 1800px;
+  width: 1850px;
   height: 40px;
   padding-bottom: 0px;
   background-color: rgba(0, 0, 0, 0.95);

--- a/content/panorama/styles/custom_game/end_screen.css
+++ b/content/panorama/styles/custom_game/end_screen.css
@@ -344,6 +344,12 @@
   margin-right: 5px;
 }
 
+.StunsColumn {
+  width: 60px;
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
 .PtsColumn {
   width: 65px;
   margin-left: 5px;

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -104,6 +104,7 @@
 		"bot_multiplier"	"Bot Multiplier"
 
 		"custom_end_screen_tower_kills"		"Towers"
+		"custom_end_screen_control_time"		"Stun"
 		"custom_end_screen_abilities"		"Abilities"
 
 		"conduct_point_bonus_tooltip"			"Conduct <font color='#FFD700'>{0}</font> bonus, points ×1.1"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1173,7 +1173,7 @@
 
 		// ---- bot技能 ----
 		// 机械救赎
-		"DOTA_Tooltip_ability_bot_power_n6"							"Bot Salvation N6"
+		"DOTA_Tooltip_ability_bot_power_n6"							"Bot Salvation"
 		"DOTA_Tooltip_ability_bot_power_n6_Description"				"The ability automatically upgrades every 5 hero levels, providing enhancements to core attributes such as attack, armor, cooldown reduction and movement speed."
 		"DOTA_Tooltip_ability_bot_power_n6_Lore"					"In the face of a player's intelligence and creativity, the Bot's design often falls short. Although they can perfectly execute commands, they can never surpass a player's intuition and strategy. To overcome this, developers injected the 'Bot Salvation' program, allowing them to unlock their potential in critical moments and turn the tide of battle."
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_damage"			"ATTACK DAMAGE:"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -104,7 +104,8 @@
 		"bot_multiplier"	"Bot Multiplier"
 
 		"custom_end_screen_tower_kills"		"Towers"
-		"custom_end_screen_control_time"		"Stun"
+		"custom_end_screen_control_time"		"Control"
+		"custom_end_screen_control_time_tooltip"	"Includes stun and root duration"
 		"custom_end_screen_abilities"		"Abilities"
 
 		"conduct_point_bonus_tooltip"			"Conduct <font color='#FFD700'>{0}</font> bonus, points ×1.1"
@@ -1258,7 +1259,7 @@
 
 		// Skywrath Mage Staff of the Scion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade"						"<font color='#d000ff'>Staff of the Scion Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>Awakening Bonus:</font> Skywrath Mage gains Staff of the Scion. Every time his abilities deal <font color='#05CAFF'>magical damage</font> to an enemy hero, the cooldown of all his abilities is reduced by %cooldown_reduction%s.<br><br><font color='#00CED1'>Autocast:</font> While enabled, Skywrath Mage automatically casts Ancient Seal, Concussive Shot and Arcane Bolt whenever an enemy hero is within cast range. Arcane Bolt also fires at creeps when no hero is available."
+		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>Awakening Bonus:</font> Skywrath Mage gains Staff of the Scion. Every time his abilities deal <font color='#05CAFF'>magical damage</font> to an enemy hero, the cooldown of all his abilities is reduced by %cooldown_reduction%s.<br><br><font color='#00CED1'>Autocast:</font> While enabled, Skywrath Mage automatically casts Ancient Seal, Concussive Shot, Mystic Flare and Arcane Bolt whenever an enemy hero is within cast range. Arcane Bolt also fires at creeps when no hero is available."
 		// Zeus God King - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_zuus_upgrade"							"<font color='#d000ff'>God King Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_zuus_upgrade_Description"				"When autocast is enabled, Zeus automatically casts Arc Lightning and Lightning Bolt on enemies within cast range.<br><br>Prioritizes heroes. Casts only Arc Lightning when only creeps are in range."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -73,7 +73,8 @@
 		"custom_end_screen_victory_message"	"Победа Radiant!"
 		"custom_end_screen_lose_message"	"Победа Dire!"
 
-		"custom_end_screen_control_time"		"Оглушение"
+		"custom_end_screen_control_time"		"Контроль"
+		"custom_end_screen_control_time_tooltip"	"Включает время оглушения и опутывания"
 
 		"player_multiplier"	"Player Multiplier"
 		"bot_multiplier"	"Bot Multiplier"
@@ -546,7 +547,7 @@
 
 		// Skywrath Mage Staff of the Scion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade"						"<font color='#d000ff'>Посох отпрыска · Пробуждение</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>Бонус пробуждения:</font> Skywrath Mage получает Staff of the Scion. Каждый раз, когда его способности наносят <font color='#05CAFF'>магический урон</font> вражескому герою, время восстановления всех его способностей сокращается на %cooldown_reduction% сек.<br><br><font color='#00CED1'>Автоприменение:</font> Если включено, Skywrath Mage автоматически применяет Ancient Seal, Concussive Shot и Arcane Bolt, когда вражеский герой находится в радиусе применения. Arcane Bolt также применяется по крипам, если героев поблизости нет."
+		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>Бонус пробуждения:</font> Skywrath Mage получает Staff of the Scion. Каждый раз, когда его способности наносят <font color='#05CAFF'>магический урон</font> вражескому герою, время восстановления всех его способностей сокращается на %cooldown_reduction% сек.<br><br><font color='#00CED1'>Автоприменение:</font> Если включено, Skywrath Mage автоматически применяет Ancient Seal, Concussive Shot, Mystic Flare и Arcane Bolt, когда вражеский герой находится в радиусе применения. Arcane Bolt также применяется по крипам, если героев поблизости нет."
 		// 炸弹人 觉醒
 		"DOTA_Tooltip_ability_techies_squees_scope"					"<font color='#d000ff'>Пробуждение: Squee's Scope</font>"
 		"DOTA_Tooltip_ability_techies_squees_scope_Description"		"Каждая единица скорости атаки героя увеличивает его дальность атаки и скорость снарядов на %attack_range_tooltip%."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -73,6 +73,8 @@
 		"custom_end_screen_victory_message"	"Победа Radiant!"
 		"custom_end_screen_lose_message"	"Победа Dire!"
 
+		"custom_end_screen_control_time"		"Оглушение"
+
 		"player_multiplier"	"Player Multiplier"
 		"bot_multiplier"	"Bot Multiplier"
 

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1168,7 +1168,7 @@
 
 		// ---- bot技能 ----
 		// 机械救赎
-		"DOTA_Tooltip_ability_bot_power_n6"							"机械救赎 N6"
+		"DOTA_Tooltip_ability_bot_power_n6"							"机械救赎"
 		"DOTA_Tooltip_ability_bot_power_n6_Description"				"每当英雄升级5级时，技能会自动升级，为其提供攻击，防御，技能冷却缩减和移动速度等核心属性的增强。"
 		"DOTA_Tooltip_ability_bot_power_n6_Lore"					"在玩家的智慧和创造力面前，Bot的设计常常显得力不从心。尽管它们能够完美执行命令，却始终无法超越玩家的直觉与策略。因此，开发者为它们注入了 机械救赎 程序，使它们在关键时刻能够激发潜力，扭转战局。"
 		"DOTA_Tooltip_ability_bot_power_n6_bonus_damage"			"攻击力："

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -105,7 +105,8 @@
 		"bot_multiplier"		"电脑倍率"
 
 		"custom_end_screen_tower_kills"		"推塔"
-		"custom_end_screen_control_time"		"眩晕"
+		"custom_end_screen_control_time"		"控制"
+		"custom_end_screen_control_time_tooltip"	"包含眩晕和缠绕时间"
 
 		"conduct_point_bonus_tooltip"			"行为分 <font color='#FFD700'>{0}</font> 奖励，积分 ×1.1"
 		"conduct_point_light_penalty_tooltip"	"行为分 <font color='#FFA726'>{0}</font> 惩罚，积分 ×0.8"
@@ -1255,7 +1256,7 @@
 
 		// 天怒法师 天裔之杖-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade"						"<font color='#d000ff'>天裔之杖 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>觉醒强化：</font>天怒法师获得天裔之杖，其技能对敌方英雄造成<font color='#05CAFF'>魔法伤害</font>时，他所有技能的冷却时间都会减少%cooldown_reduction%秒。<br><br><font color='#00CED1'>自动施法：</font>开启后，施法距离内出现敌方英雄时，天怒法师自动施放上古封印、震荡光弹与奥法鹰隼，其中奥法鹰隼在只有小兵时也会施放。"
+		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>觉醒强化：</font>天怒法师获得天裔之杖，其技能对敌方英雄造成<font color='#05CAFF'>魔法伤害</font>时，他所有技能的冷却时间都会减少%cooldown_reduction%秒。<br><br><font color='#00CED1'>自动施法：</font>开启后，施法距离内出现敌方英雄时，天怒法师自动施放上古封印、震荡光弹、神秘之耀与奥法鹰隼，其中奥法鹰隼在只有小兵时也会施放。"
 		// 宙斯 神王-觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_zuus_upgrade"							"<font color='#d000ff'>神王 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_zuus_upgrade_Description"				"开启自动施法后，宙斯自动对施法距离内的敌人施放弧形闪电与雷击。<br><br>优先对英雄施法，范围内只有小兵时仅施放弧形闪电。"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -105,6 +105,7 @@
 		"bot_multiplier"		"电脑倍率"
 
 		"custom_end_screen_tower_kills"		"推塔"
+		"custom_end_screen_control_time"		"眩晕"
 
 		"conduct_point_bonus_tooltip"			"行为分 <font color='#FFD700'>{0}</font> 奖励，积分 ×1.1"
 		"conduct_point_light_penalty_tooltip"	"行为分 <font color='#FFA726'>{0}</font> 惩罚，积分 ×0.8"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -62,9 +62,9 @@
 		{
 			// 攻击
 			"bonus_damage"				"10 20 30 40 50 60 70 80 90 100"
-			"bonus_attack_speed"		"10 20 30 40 50 60 70 80 90 100"
+			"bonus_attack_speed"		"5 10 15 20 25 30 35 40 45 50"
 			// 技能
-			"bonus_spell_amplify"		"5 10 15 20 25 30 35 40 45 50"
+			"bonus_spell_amplify"		"4 8 12 16 20 24 28 32 36 40"
 			"bonus_cooldown"			"2 4 6 8 10 12 14 16 18 20"
 			// 防御
 			"bonus_move_speed"			"10 20 30 40 50 60 70 80 90 100"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -68,10 +68,10 @@
 			"bonus_cooldown"			"2 4 6 8 10 12 14 16 18 20"
 			// 防御
 			"bonus_move_speed"			"10 20 30 40 50 60 70 80 90 100"
-			"bonus_armor"				"3 6 9 12 15 18 21 24 27 30"
+			"bonus_armor"				"2 4 6 8 10 12 14 16 18 20"
 			"bonus_magic_resistance"	"2 4 6 8 10 12 14 16 18 20"
 			// 全属性
-			"bonus_attributes"			"10 20 30 40 50 60 70 80 90 100"
+			"bonus_attributes"			"5 10 15 20 25 30 35 40 45 50"
 		}
 
 		"Modifiers"

--- a/game/scripts/vscripts/lua_abilities/tinker_rearm_lua/tinker_rearm_lua.lua
+++ b/game/scripts/vscripts/lua_abilities/tinker_rearm_lua/tinker_rearm_lua.lua
@@ -135,8 +135,9 @@ tinker_rearm_lua.ItemException = {
 	["item_candy_candy"] = true,
 	["item_switchable_crit_blade"] = true,
 	["item_magic_crit_blade"] = true,
-	["item_time_gem"] = true,  -- 时间宝石
+	["item_time_gem"] = true,     -- 时间宝石
 	["item_beast_shield"] = true, -- 兽化盾
+	["item_withered_spring"] = true, -- 生命之心
 }
 
 --------------------------------------------------------------------------------

--- a/src/common/net_tables.d.ts
+++ b/src/common/net_tables.d.ts
@@ -37,6 +37,7 @@ declare global {
         agi: number;
         int: number;
         towerKills: number;
+        stuns: number;
       };
     };
     loading_status: {

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_skywrath_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_skywrath_upgrade.ts
@@ -13,9 +13,9 @@ export class SpecialBonusUniqueSkywrathUpgrade extends AutoCastAbility {
   // 每轮 think 最多放一个技能，避免四个技能同帧连发，下一个留给下轮 think
   OnAutoCastThink(caster: CDOTA_BaseNPC_Hero): void {
     if (this.castAncientSeal(caster)) return;
-    // if (this.castMysticFlare(caster)) return;
+    if (this.castConcussiveShot(caster)) return;
+    if (this.castMysticFlare(caster)) return;
     if (this.castArcaneBolt(caster)) return;
-    this.castConcussiveShot(caster);
   }
 
   // 上古封印

--- a/src/vscripts/api/analytics/dto/game-end-dto.ts
+++ b/src/vscripts/api/analytics/dto/game-end-dto.ts
@@ -29,6 +29,8 @@ export class GameEndPlayerDto {
   lastHits: number;
   healing: number;
   towerKills: number;
+  stuns: number;
+  roshanKills: number;
 
   /** 0=未觉醒 1=已觉醒。用数值而非布尔，为将来多阶觉醒等档位留扩展余地 */
   awaken: number;

--- a/src/vscripts/modules/debug/Debug.ts
+++ b/src/vscripts/modules/debug/Debug.ts
@@ -45,6 +45,12 @@ export class Debug {
 
     // ---- 常用命令 ----
 
+    // -s GetStuns(playerId: PlayerID
+    if (cmd === CMD.S) {
+      const playerId = keys.playerid;
+      const stuns = PlayerResource.GetStuns(playerId);
+      this.log(`Player ${playerId} stuns: ${stuns}`);
+    }
     if (cmd === CMD.D) {
       const playerId = keys.playerid;
       const damage = PlayerResource.GetRawPlayerDamage(playerId);

--- a/src/vscripts/modules/debug/debug-cmd.ts
+++ b/src/vscripts/modules/debug/debug-cmd.ts
@@ -8,6 +8,7 @@ export enum CMD {
   REFRESH_AI = '-r', // 刷新AI
   TIME = '-time', // 获取当前时间，不包含暂停
   D = '-d', // 获取当前伤害
+  S = '-s', // 获取控制时长
 
   KILL = '-k',
   KILL_ALL = '-kall',

--- a/src/vscripts/modules/event/game-end/game-end-point.test.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.test.ts
@@ -24,6 +24,8 @@ describe('GameEndPoint', () => {
     healing: 0,
     lastHits: 0,
     towerKills: 0,
+    stuns: 0,
+    roshanKills: 0,
     score: 0,
     battlePoints: 0,
     awaken: 0,
@@ -61,7 +63,7 @@ describe('GameEndPoint', () => {
         towerKills: 2,
       });
       const score = GameEndPoint.CalculatePlayerScore(player);
-      expect(score).toBe(43);
+      expect(score).toBe(41);
     });
 
     it('应该正确计算超高数据玩家的分数', () => {
@@ -75,6 +77,11 @@ describe('GameEndPoint', () => {
       });
       const score = GameEndPoint.CalculatePlayerScore(player);
       expect(score).toBe(151);
+    });
+
+    it('应该为控制时间增加递减且封顶的分数', () => {
+      expect(GameEndPoint.CalculatePlayerScore(createBasePlayer({ stuns: 400 }))).toBe(5);
+      expect(GameEndPoint.CalculatePlayerScore(createBasePlayer({ stuns: 10000 }))).toBe(25);
     });
   });
 

--- a/src/vscripts/modules/event/game-end/game-end-point.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.ts
@@ -7,11 +7,12 @@ export class GameEndPoint {
   static CalculatePlayerScore(player: GameEndPlayerDto): number {
     const killScore = Math.sqrt(player.kills) * 1.6;
     const deathScore = -Math.sqrt(player.deaths) * 0.6;
-    const assistScore = Math.sqrt(player.assists) * 1.8;
+    const assistScore = Math.sqrt(player.assists) * 1.6;
     const damageScore = Math.min(40, Math.sqrt(player.heroDamage) / 200);
     const damageTakenScore = Math.min(40, Math.sqrt(player.damageTaken) / 80);
     const healingScore = Math.min(40, Math.sqrt(player.healing) / 50);
     const towerKillScore = Math.sqrt(player.towerKills) * 3;
+    const stunScore = Math.min(25, Math.sqrt(player.stuns) / 4);
 
     const totalScore =
       killScore +
@@ -20,7 +21,8 @@ export class GameEndPoint {
       damageScore +
       damageTakenScore +
       healingScore +
-      towerKillScore;
+      towerKillScore +
+      stunScore;
 
     return Math.round(totalScore);
   }

--- a/src/vscripts/modules/event/game-end/game-end.ts
+++ b/src/vscripts/modules/event/game-end/game-end.ts
@@ -116,6 +116,8 @@ export class GameEnd {
         healing: PlayerResource.GetHealing(playerId),
         lastHits: PlayerResource.GetLastHits(playerId),
         towerKills: PlayerResource.GetTowerKills(playerId),
+        stuns: PlayerResource.GetStuns(playerId),
+        roshanKills: PlayerResource.GetRoshanKills(playerId),
         score: 0,
         battlePoints: 0,
         awaken: isAwakened(hero) ? 1 : 0,
@@ -159,6 +161,7 @@ export class GameEnd {
         agi: hero.GetAgility(),
         int: hero.GetIntellect(false),
         towerKills: playerDto.towerKills,
+        stuns: playerDto.stuns,
       });
     });
 


### PR DESCRIPTION
## Issue

- [ ] fix #9999

## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.49d[/b]

- 结算界面新增控制时间（眩晕+缠绕）统计，控制表现会加成勇士积分
- 削弱电脑机械救赎
- 天怒觉醒添加神秘之耀自动施法
```

```
[b]Gameplay update v5.49d[/b]

- Added control time (stuns + roots) to the end screen, with control performance contributing to Battle Points
- Nerf Bot Salvation
- Skywrath Mage Awakening now autocasts Mystic Flare
```
